### PR TITLE
chore(release): v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.2.0] - 2026-04-27
 
 ### Added
 - **Predictive cache preloading** — new `CachePreloader` trait registered on `ThingsCache` via `set_preloader`/`clear_preloader`. After every `get_*` access the cache calls `predict(key)` to enqueue follow-up keys for warming; the warming-loop tick then calls `warm(key)` for each top-priority queued entry (replacing the previous no-op stub at `start_cache_warming`). Ships a `DefaultPreloader { Weak<ThingsCache>, Arc<ThingsDatabase> }` with three hardcoded heuristics over existing keys: `inbox:all → today:all`, `today:all → inbox:all`, `areas:all → projects:all`. `CacheStats` gains `warmed_keys` and `warming_runs` counters so tests and operators can confirm the loop is doing work. Default behavior unchanged for callers that don't register a preloader.
@@ -17,8 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Cursor-based pagination on `TaskQueryBuilder`** — new `cursor` module exposing opaque `Cursor` and `Page<T>` types, plus `TaskQueryBuilder::after(cursor)` and `execute_paged()` (gated on both `advanced-queries` and `batch-operations`). Cursor anchors on `(created, uuid)`: `created` is immutable so cursors stay valid under concurrent edits, and `uuid` provides a deterministic tiebreak. Cursor encoding is URL-safe base64 of a compact JSON payload. Default page size is 100 (overridable via `.limit()`). `execute_paged` returns `ThingsError::InvalidCursor` if `.offset()` and `.after()` are both set, or if `.fuzzy_search()` and `.after()` are both set.
 - **Streaming results API on `TaskQueryBuilder`** — new `TaskQueryBuilder::execute_stream(db)` returns `Pin<Box<dyn Stream<Item = Result<Task>> + Send>>` (gated on both `advanced-queries` and `batch-operations`). Internally chunked via `execute_paged`: yields tasks in `(creationDate DESC, uuid DESC)` order, transparently fetching pages until exhausted. `.limit(n)` controls chunk size in the streaming context (default 100), not a cap on total emitted items. Validation errors (e.g. `.fuzzy_search()` + `.after()`) surface as the stream's first `Err` item. Pulls in `async-stream` and `futures-core` as optional deps under `batch-operations`.
 - **Batch fetch-by-id primitives on `ThingsDatabase`** — new `batch` module with `ThingsDatabase::get_tasks_batch(uuids)` and `ThingsDatabase::get_projects_batch(uuids)` (gated behind `batch-operations`). Mirrors filtering semantics of `get_task_by_uuid` / `get_project_by_uuid` (trashed rows omitted). Empty input returns `Ok(vec![])` with no SQL roundtrip; duplicate input UUIDs are de-duplicated; results are ordered by `(creationDate DESC, uuid DESC)`. Internally chunks at 500 UUIDs per query so callers can pass arbitrarily long lists without hitting SQLite's `SQLITE_LIMIT_VARIABLE_NUMBER`.
-
-### Changed
 - **`ThingsDatabase::query_tasks` ordering is now deterministic** — `ORDER BY` was tightened from `creationDate DESC` to `CAST(creationDate AS INTEGER) DESC, uuid DESC`. Previously, the order of tasks tied on truncated-second `creationDate` was unspecified; now it is well-defined. No effect on callers that already had distinct timestamps.
 
 ## [1.1.0] - 2026-04-26

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3131,7 +3131,7 @@ dependencies = [
 
 [[package]]
 name = "things3-cli"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3182,7 +3182,7 @@ dependencies = [
 
 [[package]]
 name = "things3-common"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3194,7 +3194,7 @@ dependencies = [
 
 [[package]]
 name = "things3-core"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4269,7 +4269,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xtask"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 rust-version = "1.70"
 authors = ["GarthDB <garthdb@gmail.com>"]


### PR DESCRIPTION
Cuts the 1.2.0 release. Bumps workspace version `1.1.0 → 1.2.0` and converts the `[Unreleased]` CHANGELOG section into `[1.2.0] - 2026-04-27`. Closes parent epic #73.

## What ships in 1.2.0

### Added
- **Predictive cache preloading** (#94 → #103) — `CachePreloader` trait + `DefaultPreloader` + working warming loop replacing the previous no-op stub.
- **Dependency-based cache invalidation** (#93 → #102) — `invalidate_by_entity` / `invalidate_by_operation` now consult per-entry `CacheDependency` lists; `ThingsCacheInvalidationHandler` bridges middleware events into the cache.

### Changed (gated behind new `batch-operations` feature flag)
- **⚠️ Breaking**: `ThingsCache::invalidate_by_entity` / `invalidate_by_operation` are now `async fn` and return the eviction count.
- **Cursor-based pagination** (#90 → #99) — `Cursor`, `Page<T>`, `TaskQueryBuilder::after()` / `execute_paged()`.
- **Streaming results API** (#91 → #100) — `TaskQueryBuilder::execute_stream()`.
- **Batch fetch-by-id** (#92 → #101) — `ThingsDatabase::get_tasks_batch` / `get_projects_batch` with 500-uuid chunking.
- **Deterministic `query_tasks` ordering** — `ORDER BY CAST(creationDate AS INTEGER) DESC, uuid DESC`.

## Post-merge

After this merges to `main`:
1. `git tag v1.2.0 <merge-commit>`
2. `git push origin v1.2.0` — triggers `.github/workflows/release.yml` (cross-platform binary build + GitHub release).

## Test plan

- [x] `cargo build --workspace` clean at 1.2.0
- [x] Pre-commit `cargo clippy -- -D warnings` clean
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)