### PR TITLE
chore(release): version 1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "1.0.0"
 edition = "2021"
 rust-version = "1.70"
 authors = ["GarthDB <garthdb@gmail.com>"]

--- a/examples/integration/Cargo.toml
+++ b/examples/integration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "things3-integration-examples"
-version = "0.2.0"
+version = "1.0.0"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Overview

Bump version from 0.2.0 to 1.0.0 for the stable release.

## Changes

- Update workspace version to 1.0.0 in root 
- Update integration examples version to 1.0.0

All workspace members now at version 1.0.0:
- ✅ : 1.0.0
- ✅ : 1.0.0  
- ✅ : 1.0.0
- ✅ : 1.0.0
- ✅ : 1.0.0

## Next Steps

After merging:
1. Create git tag `v1.0.0`
2. Create GitHub release
3. Publish to crates.io
4. Close issue #61

## Related

- Part of 1.0.0 release preparation
- Follows PR #70 (Phase 5 completion)

---

**🎉 Ready for 1.0.0 Release!**