### PR TITLE
chore(release): v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-04-26
+
 ### Added
 - **`advanced-queries` feature flag** — gates new query execution APIs so existing builds are unaffected.
 - **`ThingsDatabase::query_tasks(filters: &TaskFilters)`** — executes a dynamic SQL query driven by all `TaskFilters` fields: status, type, project, area, start date range, deadline range, limit, and offset. Tag and search-query filters are applied in Rust after the database fetch.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3109,7 +3109,7 @@ dependencies = [
 
 [[package]]
 name = "things3-cli"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3160,7 +3160,7 @@ dependencies = [
 
 [[package]]
 name = "things3-common"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3172,7 +3172,7 @@ dependencies = [
 
 [[package]]
 name = "things3-core"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4243,7 +4243,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xtask"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.0.1"
+version = "1.1.0"
 edition = "2021"
 rust-version = "1.70"
 authors = ["GarthDB <garthdb@gmail.com>"]


### PR DESCRIPTION
Cuts the 1.1.0 release. Bumps workspace version `1.0.1 → 1.1.0` and converts the `[Unreleased]` CHANGELOG section into `[1.1.0] - 2026-04-26`.

Closes milestone #72.

## What ships in 1.1.0

All gated behind the `advanced-queries` feature flag (additive — default builds are unchanged):

- **Query execution wiring** (#73 originally, now in `query_tasks`/`TaskQueryBuilder::execute`)
- **Natural-language date helpers** — `due_today`, `overdue`, `due_this_week`, etc.
- **Flexible tag operations** — `any_tags`, `exclude_tags`, `tag_count`
- **Fuzzy search and ranked results** — windowed Levenshtein, `execute_ranked()`
- **Saved queries** — `SavedQuery` / `SavedQueryStore` with JSON persistence
- **Boolean expressions** — `FilterExpr` (AND/OR/NOT) post-filter with `where_expr()` builder method

Plus a 1.0.x carry-forward bug fix already shipped in 1.0.1: `THINGS_DB_PATH` env var (#76).

## Post-merge

After this merges to `main`:
1. `git tag v1.1.0 <merge-commit>`
2. `git push origin v1.1.0`
3. `gh release create v1.1.0` with the CHANGELOG body

## Test plan

- [x] `cargo build --workspace` clean at 1.1.0
- [x] `cargo test --features test-utils` clean (pre-push hook)
- [x] `cargo audit` clean (pre-push hook)
- [x] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)