### PR TITLE
feat(advanced-queries): wire TaskQueryBuilder.execute() to ThingsDatabase (#72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **`advanced-queries` feature flag** — gates new query execution APIs so existing builds are unaffected.
+- **`ThingsDatabase::query_tasks(filters: &TaskFilters)`** — executes a dynamic SQL query driven by all `TaskFilters` fields: status, type, project, area, start date range, deadline range, limit, and offset. Tag and search-query filters are applied in Rust after the database fetch.
+- **`TaskQueryBuilder::execute(&ThingsDatabase)`** — end-to-end shorthand that calls `.build()` and `query_tasks()` in one step.
+
 ## [1.0.1] - 2026-04-22
 
 ### Fixed

--- a/libs/things3-core/Cargo.toml
+++ b/libs/things3-core/Cargo.toml
@@ -18,7 +18,8 @@ test-utils = []
 export-csv = ["dep:csv"]
 export-opml = ["dep:quick-xml"]
 observability = ["dep:metrics"]
-full = ["export-csv", "export-opml", "observability"]
+advanced-queries = []
+full = ["export-csv", "export-opml", "observability", "advanced-queries"]
 
 [dependencies]
 # Core

--- a/libs/things3-core/src/database/core.rs
+++ b/libs/things3-core/src/database/core.rs
@@ -914,9 +914,14 @@ impl ThingsDatabase {
     /// Query tasks using a [`TaskFilters`] struct produced by [`crate::query::TaskQueryBuilder`].
     ///
     /// All filter fields are optional and combined with AND semantics in SQL.
-    /// Tag and search-query filters are applied in Rust after the query returns
-    /// (Things 3 stores tags as a BLOB). `LIMIT` is applied in SQL, so pages may
-    /// be smaller than requested when tag/search filters are also active.
+    /// Tag and search-query filters are applied in Rust after the SQL query returns
+    /// (Things 3 stores tags as a BLOB). When those post-filters are active,
+    /// `LIMIT`/`OFFSET` is also applied in Rust so pagination counts only
+    /// matching rows; without post-filters it is applied in SQL for efficiency.
+    ///
+    /// Filtering by [`TaskStatus::Trashed`] queries rows where `trashed = 1`
+    /// rather than adding a `status` condition, matching Things 3's soft-delete
+    /// semantics (trashed rows keep their original status value).
     ///
     /// # Errors
     ///
@@ -926,16 +931,21 @@ impl ThingsDatabase {
         const COLS: &str = "uuid, title, type, status, notes, startDate, deadline, stopDate, \
                             creationDate, userModificationDate, project, area, heading, cachedTags";
 
-        let mut conditions: Vec<String> = vec!["trashed = 0".to_string()];
+        // Things 3 soft-deletes by setting trashed = 1; the status column is unchanged.
+        // Requesting Trashed means "show trashed rows", not a status = 3 predicate.
+        let trashed_val = i32::from(matches!(filters.status, Some(TaskStatus::Trashed)));
+        let mut conditions: Vec<String> = vec![format!("trashed = {trashed_val}")];
 
         if let Some(status) = filters.status {
             let n = match status {
-                TaskStatus::Incomplete => 0,
-                TaskStatus::Completed => 1,
-                TaskStatus::Canceled => 2,
-                TaskStatus::Trashed => 3,
+                TaskStatus::Incomplete => Some(0),
+                TaskStatus::Completed => Some(1),
+                TaskStatus::Canceled => Some(2),
+                TaskStatus::Trashed => None, // handled via trashed = 1 above
             };
-            conditions.push(format!("status = {n}"));
+            if let Some(n) = n {
+                conditions.push(format!("status = {n}"));
+            }
         }
 
         if let Some(task_type) = filters.task_type {
@@ -4548,6 +4558,54 @@ mod tests {
             };
             let tasks = db.query_tasks(&filters).await.unwrap();
             assert!(tasks.is_empty());
+        }
+
+        #[tokio::test]
+        async fn test_query_tasks_trashed_status() {
+            use sqlx::SqlitePool;
+            use uuid::Uuid;
+
+            // Create a DB, insert one soft-deleted row (trashed = 1), then verify:
+            // - default query (trashed = 0) does NOT return it
+            // - TaskStatus::Trashed filter DOES return it
+            let f = NamedTempFile::new().unwrap();
+            crate::test_utils::create_test_database(f.path())
+                .await
+                .unwrap();
+            let pool = SqlitePool::connect(&format!("sqlite:{}", f.path().display()))
+                .await
+                .unwrap();
+            let trashed_uuid = Uuid::new_v4().to_string();
+            sqlx::query(
+                "INSERT INTO TMTask \
+                 (uuid, title, type, status, trashed, creationDate, userModificationDate) \
+                 VALUES (?, ?, 0, 0, 1, 0, 0)",
+            )
+            .bind(&trashed_uuid)
+            .bind("Trashed Task")
+            .execute(&pool)
+            .await
+            .unwrap();
+            pool.close().await;
+
+            let db = ThingsDatabase::new(f.path()).await.unwrap();
+
+            // Default query must not surface the trashed row
+            let active = db.query_tasks(&TaskFilters::default()).await.unwrap();
+            assert!(active.iter().all(|t| t.uuid.to_string() != trashed_uuid));
+
+            // Trashed filter must surface it
+            let trashed = db
+                .query_tasks(&TaskFilters {
+                    status: Some(TaskStatus::Trashed),
+                    ..TaskFilters::default()
+                })
+                .await
+                .unwrap();
+            assert!(
+                trashed.iter().any(|t| t.uuid.to_string() == trashed_uuid),
+                "expected trashed row to be returned by TaskStatus::Trashed filter"
+            );
         }
 
         #[tokio::test]

--- a/libs/things3-core/src/database/core.rs
+++ b/libs/things3-core/src/database/core.rs
@@ -4468,24 +4468,25 @@ mod tests {
         use crate::models::TaskFilters;
         use tempfile::NamedTempFile;
 
-        async fn open_test_db() -> ThingsDatabase {
+        async fn open_test_db() -> (ThingsDatabase, NamedTempFile) {
             let f = NamedTempFile::new().unwrap();
             crate::test_utils::create_test_database(f.path())
                 .await
                 .unwrap();
-            ThingsDatabase::new(f.path()).await.unwrap()
+            let db = ThingsDatabase::new(f.path()).await.unwrap();
+            (db, f)
         }
 
         #[tokio::test]
         async fn test_query_tasks_no_filters() {
-            let db = open_test_db().await;
+            let (db, _f) = open_test_db().await;
             let result = db.query_tasks(&TaskFilters::default()).await;
             assert!(result.is_ok());
         }
 
         #[tokio::test]
         async fn test_query_tasks_status_filter() {
-            let db = open_test_db().await;
+            let (db, _f) = open_test_db().await;
             let filters = TaskFilters {
                 status: Some(TaskStatus::Completed),
                 ..TaskFilters::default()
@@ -4496,7 +4497,7 @@ mod tests {
 
         #[tokio::test]
         async fn test_query_tasks_limit() {
-            let db = open_test_db().await;
+            let (db, _f) = open_test_db().await;
             let filters = TaskFilters {
                 limit: Some(1),
                 ..TaskFilters::default()
@@ -4507,7 +4508,7 @@ mod tests {
 
         #[tokio::test]
         async fn test_query_tasks_tag_filter_and_semantics() {
-            let db = open_test_db().await;
+            let (db, _f) = open_test_db().await;
             let filters = TaskFilters {
                 tags: Some(vec!["nonexistent-tag-xyz".to_string()]),
                 ..TaskFilters::default()
@@ -4518,7 +4519,7 @@ mod tests {
 
         #[tokio::test]
         async fn test_query_tasks_search_query() {
-            let db = open_test_db().await;
+            let (db, _f) = open_test_db().await;
             let filters = TaskFilters {
                 search_query: Some("zzznomatch".to_string()),
                 ..TaskFilters::default()

--- a/libs/things3-core/src/database/core.rs
+++ b/libs/things3-core/src/database/core.rs
@@ -986,10 +986,24 @@ impl ThingsDatabase {
         let mut sql =
             format!("SELECT {COLS} FROM TMTask WHERE {where_clause} ORDER BY creationDate DESC");
 
-        if let Some(limit) = filters.limit {
-            sql.push_str(&format!(" LIMIT {limit}"));
-            if let Some(offset) = filters.offset {
-                sql.push_str(&format!(" OFFSET {offset}"));
+        // When tags or search_query are active, LIMIT/OFFSET must be applied in Rust after
+        // post-filtering, because SQL LIMIT would count non-matching rows and produce incorrect pages.
+        let has_post_filters =
+            filters.tags.as_ref().is_some_and(|t| !t.is_empty()) || filters.search_query.is_some();
+
+        if !has_post_filters {
+            match (filters.limit, filters.offset) {
+                (Some(limit), Some(offset)) => {
+                    sql.push_str(&format!(" LIMIT {limit} OFFSET {offset}"));
+                }
+                (Some(limit), None) => {
+                    sql.push_str(&format!(" LIMIT {limit}"));
+                }
+                (None, Some(offset)) => {
+                    // SQLite requires LIMIT when OFFSET is used; -1 means unlimited
+                    sql.push_str(&format!(" LIMIT -1 OFFSET {offset}"));
+                }
+                (None, None) => {}
             }
         }
 
@@ -1020,6 +1034,14 @@ impl ThingsDatabase {
                         .to_lowercase()
                         .contains(&q_lower)
             });
+        }
+
+        if has_post_filters {
+            let offset = filters.offset.unwrap_or(0);
+            tasks = tasks.into_iter().skip(offset).collect();
+            if let Some(limit) = filters.limit {
+                tasks.truncate(limit);
+            }
         }
 
         Ok(tasks)
@@ -4526,6 +4548,61 @@ mod tests {
             };
             let tasks = db.query_tasks(&filters).await.unwrap();
             assert!(tasks.is_empty());
+        }
+
+        #[tokio::test]
+        async fn test_query_tasks_offset_without_limit() {
+            // Bug fix: offset must not be silently ignored when limit is absent
+            let (db, _f) = open_test_db().await;
+            let all = db.query_tasks(&TaskFilters::default()).await.unwrap();
+            if all.len() < 2 {
+                return; // not enough rows to test pagination
+            }
+            let filters = TaskFilters {
+                offset: Some(1),
+                ..TaskFilters::default()
+            };
+            let offset_tasks = db.query_tasks(&filters).await.unwrap();
+            assert_eq!(offset_tasks.len(), all.len() - 1);
+            assert_eq!(offset_tasks[0].uuid, all[1].uuid);
+        }
+
+        #[tokio::test]
+        async fn test_query_tasks_pagination_with_post_filter() {
+            // Bug fix: LIMIT/OFFSET must count post-filter matches, not raw SQL rows
+            let (db, _f) = open_test_db().await;
+            // Fetch all tasks matching search (may be 0 in empty test DB — that's fine)
+            let all_matching = db
+                .query_tasks(&TaskFilters {
+                    search_query: Some(String::new()),
+                    ..TaskFilters::default()
+                })
+                .await
+                .unwrap();
+            if all_matching.len() < 2 {
+                return;
+            }
+            let page0 = db
+                .query_tasks(&TaskFilters {
+                    search_query: Some(String::new()),
+                    limit: Some(1),
+                    offset: Some(0),
+                    ..TaskFilters::default()
+                })
+                .await
+                .unwrap();
+            let page1 = db
+                .query_tasks(&TaskFilters {
+                    search_query: Some(String::new()),
+                    limit: Some(1),
+                    offset: Some(1),
+                    ..TaskFilters::default()
+                })
+                .await
+                .unwrap();
+            assert_eq!(page0.len(), 1);
+            assert_eq!(page1.len(), 1);
+            assert_ne!(page0[0].uuid, page1[0].uuid);
         }
     }
 }

--- a/libs/things3-core/src/database/core.rs
+++ b/libs/things3-core/src/database/core.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "advanced-queries")]
+use crate::models::TaskFilters;
 use crate::{
     database::{mappers::map_task_row, query_builders::TaskUpdateBuilder, validators},
     error::{Result as ThingsResult, ThingsError},
@@ -906,6 +908,120 @@ impl ThingsDatabase {
             .collect::<ThingsResult<Vec<Task>>>()?;
 
         debug!("Found {} tasks matching query: {}", tasks.len(), query);
+        Ok(tasks)
+    }
+
+    /// Query tasks using a [`TaskFilters`] struct produced by [`crate::query::TaskQueryBuilder`].
+    ///
+    /// All filter fields are optional and combined with AND semantics in SQL.
+    /// Tag and search-query filters are applied in Rust after the query returns
+    /// (Things 3 stores tags as a BLOB). `LIMIT` is applied in SQL, so pages may
+    /// be smaller than requested when tag/search filters are also active.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database query fails or task data cannot be mapped.
+    #[cfg(feature = "advanced-queries")]
+    pub async fn query_tasks(&self, filters: &TaskFilters) -> ThingsResult<Vec<Task>> {
+        const COLS: &str = "uuid, title, type, status, notes, startDate, deadline, stopDate, \
+                            creationDate, userModificationDate, project, area, heading, cachedTags";
+
+        let mut conditions: Vec<String> = vec!["trashed = 0".to_string()];
+
+        if let Some(status) = filters.status {
+            let n = match status {
+                TaskStatus::Incomplete => 0,
+                TaskStatus::Completed => 1,
+                TaskStatus::Canceled => 2,
+                TaskStatus::Trashed => 3,
+            };
+            conditions.push(format!("status = {n}"));
+        }
+
+        if let Some(task_type) = filters.task_type {
+            let n = match task_type {
+                TaskType::Todo => 0,
+                TaskType::Project => 1,
+                TaskType::Heading => 2,
+                TaskType::Area => 3,
+            };
+            conditions.push(format!("type = {n}"));
+        }
+
+        if let Some(ref uuid) = filters.project_uuid {
+            conditions.push(format!("project = '{uuid}'"));
+        }
+
+        if let Some(ref uuid) = filters.area_uuid {
+            conditions.push(format!("area = '{uuid}'"));
+        }
+
+        if let Some(from) = filters.start_date_from {
+            conditions.push(format!(
+                "startDate >= {}",
+                naive_date_to_things_timestamp(from)
+            ));
+        }
+        if let Some(to) = filters.start_date_to {
+            conditions.push(format!(
+                "startDate <= {}",
+                naive_date_to_things_timestamp(to)
+            ));
+        }
+
+        if let Some(from) = filters.deadline_from {
+            conditions.push(format!(
+                "deadline >= {}",
+                naive_date_to_things_timestamp(from)
+            ));
+        }
+        if let Some(to) = filters.deadline_to {
+            conditions.push(format!(
+                "deadline <= {}",
+                naive_date_to_things_timestamp(to)
+            ));
+        }
+
+        let where_clause = conditions.join(" AND ");
+        let mut sql =
+            format!("SELECT {COLS} FROM TMTask WHERE {where_clause} ORDER BY creationDate DESC");
+
+        if let Some(limit) = filters.limit {
+            sql.push_str(&format!(" LIMIT {limit}"));
+            if let Some(offset) = filters.offset {
+                sql.push_str(&format!(" OFFSET {offset}"));
+            }
+        }
+
+        let rows = sqlx::query(&sql)
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| ThingsError::unknown(format!("Failed to query tasks: {e}")))?;
+
+        let mut tasks = rows
+            .iter()
+            .map(map_task_row)
+            .collect::<ThingsResult<Vec<Task>>>()?;
+
+        if let Some(ref filter_tags) = filters.tags {
+            if !filter_tags.is_empty() {
+                tasks.retain(|task| filter_tags.iter().all(|f| task.tags.contains(f)));
+            }
+        }
+
+        if let Some(ref q) = filters.search_query {
+            let q_lower = q.to_lowercase();
+            tasks.retain(|task| {
+                task.title.to_lowercase().contains(&q_lower)
+                    || task
+                        .notes
+                        .as_deref()
+                        .unwrap_or("")
+                        .to_lowercase()
+                        .contains(&q_lower)
+            });
+        }
+
         Ok(tasks)
     }
 
@@ -4343,6 +4459,72 @@ mod tests {
                 month,
                 day
             );
+        }
+    }
+
+    #[cfg(feature = "advanced-queries")]
+    mod query_tasks_tests {
+        use super::*;
+        use crate::models::TaskFilters;
+        use tempfile::NamedTempFile;
+
+        async fn open_test_db() -> ThingsDatabase {
+            let f = NamedTempFile::new().unwrap();
+            crate::test_utils::create_test_database(f.path())
+                .await
+                .unwrap();
+            ThingsDatabase::new(f.path()).await.unwrap()
+        }
+
+        #[tokio::test]
+        async fn test_query_tasks_no_filters() {
+            let db = open_test_db().await;
+            let result = db.query_tasks(&TaskFilters::default()).await;
+            assert!(result.is_ok());
+        }
+
+        #[tokio::test]
+        async fn test_query_tasks_status_filter() {
+            let db = open_test_db().await;
+            let filters = TaskFilters {
+                status: Some(TaskStatus::Completed),
+                ..TaskFilters::default()
+            };
+            let tasks = db.query_tasks(&filters).await.unwrap();
+            assert!(tasks.iter().all(|t| t.status == TaskStatus::Completed));
+        }
+
+        #[tokio::test]
+        async fn test_query_tasks_limit() {
+            let db = open_test_db().await;
+            let filters = TaskFilters {
+                limit: Some(1),
+                ..TaskFilters::default()
+            };
+            let tasks = db.query_tasks(&filters).await.unwrap();
+            assert!(tasks.len() <= 1);
+        }
+
+        #[tokio::test]
+        async fn test_query_tasks_tag_filter_and_semantics() {
+            let db = open_test_db().await;
+            let filters = TaskFilters {
+                tags: Some(vec!["nonexistent-tag-xyz".to_string()]),
+                ..TaskFilters::default()
+            };
+            let tasks = db.query_tasks(&filters).await.unwrap();
+            assert!(tasks.is_empty());
+        }
+
+        #[tokio::test]
+        async fn test_query_tasks_search_query() {
+            let db = open_test_db().await;
+            let filters = TaskFilters {
+                search_query: Some("zzznomatch".to_string()),
+                ..TaskFilters::default()
+            };
+            let tasks = db.query_tasks(&filters).await.unwrap();
+            assert!(tasks.is_empty());
         }
     }
 }

--- a/libs/things3-core/src/query.rs
+++ b/libs/things3-core/src/query.rs
@@ -100,6 +100,21 @@ impl TaskQueryBuilder {
     pub fn build(self) -> TaskFilters {
         self.filters
     }
+
+    /// Execute the query against a live database connection.
+    ///
+    /// Requires the `advanced-queries` feature flag.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database query fails or task data cannot be mapped.
+    #[cfg(feature = "advanced-queries")]
+    pub async fn execute(
+        &self,
+        db: &crate::database::ThingsDatabase,
+    ) -> crate::error::Result<Vec<crate::models::Task>> {
+        db.query_tasks(&self.filters).await
+    }
 }
 
 impl Default for TaskQueryBuilder {
@@ -230,6 +245,45 @@ mod tests {
         let filters = builder.build();
 
         assert_eq!(filters.offset, Some(10));
+    }
+
+    #[cfg(feature = "advanced-queries")]
+    mod execute_tests {
+        use super::*;
+        use tempfile::NamedTempFile;
+
+        #[tokio::test]
+        async fn test_execute_empty_builder() {
+            let f = NamedTempFile::new().unwrap();
+            crate::test_utils::create_test_database(f.path())
+                .await
+                .unwrap();
+            let db = crate::database::ThingsDatabase::new(f.path())
+                .await
+                .unwrap();
+            let result = TaskQueryBuilder::new().execute(&db).await;
+            assert!(result.is_ok());
+        }
+
+        #[tokio::test]
+        async fn test_execute_with_status_filter() {
+            let f = NamedTempFile::new().unwrap();
+            crate::test_utils::create_test_database(f.path())
+                .await
+                .unwrap();
+            let db = crate::database::ThingsDatabase::new(f.path())
+                .await
+                .unwrap();
+            let result = TaskQueryBuilder::new()
+                .status(TaskStatus::Incomplete)
+                .execute(&db)
+                .await;
+            assert!(result.is_ok());
+            assert!(result
+                .unwrap()
+                .iter()
+                .all(|t| t.status == TaskStatus::Incomplete));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds the `advanced-queries` feature flag to `things3-core` — all new APIs are gated behind it, so existing builds and the public API surface are unaffected
- `ThingsDatabase::query_tasks(filters: &TaskFilters)` executes a dynamic SQL query driven by status, type, project UUID, area UUID, start/deadline date ranges, limit, and offset — tags and search-query filters are applied in Rust post-fetch (consistent with the existing `search_logbook` pattern, since Things 3 stores tags as a BLOB)
- `TaskQueryBuilder::execute(&db)` wires the builder directly to `query_tasks` so callers don't need to call `.build()` manually
- Reuses `naive_date_to_things_timestamp()` (`core.rs:53`) for date conversions — no new utilities introduced
- Known limitation documented in code: `LIMIT` is applied in SQL before Rust post-filters, so pages may be smaller than requested when tag/search_query filters are active

## Test plan

- [ ] `cargo test -p things3-core --features "advanced-queries,test-utils" --lib` → 402 passed
- [ ] `cargo clippy -p things3-core --all-targets --all-features -- -D warnings` → clean
- [ ] `cargo test -p things3-core --lib` (no feature) → existing 392 tests still pass, new code excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)