### PR TITLE
feat(batch-operations): cursor-based pagination on TaskQueryBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`batch-operations` feature flag** — gates new pagination, streaming, and batch-fetch APIs (1.2.0 milestone). Additive; default builds are unaffected.
+- **Cursor-based pagination on `TaskQueryBuilder`** — new `cursor` module exposing opaque `Cursor` and `Page<T>` types, plus `TaskQueryBuilder::after(cursor)` and `execute_paged()` (gated on both `advanced-queries` and `batch-operations`). Cursor anchors on `(created, uuid)`: `created` is immutable so cursors stay valid under concurrent edits, and `uuid` provides a deterministic tiebreak. Cursor encoding is URL-safe base64 of a compact JSON payload. Default page size is 100 (overridable via `.limit()`). `execute_paged` returns `ThingsError::InvalidCursor` if `.offset()` and `.after()` are both set, or if `.fuzzy_search()` and `.after()` are both set.
+
+### Changed
+- **`ThingsDatabase::query_tasks` ordering is now deterministic** — `ORDER BY` was tightened from `creationDate DESC` to `CAST(creationDate AS INTEGER) DESC, uuid DESC`. Previously, the order of tasks tied on truncated-second `creationDate` was unspecified; now it is well-defined. No effect on callers that already had distinct timestamps.
+
 ## [1.1.0] - 2026-04-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3176,6 +3176,7 @@ version = "1.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64 0.22.1",
  "chrono",
  "criterion",
  "csv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,9 @@ rusqlite = { version = "0.31", features = ["bundled"] }
 # String similarity (for tag fuzzy matching)
 strsim = "0.11"
 
+# Cursor pagination (batch-operations feature)
+base64 = "0.22"
+
 # CLI
 clap = { version = "4.0", features = ["derive"] }
 

--- a/apps/things3-cli/src/mcp.rs
+++ b/apps/things3-cli/src/mcp.rs
@@ -407,6 +407,9 @@ impl From<ThingsError> for McpError {
                 McpError::validation_error(format!("Area not found: {uuid}"))
             }
             ThingsError::Validation { message } => McpError::validation_error(message),
+            ThingsError::InvalidCursor(message) => {
+                McpError::validation_error(format!("Invalid cursor: {message}"))
+            }
             ThingsError::Configuration { message } => McpError::configuration_error(message),
             ThingsError::DateValidation(e) => {
                 McpError::validation_error(format!("Date validation failed: {e}"))

--- a/libs/things3-core/Cargo.toml
+++ b/libs/things3-core/Cargo.toml
@@ -19,7 +19,8 @@ export-csv = ["dep:csv"]
 export-opml = ["dep:quick-xml"]
 observability = ["dep:metrics"]
 advanced-queries = []
-full = ["export-csv", "export-opml", "observability", "advanced-queries"]
+batch-operations = ["dep:base64"]
+full = ["export-csv", "export-opml", "observability", "advanced-queries", "batch-operations"]
 
 [dependencies]
 # Core
@@ -36,6 +37,9 @@ rusqlite = { version = "0.32", features = ["bundled"] }
 
 # String similarity (for tag fuzzy matching)
 strsim.workspace = true
+
+# Cursor pagination (optional, gated behind `batch-operations`)
+base64 = { workspace = true, optional = true }
 
 # Async
 tokio.workspace = true

--- a/libs/things3-core/src/cursor.rs
+++ b/libs/things3-core/src/cursor.rs
@@ -95,12 +95,15 @@ pub(crate) struct CursorPayload {
 }
 
 /// A page of results plus an optional cursor for the next page.
-///
-/// `next_cursor` is `None` when the page is the last one (i.e. the page
-/// returned fewer items than the configured page size).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Page<T> {
     pub items: Vec<T>,
+    /// Cursor for the next page, or `None` when this is the last page.
+    ///
+    /// Uses the "full page → maybe more" heuristic: a cursor is returned
+    /// whenever `items.len() == page_size`, even if no further rows exist.
+    /// In that case the subsequent fetch returns an empty `Page` with
+    /// `next_cursor: None`. This is standard keyset pagination behavior.
     pub next_cursor: Option<Cursor>,
 }
 

--- a/libs/things3-core/src/cursor.rs
+++ b/libs/things3-core/src/cursor.rs
@@ -1,0 +1,197 @@
+//! Opaque keyset pagination cursors.
+//!
+//! [`Cursor`] is a base64-encoded JSON payload identifying the last task
+//! returned in a page. [`Page`] bundles a slice of items with the optional
+//! cursor for the next page. Both are returned by
+//! [`crate::query::TaskQueryBuilder::execute_paged`].
+//!
+//! Cursors anchor on `(created, uuid)`:
+//! - `created` is immutable (a task's creation date never changes), so a
+//!   cursor remains valid even if the underlying task is edited between
+//!   page fetches.
+//! - `uuid` is a deterministic tiebreaker.
+//!
+//! The encoded form is URL-safe base64 (no padding) so cursors can travel
+//! through HTTP query strings without further escaping.
+//!
+//! Requires the `batch-operations` feature flag.
+
+#![cfg(feature = "batch-operations")]
+
+use std::fmt;
+use std::str::FromStr;
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::error::{Result, ThingsError};
+
+/// Opaque pagination token. Constructed by
+/// [`crate::query::TaskQueryBuilder::execute_paged`] and round-tripped
+/// through [`Display`]/[`FromStr`].
+///
+/// Callers should treat the wrapped string as opaque — the encoding is an
+/// implementation detail that may change without breaking the public API.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Cursor(String);
+
+impl Cursor {
+    /// Borrow the encoded string.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Encode a payload into a cursor.
+    ///
+    /// Only invoked from `execute_paged`, which requires both `advanced-queries`
+    /// and `batch-operations`. Under `batch-operations` alone the function is
+    /// unused — allow dead_code rather than tightening the gate on the type.
+    #[cfg_attr(not(feature = "advanced-queries"), allow(dead_code))]
+    pub(crate) fn encode(payload: &CursorPayload) -> Result<Self> {
+        let bytes = serde_json::to_vec(payload)?;
+        Ok(Self(URL_SAFE_NO_PAD.encode(bytes)))
+    }
+
+    /// Decode the cursor back into its payload.
+    pub(crate) fn decode(&self) -> Result<CursorPayload> {
+        let bytes = URL_SAFE_NO_PAD
+            .decode(self.0.as_bytes())
+            .map_err(|e| ThingsError::InvalidCursor(format!("base64 decode failed: {e}")))?;
+        serde_json::from_slice(&bytes)
+            .map_err(|e| ThingsError::InvalidCursor(format!("payload parse failed: {e}")))
+    }
+}
+
+impl fmt::Display for Cursor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl FromStr for Cursor {
+    type Err = ThingsError;
+
+    fn from_str(s: &str) -> Result<Self> {
+        let cursor = Self(s.to_string());
+        // Validate decoding eagerly so bad input is rejected at the API boundary.
+        cursor.decode()?;
+        Ok(cursor)
+    }
+}
+
+/// Internal cursor payload: the anchor for "what comes after."
+///
+/// Field names are deliberately one letter to keep the encoded cursor short.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct CursorPayload {
+    /// `created` of the last-returned task.
+    pub(crate) c: DateTime<Utc>,
+    /// `uuid` of the last-returned task.
+    pub(crate) u: Uuid,
+}
+
+/// A page of results plus an optional cursor for the next page.
+///
+/// `next_cursor` is `None` when the page is the last one (i.e. the page
+/// returned fewer items than the configured page size).
+#[derive(Debug, Clone)]
+pub struct Page<T> {
+    pub items: Vec<T>,
+    pub next_cursor: Option<Cursor>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn payload() -> CursorPayload {
+        CursorPayload {
+            c: DateTime::parse_from_rfc3339("2026-04-27T12:34:56Z")
+                .unwrap()
+                .with_timezone(&Utc),
+            u: Uuid::parse_str("12345678-1234-5678-1234-567812345678").unwrap(),
+        }
+    }
+
+    #[test]
+    fn test_cursor_encode_decode_roundtrip() {
+        let p = payload();
+        let cursor = Cursor::encode(&p).unwrap();
+        let decoded = cursor.decode().unwrap();
+        assert_eq!(decoded, p);
+    }
+
+    #[test]
+    fn test_cursor_display_fromstr_roundtrip() {
+        let p = payload();
+        let cursor = Cursor::encode(&p).unwrap();
+        let s = cursor.to_string();
+        let parsed = Cursor::from_str(&s).unwrap();
+        assert_eq!(parsed, cursor);
+    }
+
+    #[test]
+    fn test_cursor_rejects_invalid_base64() {
+        let err = Cursor::from_str("!!!not base64!!!").unwrap_err();
+        match err {
+            ThingsError::InvalidCursor(msg) => assert!(msg.contains("base64")),
+            other => panic!("expected InvalidCursor, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_cursor_rejects_invalid_json() {
+        let bogus = URL_SAFE_NO_PAD.encode(b"not json");
+        let err = Cursor::from_str(&bogus).unwrap_err();
+        match err {
+            ThingsError::InvalidCursor(msg) => assert!(msg.contains("payload parse failed")),
+            other => panic!("expected InvalidCursor, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_cursor_rejects_missing_fields() {
+        let bogus = URL_SAFE_NO_PAD.encode(b"{}");
+        assert!(matches!(
+            Cursor::from_str(&bogus),
+            Err(ThingsError::InvalidCursor(_))
+        ));
+    }
+
+    #[test]
+    fn test_cursor_url_safe_encoding() {
+        // URL-safe base64 uses '-' and '_' instead of '+' and '/' and omits padding.
+        let p = payload();
+        let cursor = Cursor::encode(&p).unwrap();
+        let s = cursor.as_str();
+        assert!(!s.contains('+'), "cursor should not contain '+': {s}");
+        assert!(!s.contains('/'), "cursor should not contain '/': {s}");
+        assert!(
+            !s.contains('='),
+            "cursor should not contain '=' padding: {s}"
+        );
+    }
+
+    #[test]
+    fn test_cursor_serde_through_json() {
+        let p = payload();
+        let cursor = Cursor::encode(&p).unwrap();
+        let json = serde_json::to_string(&cursor).unwrap();
+        let parsed: Cursor = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, cursor);
+    }
+
+    #[test]
+    fn test_page_construction() {
+        let page: Page<i32> = Page {
+            items: vec![1, 2, 3],
+            next_cursor: None,
+        };
+        assert_eq!(page.items.len(), 3);
+        assert!(page.next_cursor.is_none());
+    }
+}

--- a/libs/things3-core/src/database/core.rs
+++ b/libs/things3-core/src/database/core.rs
@@ -1012,14 +1012,16 @@ impl ThingsDatabase {
             ));
         }
 
-        if let Some((after_seconds, after_uuid)) = after {
+        if let Some((after_seconds, _)) = after {
             // Strictly less than the cursor in (truncated_seconds DESC, uuid DESC)
             // ordering — i.e. older second, or same second with smaller uuid.
             // Casting to INTEGER matches the precision of `Task::created`,
             // which is reconstructed at second precision when reading rows.
+            // UUID is bound as a parameter (?) rather than interpolated for
+            // consistency with the rest of the codebase's query practices.
             conditions.push(format!(
                 "(CAST(creationDate AS INTEGER) < {after_seconds} \
-                 OR (CAST(creationDate AS INTEGER) = {after_seconds} AND uuid < '{after_uuid}'))"
+                 OR (CAST(creationDate AS INTEGER) = {after_seconds} AND uuid < ?))"
             ));
         }
 
@@ -1054,10 +1056,15 @@ impl ThingsDatabase {
             }
         }
 
-        let rows = sqlx::query(&sql)
-            .fetch_all(&self.pool)
-            .await
-            .map_err(|e| ThingsError::unknown(format!("Failed to query tasks: {e}")))?;
+        let rows = if let Some((_, after_uuid)) = after {
+            sqlx::query(&sql)
+                .bind(after_uuid.to_string())
+                .fetch_all(&self.pool)
+                .await
+        } else {
+            sqlx::query(&sql).fetch_all(&self.pool).await
+        }
+        .map_err(|e| ThingsError::unknown(format!("Failed to query tasks: {e}")))?;
 
         let mut tasks = rows
             .iter()

--- a/libs/things3-core/src/database/core.rs
+++ b/libs/things3-core/src/database/core.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "advanced-queries")]
+#[cfg(any(feature = "advanced-queries", feature = "batch-operations"))]
 use crate::models::TaskFilters;
 use crate::{
     database::{mappers::map_task_row, query_builders::TaskUpdateBuilder, validators},
@@ -928,8 +928,26 @@ impl ThingsDatabase {
     /// # Errors
     ///
     /// Returns an error if the database query fails or task data cannot be mapped.
-    #[cfg(feature = "advanced-queries")]
+    #[cfg(any(feature = "advanced-queries", feature = "batch-operations"))]
     pub async fn query_tasks(&self, filters: &TaskFilters) -> ThingsResult<Vec<Task>> {
+        self.query_tasks_inner(filters, None).await
+    }
+
+    /// Internal query path that optionally applies a cursor WHERE clause.
+    ///
+    /// `after` is `(seconds_since_unix_epoch, uuid)` of the last-returned
+    /// task. When `Some`, an additional `WHERE` clause restricts results to
+    /// rows strictly older than that anchor in the canonical
+    /// `CAST(creationDate AS INTEGER) DESC, uuid DESC` ordering.
+    ///
+    /// Gated on either `advanced-queries` or `batch-operations` because both
+    /// public surfaces (`query_tasks` and `execute_paged`) share this engine.
+    #[cfg(any(feature = "advanced-queries", feature = "batch-operations"))]
+    pub(crate) async fn query_tasks_inner(
+        &self,
+        filters: &TaskFilters,
+        after: Option<(i64, Uuid)>,
+    ) -> ThingsResult<Vec<Task>> {
         const COLS: &str = "uuid, title, type, status, notes, startDate, deadline, stopDate, \
                             creationDate, userModificationDate, project, area, heading, cachedTags";
 
@@ -994,9 +1012,26 @@ impl ThingsDatabase {
             ));
         }
 
+        if let Some((after_seconds, after_uuid)) = after {
+            // Strictly less than the cursor in (truncated_seconds DESC, uuid DESC)
+            // ordering — i.e. older second, or same second with smaller uuid.
+            // Casting to INTEGER matches the precision of `Task::created`,
+            // which is reconstructed at second precision when reading rows.
+            conditions.push(format!(
+                "(CAST(creationDate AS INTEGER) < {after_seconds} \
+                 OR (CAST(creationDate AS INTEGER) = {after_seconds} AND uuid < '{after_uuid}'))"
+            ));
+        }
+
         let where_clause = conditions.join(" AND ");
-        let mut sql =
-            format!("SELECT {COLS} FROM TMTask WHERE {where_clause} ORDER BY creationDate DESC");
+        // ORDER BY uses the truncated-second value so it agrees with the
+        // cursor pagination logic (which compares at second precision because
+        // `Task::created` is reconstructed at second precision). `uuid DESC` is
+        // a deterministic tiebreak within the same second.
+        let mut sql = format!(
+            "SELECT {COLS} FROM TMTask WHERE {where_clause} \
+             ORDER BY CAST(creationDate AS INTEGER) DESC, uuid DESC"
+        );
 
         // When tags or search_query are active, LIMIT/OFFSET must be applied in Rust
         // after post-filtering, because SQL LIMIT would count non-matching rows.
@@ -5088,6 +5123,150 @@ mod tests {
             let uuids: std::collections::HashSet<_> = tasks.iter().map(|t| t.uuid).collect();
             assert!(uuids.contains(&target));
             assert_eq!(tasks.len(), 1);
+        }
+
+        #[cfg(feature = "batch-operations")]
+        mod cursor_pagination_tests {
+            use super::*;
+
+            #[tokio::test]
+            async fn test_execute_paged_walks_through_all_tasks() {
+                let (db, _f) = open_test_db().await;
+                let mut inserted = vec![];
+                for i in 0..5 {
+                    inserted.push(insert_task(&db, &format!("task-{i}"), None, &[]).await);
+                }
+
+                let mut all_collected: Vec<Uuid> = vec![];
+                let mut cursor = None;
+                let mut page_count = 0;
+                loop {
+                    let mut builder = TaskQueryBuilder::new().limit(2);
+                    if let Some(c) = cursor.take() {
+                        builder = builder.after(c);
+                    }
+                    let page = builder.execute_paged(&db).await.unwrap();
+                    page_count += 1;
+                    all_collected.extend(page.items.iter().map(|t| t.uuid));
+                    if let Some(next) = page.next_cursor {
+                        cursor = Some(next);
+                    } else {
+                        break;
+                    }
+                    assert!(page_count < 10, "runaway pagination loop");
+                }
+
+                let inserted_set: std::collections::HashSet<_> = inserted.iter().copied().collect();
+                let collected_set: std::collections::HashSet<_> =
+                    all_collected.iter().copied().collect();
+                for uuid in &inserted_set {
+                    assert!(collected_set.contains(uuid), "missing inserted uuid {uuid}");
+                }
+                let mut sorted = all_collected.clone();
+                sorted.sort();
+                sorted.dedup();
+                assert_eq!(sorted.len(), all_collected.len(), "duplicates in pages");
+            }
+
+            #[tokio::test]
+            async fn test_execute_paged_last_page_has_no_next_cursor() {
+                let (db, _f) = open_test_db().await;
+                insert_task(&db, "only-task", None, &[]).await;
+                let page = TaskQueryBuilder::new()
+                    .status(TaskStatus::Incomplete)
+                    .limit(100)
+                    .execute_paged(&db)
+                    .await
+                    .unwrap();
+                assert!(
+                    page.next_cursor.is_none(),
+                    "non-full page should not have a next cursor"
+                );
+            }
+
+            #[tokio::test]
+            async fn test_execute_paged_with_status_filter() {
+                let (db, _f) = open_test_db().await;
+                let target = insert_task(&db, "incomplete-task", None, &[]).await;
+                let page = TaskQueryBuilder::new()
+                    .status(TaskStatus::Incomplete)
+                    .limit(50)
+                    .execute_paged(&db)
+                    .await
+                    .unwrap();
+                let uuids: std::collections::HashSet<_> =
+                    page.items.iter().map(|t| t.uuid).collect();
+                assert!(uuids.contains(&target));
+                for task in &page.items {
+                    assert_eq!(task.status, TaskStatus::Incomplete);
+                }
+            }
+
+            #[tokio::test]
+            async fn test_execute_paged_with_post_filter_any_tags() {
+                let (db, _f) = open_test_db().await;
+                let a1 = insert_task_with_tags(&db, "a1", &["a"]).await;
+                let a2 = insert_task_with_tags(&db, "a2", &["a"]).await;
+                let a3 = insert_task_with_tags(&db, "a3", &["a"]).await;
+                let _b = insert_task_with_tags(&db, "b1", &["b"]).await;
+
+                let mut all: Vec<Uuid> = vec![];
+                let mut cursor = None;
+                loop {
+                    let mut builder = TaskQueryBuilder::new()
+                        .any_tags(vec!["a".to_string()])
+                        .limit(2);
+                    if let Some(c) = cursor.take() {
+                        builder = builder.after(c);
+                    }
+                    let page = builder.execute_paged(&db).await.unwrap();
+                    all.extend(page.items.iter().map(|t| t.uuid));
+                    if let Some(n) = page.next_cursor {
+                        cursor = Some(n);
+                    } else {
+                        break;
+                    }
+                }
+
+                let collected: std::collections::HashSet<_> = all.iter().copied().collect();
+                assert!(collected.contains(&a1));
+                assert!(collected.contains(&a2));
+                assert!(collected.contains(&a3));
+                assert_eq!(collected.len(), 3, "should contain only a-tagged tasks");
+            }
+
+            #[tokio::test]
+            async fn test_execute_paged_default_page_size_when_no_limit() {
+                let (db, _f) = open_test_db().await;
+                // Confirm a builder without `.limit()` doesn't error and returns a Page.
+                // Default page size is 100 — with the empty test DB, all tasks fit and
+                // we expect no next_cursor.
+                let page = TaskQueryBuilder::new()
+                    .status(TaskStatus::Incomplete)
+                    .execute_paged(&db)
+                    .await
+                    .unwrap();
+                assert!(page.items.len() <= 100);
+                assert!(page.next_cursor.is_none());
+            }
+
+            #[tokio::test]
+            async fn test_query_tasks_order_is_deterministic_by_uuid_tiebreak() {
+                let (db, _f) = open_test_db().await;
+                // insert_task hardcodes creationDate = 0, so all tasks tie. ORDER BY
+                // uuid DESC gives a deterministic tiebreak.
+                for i in 0..3 {
+                    insert_task(&db, &format!("dup-time-{i}"), None, &[]).await;
+                }
+                let first = db.query_tasks(&TaskFilters::default()).await.unwrap();
+                let second = db.query_tasks(&TaskFilters::default()).await.unwrap();
+                let first_uuids: Vec<_> = first.iter().map(|t| t.uuid).collect();
+                let second_uuids: Vec<_> = second.iter().map(|t| t.uuid).collect();
+                assert_eq!(
+                    first_uuids, second_uuids,
+                    "tied-creationDate ordering should be deterministic"
+                );
+            }
         }
     }
 }

--- a/libs/things3-core/src/error.rs
+++ b/libs/things3-core/src/error.rs
@@ -44,6 +44,9 @@ pub enum ThingsError {
     #[error("Validation error: {message}")]
     Validation { message: String },
 
+    #[error("Invalid cursor: {0}")]
+    InvalidCursor(String),
+
     #[error("Configuration error: {message}")]
     Configuration { message: String },
 

--- a/libs/things3-core/src/lib.rs
+++ b/libs/things3-core/src/lib.rs
@@ -61,6 +61,9 @@ pub mod error;
 #[cfg(feature = "advanced-queries")]
 pub mod filter_expr;
 
+#[cfg(feature = "batch-operations")]
+pub mod cursor;
+
 #[cfg(any(feature = "export-csv", feature = "export-opml"))]
 pub mod export;
 
@@ -124,6 +127,9 @@ pub use query_cache::{QueryCache, QueryCacheConfig, QueryCacheStats};
 
 #[cfg(feature = "advanced-queries")]
 pub use filter_expr::{FilterExpr, FilterPredicate};
+
+#[cfg(feature = "batch-operations")]
+pub use cursor::{Cursor, Page};
 pub use query_performance::{
     ImplementationEffort, OptimizationPriority, OptimizationType, QueryContext,
     QueryOptimizationSuggestion, QueryPerformanceMetrics, QueryPerformanceStats,

--- a/libs/things3-core/src/query.rs
+++ b/libs/things3-core/src/query.rs
@@ -23,6 +23,10 @@ pub struct TaskQueryBuilder {
     fuzzy_threshold: Option<f32>,
     #[cfg(feature = "advanced-queries")]
     where_expr: Option<crate::filter_expr::FilterExpr>,
+    /// Cursor for keyset pagination via `execute_paged`. Stored on the builder
+    /// because `TaskFilters` is frozen public API.
+    #[cfg(feature = "batch-operations")]
+    after: Option<crate::cursor::Cursor>,
 }
 
 impl TaskQueryBuilder {
@@ -43,6 +47,8 @@ impl TaskQueryBuilder {
             fuzzy_threshold: None,
             #[cfg(feature = "advanced-queries")]
             where_expr: None,
+            #[cfg(feature = "batch-operations")]
+            after: None,
         }
     }
 
@@ -160,6 +166,22 @@ impl TaskQueryBuilder {
     #[must_use]
     pub fn where_expr(mut self, expr: crate::filter_expr::FilterExpr) -> Self {
         self.where_expr = Some(expr);
+        self
+    }
+
+    /// Continue cursor-based pagination from a previously-returned [`crate::cursor::Cursor`].
+    ///
+    /// The cursor identifies the last task delivered on the previous page;
+    /// [`Self::execute_paged`] will return tasks strictly after it in the
+    /// `(creationDate DESC, uuid DESC)` ordering. Mutually exclusive with
+    /// `.offset(...)` — `execute_paged` will return [`crate::error::ThingsError::InvalidCursor`]
+    /// if both are set.
+    ///
+    /// Requires the `batch-operations` feature flag.
+    #[cfg(feature = "batch-operations")]
+    #[must_use]
+    pub fn after(mut self, cursor: crate::cursor::Cursor) -> Self {
+        self.after = Some(cursor);
         self
     }
 
@@ -355,6 +377,108 @@ impl TaskQueryBuilder {
         tasks
     }
 
+    /// Execute the query and return one page of results plus an optional
+    /// cursor for the next page.
+    ///
+    /// Pagination is keyset-based: the cursor encodes `(created, uuid)` of the
+    /// last-returned task and the next page admits only rows strictly older in
+    /// the canonical `(creationDate DESC, uuid DESC)` ordering. Unlike
+    /// `offset`, page boundaries are stable when underlying data changes
+    /// between fetches.
+    ///
+    /// Page size is `self.filters.limit` if set, otherwise `100`. The returned
+    /// `Page::next_cursor` is `Some` only if the page is full (i.e. there may
+    /// be more rows); the last page always has `next_cursor: None`.
+    ///
+    /// Requires both the `advanced-queries` and `batch-operations` feature
+    /// flags (cursor pagination is built on top of `query_tasks`).
+    ///
+    /// # Errors
+    ///
+    /// - [`crate::error::ThingsError::InvalidCursor`] if `.offset(...)` and
+    ///   `.after(...)` are both set, or if `.fuzzy_search(...)` and
+    ///   `.after(...)` are both set, or if the cursor itself is malformed.
+    /// - Any error returned by [`crate::database::ThingsDatabase::query_tasks`].
+    #[cfg(all(feature = "advanced-queries", feature = "batch-operations"))]
+    pub async fn execute_paged(
+        &self,
+        db: &crate::database::ThingsDatabase,
+    ) -> crate::error::Result<crate::cursor::Page<crate::models::Task>> {
+        if self.fuzzy_query.is_some() && self.after.is_some() {
+            return Err(crate::error::ThingsError::InvalidCursor(
+                "cursor pagination is not compatible with fuzzy_search".to_string(),
+            ));
+        }
+        if self.filters.offset.is_some() && self.after.is_some() {
+            return Err(crate::error::ThingsError::InvalidCursor(
+                "offset and after are mutually exclusive".to_string(),
+            ));
+        }
+
+        let after_payload = self
+            .after
+            .as_ref()
+            .map(crate::cursor::Cursor::decode)
+            .transpose()?;
+        let after_anchor = after_payload.as_ref().map(|p| (p.c.timestamp(), p.u));
+
+        let page_size = self.filters.limit.unwrap_or(DEFAULT_PAGE_SIZE);
+
+        // Build a TaskFilters with the page size applied at the SQL layer when
+        // there are no post-filters; with post-filters, defer to Rust below.
+        let has_tag_post_filters = self.any_tags.as_ref().is_some_and(|t| !t.is_empty())
+            || self.exclude_tags.as_ref().is_some_and(|t| !t.is_empty())
+            || self.tag_count_min.is_some();
+        let has_where_expr = self.where_expr.is_some();
+        let has_post_filters = has_tag_post_filters || has_where_expr;
+
+        let mut filters = self.filters.clone();
+        filters.offset = None;
+        if has_post_filters {
+            // SQL fetches everything; Rust does the slicing.
+            filters.limit = None;
+        } else {
+            filters.limit = Some(page_size);
+        }
+
+        let mut tasks = db.query_tasks_inner(&filters, after_anchor).await?;
+
+        if has_tag_post_filters {
+            tasks = Self::apply_tag_filters(
+                tasks,
+                self.any_tags.as_deref(),
+                self.exclude_tags.as_deref(),
+                self.tag_count_min,
+            );
+        }
+        if let Some(expr) = &self.where_expr {
+            tasks.retain(|task| expr.matches(task));
+        }
+        if has_post_filters {
+            tasks.truncate(page_size);
+        }
+
+        let next_cursor = if tasks.len() == page_size {
+            tasks
+                .last()
+                .map(|last| {
+                    let payload = crate::cursor::CursorPayload {
+                        c: last.created,
+                        u: last.uuid,
+                    };
+                    crate::cursor::Cursor::encode(&payload)
+                })
+                .transpose()?
+        } else {
+            None
+        };
+
+        Ok(crate::cursor::Page {
+            items: tasks,
+            next_cursor,
+        })
+    }
+
     /// Execute the query and return tasks paired with their fuzzy-match scores,
     /// sorted by score descending (ties broken by UUID for determinism).
     ///
@@ -472,6 +596,9 @@ impl TaskQueryBuilder {
             fuzzy_query: query.fuzzy_query.clone(),
             fuzzy_threshold: query.fuzzy_threshold.map(|t| t.clamp(0.0, 1.0)),
             where_expr: query.where_expr.clone(),
+            // Cursors are ephemeral and not part of saved-query state.
+            #[cfg(feature = "batch-operations")]
+            after: None,
         }
     }
 }
@@ -484,6 +611,9 @@ impl Default for TaskQueryBuilder {
 
 #[cfg(feature = "advanced-queries")]
 const DEFAULT_FUZZY_THRESHOLD: f32 = 0.6;
+
+#[cfg(all(feature = "advanced-queries", feature = "batch-operations"))]
+const DEFAULT_PAGE_SIZE: usize = 100;
 
 #[cfg(feature = "advanced-queries")]
 fn task_fuzzy_score(query_lc: &str, task: &crate::models::Task) -> f32 {
@@ -647,6 +777,79 @@ mod tests {
         let expr = FilterExpr::status(TaskStatus::Incomplete);
         let builder = TaskQueryBuilder::new().where_expr(expr.clone());
         assert_eq!(builder.where_expr, Some(expr));
+    }
+
+    #[cfg(feature = "batch-operations")]
+    mod cursor_builder_tests {
+        use super::*;
+        use crate::cursor::{Cursor, CursorPayload};
+        use chrono::Utc;
+        use uuid::Uuid;
+
+        fn sample_cursor() -> Cursor {
+            Cursor::encode(&CursorPayload {
+                c: Utc::now(),
+                u: Uuid::new_v4(),
+            })
+            .unwrap()
+        }
+
+        #[test]
+        fn test_after_setter_stores_cursor() {
+            let c = sample_cursor();
+            let builder = TaskQueryBuilder::new().after(c.clone());
+            assert_eq!(builder.after, Some(c));
+        }
+
+        #[cfg(feature = "advanced-queries")]
+        #[tokio::test]
+        async fn test_execute_paged_rejects_offset_and_after() {
+            use tempfile::NamedTempFile;
+            let f = NamedTempFile::new().unwrap();
+            crate::test_utils::create_test_database(f.path())
+                .await
+                .unwrap();
+            let db = crate::database::ThingsDatabase::new(f.path())
+                .await
+                .unwrap();
+
+            let result = TaskQueryBuilder::new()
+                .offset(5)
+                .after(sample_cursor())
+                .execute_paged(&db)
+                .await;
+            match result {
+                Err(crate::error::ThingsError::InvalidCursor(msg)) => {
+                    assert!(msg.contains("offset and after"), "msg: {msg}");
+                }
+                other => panic!("expected InvalidCursor, got {other:?}"),
+            }
+        }
+
+        #[cfg(feature = "advanced-queries")]
+        #[tokio::test]
+        async fn test_execute_paged_rejects_fuzzy_and_after() {
+            use tempfile::NamedTempFile;
+            let f = NamedTempFile::new().unwrap();
+            crate::test_utils::create_test_database(f.path())
+                .await
+                .unwrap();
+            let db = crate::database::ThingsDatabase::new(f.path())
+                .await
+                .unwrap();
+
+            let result = TaskQueryBuilder::new()
+                .fuzzy_search("anything")
+                .after(sample_cursor())
+                .execute_paged(&db)
+                .await;
+            match result {
+                Err(crate::error::ThingsError::InvalidCursor(msg)) => {
+                    assert!(msg.contains("fuzzy"), "msg: {msg}");
+                }
+                other => panic!("expected InvalidCursor, got {other:?}"),
+            }
+        }
     }
 
     #[cfg(feature = "advanced-queries")]


### PR DESCRIPTION
## Summary

- Introduces the `batch-operations` feature flag (first of the 1.2.0 milestone sub-issues)
- Adds opaque `Cursor` / `Page<T>` types in a new `cursor` module (URL-safe base64-encoded JSON payload anchored on `(created, uuid)`)
- Adds `TaskQueryBuilder::after(cursor)` and `execute_paged()` (gated on both `advanced-queries` and `batch-operations`)
- Fixes `ORDER BY` determinism: tightened from `creationDate DESC` to `CAST(creationDate AS INTEGER) DESC, uuid DESC` — unconditional correctness fix, not gated
- Adds `ThingsError::InvalidCursor` variant; wired into CLI MCP error conversion

## Design decisions

- **`(created, uuid)` anchor** — `created` is immutable so cursors remain valid under concurrent edits; `uuid` is the deterministic tiebreaker
- **`execute_paged` gated on both flags** — calls `query_tasks_inner` which requires `advanced-queries`; the cursor infrastructure alone compiles under `batch-operations` only
- **Dual-path pagination** — SQL `LIMIT` when no post-filters; full-fetch + Rust truncation when post-filters active (mirrors existing `execute()` pattern)
- **Cursor + fuzzy = error** — score-ordered results don't compose with a `(created, uuid)` cursor; explicit `InvalidCursor` returned

## Test plan

- [ ] `cargo test -p things3-core --features batch-operations --lib` — 17 new cursor + builder tests pass
- [ ] `cargo test -p things3-core --features 'batch-operations advanced-queries' --lib` — all tests including integration cursor pagination tests pass
- [ ] `cargo test -p things3-core --lib` — no leakage without feature flag
- [ ] `cargo clippy -p things3-core --lib --features full -- -D warnings` — clean
- [ ] `cargo test --features full` — full workspace test suite passes

Closes #90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)