### PR TITLE
chore(release): v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-04-27
+
+### Added
+- **TaskPaper export format** (#105 → #107) — new `export-taskpaper` feature flag adds an `ExportFormat::TaskPaper` variant on `DataExporter::export()`, plus `"taskpaper"` / `"tp"` in the `FromStr` parser. TaskPaper is a plain-text outline format consumed by Hog Bay Software's TaskPaper / Taskmator and other macOS scratch-list apps. Areas render as top-level project headers, projects nest under their area at one tab, tasks at two; status maps to `@done(stop_date)` / `@cancelled` / `@trashed`; deadlines and start dates to `@due(date)` / `@start(date)`; tags become sanitized `@tag` tokens (whitespace runs collapse to `-`, `@`, `(`, `)`, and control chars are stripped). Subtasks recurse via `task.children` or `parent_uuid`. No new external dependencies.
+- **iCalendar (.ics) export format** (#106 → #108) — new `export-ical` feature flag adds an `ExportFormat::ICalendar` variant plus `"ical"` / `"ics"` / `"icalendar"` in the `FromStr` parser. All Things tasks and projects map to RFC 5545 `VTODO` components (no `VEVENT` — Things items are to-dos, not time-bounded events). Areas surface as `CATEGORIES` entries on each task/project rather than standalone components. Tasks emit `RELATED-TO:<project-uid>` for project linkage, plus an additional `RELATED-TO:<parent-uid>` for subtask hierarchy. UIDs are the Things UUID strings, so re-exports update existing entries rather than duplicate. Status maps `Incomplete → STATUS:NEEDS-ACTION`, `Completed → STATUS:COMPLETED` (+ `COMPLETED:<stop_date>` when present), `Canceled` / `Trashed → STATUS:CANCELLED`. `NaiveDate` fields use the `DATE` value type; `DateTime<Utc>` fields use `DATE-TIME` UTC. Pulls in `icalendar` 0.17 as a new optional dep.
+
 ## [1.2.0] - 2026-04-27
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,6 +1281,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "icalendar"
+version = "0.17.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "264fe856964b7a84076dec2d8ea29fce7c9b422968c9a2f404d4aa3771ae2179"
+dependencies = [
+ "chrono",
+ "iso8601",
+ "nom",
+ "nom-language",
+ "uuid",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1436,6 +1449,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "iso8601"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1082f0c48f143442a1ac6122f67e360ceee130b967af4d50996e5154a45df46"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "itertools"
@@ -1758,6 +1780,24 @@ name = "no-std-compat"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "nom-language"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2de2bc5b451bfedaef92c90b8939a8fff5770bdcc1fafd6239d086aab8fa6b29"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "nonzero_ext"
@@ -3206,6 +3246,7 @@ dependencies = [
  "dashmap",
  "futures-core",
  "futures-util",
+ "icalendar",
  "metrics 0.22.4",
  "moka",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3171,7 +3171,7 @@ dependencies = [
 
 [[package]]
 name = "things3-cli"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3222,7 +3222,7 @@ dependencies = [
 
 [[package]]
 name = "things3-common"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3234,7 +3234,7 @@ dependencies = [
 
 [[package]]
 name = "things3-core"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4310,7 +4310,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xtask"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 rust-version = "1.70"
 authors = ["GarthDB <garthdb@gmail.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ once_cell = "1.19"
 # Export formats
 csv = "1.3"
 quick-xml = { version = "0.36", features = ["serialize"] }
-icalendar = { version = "0.17", features = ["parser"] }
+icalendar = "0.17"
 
 # Performance monitoring
 sysinfo = "0.30"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ once_cell = "1.19"
 # Export formats
 csv = "1.3"
 quick-xml = { version = "0.36", features = ["serialize"] }
+icalendar = { version = "0.17", features = ["parser"] }
 
 # Performance monitoring
 sysinfo = "0.30"

--- a/libs/things3-core/Cargo.toml
+++ b/libs/things3-core/Cargo.toml
@@ -18,10 +18,11 @@ test-utils = []
 export-csv = ["dep:csv"]
 export-opml = ["dep:quick-xml"]
 export-taskpaper = []
+export-ical = ["dep:icalendar"]
 observability = ["dep:metrics"]
 advanced-queries = []
 batch-operations = ["dep:base64", "dep:async-stream", "dep:futures-core"]
-full = ["export-csv", "export-opml", "export-taskpaper", "observability", "advanced-queries", "batch-operations"]
+full = ["export-csv", "export-opml", "export-taskpaper", "export-ical", "observability", "advanced-queries", "batch-operations"]
 
 [dependencies]
 # Core
@@ -59,6 +60,7 @@ zstd = "0.13"
 # Export formats (optional)
 csv = { workspace = true, optional = true }
 quick-xml = { workspace = true, optional = true }
+icalendar = { workspace = true, optional = true }
 
 # Configuration
 serde_yaml = "0.9"
@@ -104,4 +106,4 @@ required-features = ["test-utils"]
 
 [[example]]
 name = "export_data"
-required-features = ["export-csv", "export-opml", "export-taskpaper"]
+required-features = ["export-csv", "export-opml", "export-taskpaper", "export-ical"]

--- a/libs/things3-core/examples/export_data.rs
+++ b/libs/things3-core/examples/export_data.rs
@@ -51,6 +51,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     std::fs::write("export.taskpaper", &taskpaper)?;
     println!("  ✓ Saved to export.taskpaper ({} bytes)", taskpaper.len());
 
+    // Export to iCalendar
+    println!("Exporting to iCalendar...");
+    let ical = exporter.export(&export_data, ExportFormat::ICalendar)?;
+    std::fs::write("export.ics", &ical)?;
+    println!("  ✓ Saved to export.ics ({} bytes)", ical.len());
+
     println!("\n✓ Export completed successfully");
     Ok(())
 }

--- a/libs/things3-core/src/export.rs
+++ b/libs/things3-core/src/export.rs
@@ -1,6 +1,8 @@
 //! Data export functionality for Things 3 data
 
-use crate::models::{Area, Project, Task, TaskStatus, TaskType};
+#[cfg(any(feature = "export-csv", feature = "export-taskpaper"))]
+use crate::models::TaskType;
+use crate::models::{Area, Project, Task, TaskStatus};
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -16,6 +18,7 @@ pub enum ExportFormat {
     Opml,
     Markdown,
     TaskPaper,
+    ICalendar,
 }
 
 impl std::str::FromStr for ExportFormat {
@@ -28,6 +31,7 @@ impl std::str::FromStr for ExportFormat {
             "opml" => Ok(Self::Opml),
             "markdown" | "md" => Ok(Self::Markdown),
             "taskpaper" | "tp" => Ok(Self::TaskPaper),
+            "ical" | "ics" | "icalendar" => Ok(Self::ICalendar),
             _ => Err(anyhow::anyhow!("Unsupported export format: {s}")),
         }
     }
@@ -122,6 +126,12 @@ impl DataExporter {
             #[cfg(not(feature = "export-taskpaper"))]
             ExportFormat::TaskPaper => Err(anyhow::anyhow!(
                 "TaskPaper export is not enabled. Enable the 'export-taskpaper' feature."
+            )),
+            #[cfg(feature = "export-ical")]
+            ExportFormat::ICalendar => Ok(export_icalendar(data)),
+            #[cfg(not(feature = "export-ical"))]
+            ExportFormat::ICalendar => Err(anyhow::anyhow!(
+                "iCalendar export is not enabled. Enable the 'export-ical' feature."
             )),
         }
     }
@@ -599,6 +609,113 @@ fn escape_xml(s: &str) -> String {
         .replace('>', "&gt;")
         .replace('"', "&quot;")
         .replace('\'', "&apos;")
+}
+
+/// Export as iCalendar (RFC 5545) — all items map to VTODO components.
+///
+/// Projects export as top-level VTODOs. Tasks reference their project via
+/// `RELATED-TO`. Areas are not emitted as components; they surface as entries
+/// in each task/project's `CATEGORIES` list.
+#[cfg(feature = "export-ical")]
+fn export_icalendar(data: &ExportData) -> String {
+    use icalendar::{Calendar, Component, DatePerhapsTime, EventLike, Todo};
+
+    let mut cal = Calendar::new();
+    cal.name("Things 3 Export");
+
+    for project in &data.projects {
+        let mut todo = Todo::new();
+        todo.uid(&project.uuid.to_string());
+        todo.summary(&project.title);
+
+        if let Some(notes) = &project.notes {
+            todo.description(notes);
+        }
+
+        todo.status(ical_todo_status(project.status));
+
+        if let Some(d) = project.deadline {
+            todo.due(DatePerhapsTime::Date(d));
+        }
+        if let Some(d) = project.start_date {
+            todo.starts(DatePerhapsTime::Date(d));
+        }
+
+        let mut cats: Vec<&str> = project.tags.iter().map(String::as_str).collect();
+        if let Some(area) = data
+            .areas
+            .iter()
+            .find(|a| Some(a.uuid) == project.area_uuid)
+        {
+            cats.push(&area.title);
+        }
+        if !cats.is_empty() {
+            todo.add_property("CATEGORIES", cats.join(","));
+        }
+
+        todo.add_property("CREATED", ical_datetime(project.created));
+        todo.add_property("LAST-MODIFIED", ical_datetime(project.modified));
+
+        cal.push(todo);
+    }
+
+    for task in &data.tasks {
+        let mut todo = Todo::new();
+        todo.uid(&task.uuid.to_string());
+        todo.summary(&task.title);
+
+        if let Some(notes) = &task.notes {
+            todo.description(notes);
+        }
+
+        todo.status(ical_todo_status(task.status));
+
+        if task.status == TaskStatus::Completed {
+            if let Some(stop) = task.stop_date {
+                todo.add_property("COMPLETED", ical_datetime(stop));
+            }
+        }
+
+        if let Some(d) = task.deadline {
+            todo.due(DatePerhapsTime::Date(d));
+        }
+        if let Some(d) = task.start_date {
+            todo.starts(DatePerhapsTime::Date(d));
+        }
+
+        let mut cats: Vec<&str> = task.tags.iter().map(String::as_str).collect();
+        if let Some(area) = data.areas.iter().find(|a| Some(a.uuid) == task.area_uuid) {
+            cats.push(&area.title);
+        }
+        if !cats.is_empty() {
+            todo.add_property("CATEGORIES", cats.join(","));
+        }
+
+        if let Some(proj_uuid) = task.project_uuid {
+            todo.add_property("RELATED-TO", proj_uuid.to_string());
+        }
+
+        todo.add_property("CREATED", ical_datetime(task.created));
+        todo.add_property("LAST-MODIFIED", ical_datetime(task.modified));
+
+        cal.push(todo);
+    }
+
+    cal.to_string()
+}
+
+#[cfg(feature = "export-ical")]
+fn ical_todo_status(status: TaskStatus) -> icalendar::TodoStatus {
+    match status {
+        TaskStatus::Incomplete => icalendar::TodoStatus::NeedsAction,
+        TaskStatus::Completed => icalendar::TodoStatus::Completed,
+        TaskStatus::Canceled | TaskStatus::Trashed => icalendar::TodoStatus::Cancelled,
+    }
+}
+
+#[cfg(feature = "export-ical")]
+fn ical_datetime(dt: DateTime<Utc>) -> String {
+    dt.format("%Y%m%dT%H%M%SZ").to_string()
 }
 
 #[cfg(test)]
@@ -1237,5 +1354,361 @@ mod tests {
             "Ends with colon: "
         );
         assert_eq!(escape_taskpaper_title("Not a colon"), "Not a colon");
+    }
+
+    // Not gated behind #[cfg(feature = "export-ical")] intentionally:
+    // ExportFormat::ICalendar is an unconditional enum variant and FromStr
+    // always matches "ical"/"ics"/"icalendar" — the feature flag only controls
+    // whether the actual serialization work is compiled in.
+    #[test]
+    fn test_export_format_from_str_icalendar() {
+        assert_eq!(
+            "ical".parse::<ExportFormat>().unwrap(),
+            ExportFormat::ICalendar
+        );
+        assert_eq!(
+            "ICAL".parse::<ExportFormat>().unwrap(),
+            ExportFormat::ICalendar
+        );
+        assert_eq!(
+            "ics".parse::<ExportFormat>().unwrap(),
+            ExportFormat::ICalendar
+        );
+        assert_eq!(
+            "ICS".parse::<ExportFormat>().unwrap(),
+            ExportFormat::ICalendar
+        );
+        assert_eq!(
+            "icalendar".parse::<ExportFormat>().unwrap(),
+            ExportFormat::ICalendar
+        );
+        assert_eq!(
+            "iCalendar".parse::<ExportFormat>().unwrap(),
+            ExportFormat::ICalendar
+        );
+    }
+
+    #[test]
+    #[cfg(not(feature = "export-ical"))]
+    fn test_export_icalendar_disabled() {
+        let exporter = DataExporter::new_default();
+        let data = ExportData::new(vec![], vec![], vec![]);
+        let result = exporter.export(&data, ExportFormat::ICalendar);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("export-ical"),
+            "Error should name the missing feature, got: {msg}"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "export-ical")]
+    fn test_export_icalendar_empty() {
+        let exporter = DataExporter::new_default();
+        let data = ExportData::new(vec![], vec![], vec![]);
+        let result = exporter.export(&data, ExportFormat::ICalendar);
+        assert!(result.is_ok());
+        let ics = result.unwrap();
+        assert!(ics.contains("BEGIN:VCALENDAR"), "Missing VCALENDAR:\n{ics}");
+        assert!(
+            ics.contains("END:VCALENDAR"),
+            "Missing END:VCALENDAR:\n{ics}"
+        );
+        assert!(
+            !ics.contains("BEGIN:VTODO"),
+            "Empty export should have no VTODOs:\n{ics}"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "export-ical")]
+    fn test_export_icalendar_with_data() {
+        let exporter = DataExporter::new_default();
+        let tasks = create_mock_tasks();
+        let projects = create_mock_projects();
+        let areas = create_mock_areas();
+        let data = ExportData::new(tasks, projects, areas);
+
+        let ics = exporter.export(&data, ExportFormat::ICalendar).unwrap();
+
+        assert!(ics.contains("BEGIN:VCALENDAR"), "Missing VCALENDAR:\n{ics}");
+        // Projects and tasks both become VTODOs
+        assert!(ics.contains("BEGIN:VTODO"), "Missing VTODO:\n{ics}");
+        assert!(
+            ics.contains("SUMMARY:Website Redesign"),
+            "Missing project summary:\n{ics}"
+        );
+        assert!(
+            ics.contains("SUMMARY:Research competitors"),
+            "Missing task summary:\n{ics}"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "export-ical")]
+    fn test_export_icalendar_uid_stable() {
+        use crate::models::TaskType;
+        let task_uuid = uuid::Uuid::parse_str("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee").unwrap();
+        let task = Task {
+            uuid: task_uuid,
+            title: "UID test".to_string(),
+            task_type: TaskType::Todo,
+            status: TaskStatus::Incomplete,
+            notes: None,
+            start_date: None,
+            deadline: None,
+            created: Utc::now(),
+            modified: Utc::now(),
+            stop_date: None,
+            project_uuid: None,
+            area_uuid: None,
+            parent_uuid: None,
+            tags: vec![],
+            children: vec![],
+        };
+        let data = ExportData::new(vec![task], vec![], vec![]);
+        let ics = DataExporter::new_default()
+            .export(&data, ExportFormat::ICalendar)
+            .unwrap();
+
+        assert!(
+            ics.contains("UID:aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
+            "UID should equal task UUID:\n{ics}"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "export-ical")]
+    fn test_export_icalendar_status_mapping() {
+        use crate::models::TaskType;
+        use chrono::TimeZone;
+
+        let make_task = |n: u8, status: TaskStatus, stop: Option<DateTime<Utc>>| Task {
+            uuid: uuid::Uuid::parse_str(&format!("00000000-0000-0000-0000-{n:012}")).unwrap(),
+            title: format!("Task {n}"),
+            task_type: TaskType::Todo,
+            status,
+            notes: None,
+            start_date: None,
+            deadline: None,
+            created: Utc::now(),
+            modified: Utc::now(),
+            stop_date: stop,
+            project_uuid: None,
+            area_uuid: None,
+            parent_uuid: None,
+            tags: vec![],
+            children: vec![],
+        };
+
+        let stop = Utc.with_ymd_and_hms(2026, 1, 15, 10, 30, 0).unwrap();
+        let tasks = vec![
+            make_task(1, TaskStatus::Incomplete, None),
+            make_task(2, TaskStatus::Completed, Some(stop)),
+            make_task(3, TaskStatus::Completed, None),
+            make_task(4, TaskStatus::Canceled, None),
+            make_task(5, TaskStatus::Trashed, None),
+        ];
+        let data = ExportData::new(tasks, vec![], vec![]);
+        let ics = DataExporter::new_default()
+            .export(&data, ExportFormat::ICalendar)
+            .unwrap();
+
+        assert!(
+            ics.contains("STATUS:NEEDS-ACTION"),
+            "Incomplete → NEEDS-ACTION:\n{ics}"
+        );
+        assert!(
+            ics.contains("STATUS:COMPLETED"),
+            "Completed → COMPLETED:\n{ics}"
+        );
+        // Completed task with stop_date should have COMPLETED: property
+        assert!(
+            ics.contains("COMPLETED:20260115T103000Z"),
+            "Expected COMPLETED timestamp:\n{ics}"
+        );
+        assert!(
+            ics.contains("STATUS:CANCELLED"),
+            "Canceled/Trashed → CANCELLED:\n{ics}"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "export-ical")]
+    fn test_export_icalendar_due_date() {
+        use crate::models::TaskType;
+        use chrono::NaiveDate;
+
+        let task = Task {
+            uuid: uuid::Uuid::parse_str("11111111-0000-0000-0000-000000000001").unwrap(),
+            title: "Task with deadline".to_string(),
+            task_type: TaskType::Todo,
+            status: TaskStatus::Incomplete,
+            notes: None,
+            start_date: Some(NaiveDate::from_ymd_opt(2026, 3, 1).unwrap()),
+            deadline: Some(NaiveDate::from_ymd_opt(2026, 4, 30).unwrap()),
+            created: Utc::now(),
+            modified: Utc::now(),
+            stop_date: None,
+            project_uuid: None,
+            area_uuid: None,
+            parent_uuid: None,
+            tags: vec![],
+            children: vec![],
+        };
+        let data = ExportData::new(vec![task], vec![], vec![]);
+        let ics = DataExporter::new_default()
+            .export(&data, ExportFormat::ICalendar)
+            .unwrap();
+
+        assert!(ics.contains("20260430"), "DUE date in output:\n{ics}");
+        assert!(ics.contains("20260301"), "DTSTART date in output:\n{ics}");
+    }
+
+    #[test]
+    #[cfg(feature = "export-ical")]
+    fn test_export_icalendar_categories() {
+        use crate::models::{Area, TaskType};
+
+        let area_uuid = uuid::Uuid::parse_str("aaaaaaaa-0000-0000-0000-000000000000").unwrap();
+        let area = Area {
+            uuid: area_uuid,
+            title: "Work".to_string(),
+            notes: None,
+            created: Utc::now(),
+            modified: Utc::now(),
+            tags: vec![],
+            projects: vec![],
+        };
+        let task = Task {
+            uuid: uuid::Uuid::parse_str("bbbbbbbb-0000-0000-0000-000000000001").unwrap(),
+            title: "Tagged task".to_string(),
+            task_type: TaskType::Todo,
+            status: TaskStatus::Incomplete,
+            notes: None,
+            start_date: None,
+            deadline: None,
+            created: Utc::now(),
+            modified: Utc::now(),
+            stop_date: None,
+            project_uuid: None,
+            area_uuid: Some(area_uuid),
+            parent_uuid: None,
+            tags: vec!["focus".to_string(), "deep-work".to_string()],
+            children: vec![],
+        };
+        let data = ExportData::new(vec![task], vec![], vec![area]);
+        let ics = DataExporter::new_default()
+            .export(&data, ExportFormat::ICalendar)
+            .unwrap();
+
+        assert!(
+            ics.contains("CATEGORIES:"),
+            "Expected CATEGORIES property:\n{ics}"
+        );
+        assert!(
+            ics.contains("focus"),
+            "Expected 'focus' in categories:\n{ics}"
+        );
+        assert!(
+            ics.contains("deep-work"),
+            "Expected 'deep-work' in categories:\n{ics}"
+        );
+        assert!(
+            ics.contains("Work"),
+            "Expected area name in categories:\n{ics}"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "export-ical")]
+    fn test_export_icalendar_related_to() {
+        use crate::models::TaskType;
+        let proj_uuid = uuid::Uuid::parse_str("12345678-0000-0000-0000-000000000000").unwrap();
+        let project = crate::models::Project {
+            uuid: proj_uuid,
+            title: "My Project".to_string(),
+            notes: None,
+            start_date: None,
+            deadline: None,
+            created: Utc::now(),
+            modified: Utc::now(),
+            area_uuid: None,
+            tags: vec![],
+            status: TaskStatus::Incomplete,
+            tasks: vec![],
+        };
+        let task = Task {
+            uuid: uuid::Uuid::parse_str("87654321-0000-0000-0000-000000000001").unwrap(),
+            title: "Child task".to_string(),
+            task_type: TaskType::Todo,
+            status: TaskStatus::Incomplete,
+            notes: None,
+            start_date: None,
+            deadline: None,
+            created: Utc::now(),
+            modified: Utc::now(),
+            stop_date: None,
+            project_uuid: Some(proj_uuid),
+            area_uuid: None,
+            parent_uuid: None,
+            tags: vec![],
+            children: vec![],
+        };
+        let data = ExportData::new(vec![task], vec![project], vec![]);
+        let ics = DataExporter::new_default()
+            .export(&data, ExportFormat::ICalendar)
+            .unwrap();
+
+        assert!(
+            ics.contains("RELATED-TO:12345678-0000-0000-0000-000000000000"),
+            "Expected RELATED-TO with project UUID:\n{ics}"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "export-ical")]
+    fn test_export_icalendar_notes_multiline() {
+        use crate::models::TaskType;
+        let task = Task {
+            uuid: uuid::Uuid::parse_str("cccccccc-0000-0000-0000-000000000001").unwrap(),
+            title: "Task with notes".to_string(),
+            task_type: TaskType::Todo,
+            status: TaskStatus::Incomplete,
+            notes: Some("First line\nSecond line\nThird line".to_string()),
+            start_date: None,
+            deadline: None,
+            created: Utc::now(),
+            modified: Utc::now(),
+            stop_date: None,
+            project_uuid: None,
+            area_uuid: None,
+            parent_uuid: None,
+            tags: vec![],
+            children: vec![],
+        };
+        let data = ExportData::new(vec![task], vec![], vec![]);
+        let ics = DataExporter::new_default()
+            .export(&data, ExportFormat::ICalendar)
+            .unwrap();
+
+        // RFC 5545 escapes newlines in DESCRIPTION as \n (literal backslash-n)
+        assert!(
+            ics.contains("DESCRIPTION:"),
+            "Expected DESCRIPTION property:\n{ics}"
+        );
+        assert!(
+            ics.contains("First line"),
+            "Expected first line in description:\n{ics}"
+        );
+        assert!(
+            ics.contains("Second line"),
+            "Expected second line in description:\n{ics}"
+        );
+        assert!(
+            ics.contains("Third line"),
+            "Expected third line in description:\n{ics}"
+        );
     }
 }

--- a/libs/things3-core/src/export.rs
+++ b/libs/things3-core/src/export.rs
@@ -128,7 +128,7 @@ impl DataExporter {
                 "TaskPaper export is not enabled. Enable the 'export-taskpaper' feature."
             )),
             #[cfg(feature = "export-ical")]
-            ExportFormat::ICalendar => Ok(export_icalendar(data)),
+            ExportFormat::ICalendar => Ok(Self::export_icalendar(data)),
             #[cfg(not(feature = "export-ical"))]
             ExportFormat::ICalendar => Err(anyhow::anyhow!(
                 "iCalendar export is not enabled. Enable the 'export-ical' feature."
@@ -407,6 +407,107 @@ impl DataExporter {
 
         md
     }
+
+    /// Export as iCalendar (RFC 5545) — all items map to VTODO components.
+    ///
+    /// Projects export as top-level VTODOs. Tasks with a project emit
+    /// `RELATED-TO:<project-uid>`; tasks with a parent task also emit
+    /// `RELATED-TO:<parent-uid>` (RELTYPE defaults to PARENT per RFC 5545).
+    /// Areas surface as `CATEGORIES` entries rather than standalone components.
+    #[cfg(feature = "export-ical")]
+    fn export_icalendar(data: &ExportData) -> String {
+        use icalendar::{Calendar, Component, DatePerhapsTime, EventLike, Todo};
+
+        let mut cal = Calendar::new();
+        cal.name("Things 3 Export");
+
+        for project in &data.projects {
+            let mut todo = Todo::new();
+            todo.uid(&project.uuid.to_string());
+            todo.summary(&project.title);
+
+            if let Some(notes) = &project.notes {
+                todo.description(notes);
+            }
+
+            todo.status(ical_todo_status(project.status));
+
+            if let Some(d) = project.deadline {
+                todo.due(DatePerhapsTime::Date(d));
+            }
+            if let Some(d) = project.start_date {
+                todo.starts(DatePerhapsTime::Date(d));
+            }
+
+            let area_cat = data
+                .areas
+                .iter()
+                .find(|a| Some(a.uuid) == project.area_uuid);
+            for cat in project
+                .tags
+                .iter()
+                .map(String::as_str)
+                .chain(area_cat.map(|a| a.title.as_str()))
+            {
+                todo.add_multi_property("CATEGORIES", cat);
+            }
+
+            todo.created(project.created);
+            todo.last_modified(project.modified);
+
+            cal.push(todo);
+        }
+
+        for task in &data.tasks {
+            let mut todo = Todo::new();
+            todo.uid(&task.uuid.to_string());
+            todo.summary(&task.title);
+
+            if let Some(notes) = &task.notes {
+                todo.description(notes);
+            }
+
+            todo.status(ical_todo_status(task.status));
+
+            if task.status == TaskStatus::Completed {
+                if let Some(stop) = task.stop_date {
+                    todo.completed(stop);
+                }
+            }
+
+            if let Some(d) = task.deadline {
+                todo.due(DatePerhapsTime::Date(d));
+            }
+            if let Some(d) = task.start_date {
+                todo.starts(DatePerhapsTime::Date(d));
+            }
+
+            let area_cat = data.areas.iter().find(|a| Some(a.uuid) == task.area_uuid);
+            for cat in task
+                .tags
+                .iter()
+                .map(String::as_str)
+                .chain(area_cat.map(|a| a.title.as_str()))
+            {
+                todo.add_multi_property("CATEGORIES", cat);
+            }
+
+            // RELATED-TO links project and parent task (RELTYPE defaults to PARENT per RFC 5545)
+            if let Some(proj_uuid) = task.project_uuid {
+                todo.add_multi_property("RELATED-TO", &proj_uuid.to_string());
+            }
+            if let Some(parent_uuid) = task.parent_uuid {
+                todo.add_multi_property("RELATED-TO", &parent_uuid.to_string());
+            }
+
+            todo.created(task.created);
+            todo.last_modified(task.modified);
+
+            cal.push(todo);
+        }
+
+        cal.to_string()
+    }
 }
 
 /// Helper functions for CSV export
@@ -611,99 +712,6 @@ fn escape_xml(s: &str) -> String {
         .replace('\'', "&apos;")
 }
 
-/// Export as iCalendar (RFC 5545) — all items map to VTODO components.
-///
-/// Projects export as top-level VTODOs. Tasks reference their project via
-/// `RELATED-TO`. Areas are not emitted as components; they surface as entries
-/// in each task/project's `CATEGORIES` list.
-#[cfg(feature = "export-ical")]
-fn export_icalendar(data: &ExportData) -> String {
-    use icalendar::{Calendar, Component, DatePerhapsTime, EventLike, Todo};
-
-    let mut cal = Calendar::new();
-    cal.name("Things 3 Export");
-
-    for project in &data.projects {
-        let mut todo = Todo::new();
-        todo.uid(&project.uuid.to_string());
-        todo.summary(&project.title);
-
-        if let Some(notes) = &project.notes {
-            todo.description(notes);
-        }
-
-        todo.status(ical_todo_status(project.status));
-
-        if let Some(d) = project.deadline {
-            todo.due(DatePerhapsTime::Date(d));
-        }
-        if let Some(d) = project.start_date {
-            todo.starts(DatePerhapsTime::Date(d));
-        }
-
-        let mut cats: Vec<&str> = project.tags.iter().map(String::as_str).collect();
-        if let Some(area) = data
-            .areas
-            .iter()
-            .find(|a| Some(a.uuid) == project.area_uuid)
-        {
-            cats.push(&area.title);
-        }
-        if !cats.is_empty() {
-            todo.add_property("CATEGORIES", cats.join(","));
-        }
-
-        todo.add_property("CREATED", ical_datetime(project.created));
-        todo.add_property("LAST-MODIFIED", ical_datetime(project.modified));
-
-        cal.push(todo);
-    }
-
-    for task in &data.tasks {
-        let mut todo = Todo::new();
-        todo.uid(&task.uuid.to_string());
-        todo.summary(&task.title);
-
-        if let Some(notes) = &task.notes {
-            todo.description(notes);
-        }
-
-        todo.status(ical_todo_status(task.status));
-
-        if task.status == TaskStatus::Completed {
-            if let Some(stop) = task.stop_date {
-                todo.add_property("COMPLETED", ical_datetime(stop));
-            }
-        }
-
-        if let Some(d) = task.deadline {
-            todo.due(DatePerhapsTime::Date(d));
-        }
-        if let Some(d) = task.start_date {
-            todo.starts(DatePerhapsTime::Date(d));
-        }
-
-        let mut cats: Vec<&str> = task.tags.iter().map(String::as_str).collect();
-        if let Some(area) = data.areas.iter().find(|a| Some(a.uuid) == task.area_uuid) {
-            cats.push(&area.title);
-        }
-        if !cats.is_empty() {
-            todo.add_property("CATEGORIES", cats.join(","));
-        }
-
-        if let Some(proj_uuid) = task.project_uuid {
-            todo.add_property("RELATED-TO", proj_uuid.to_string());
-        }
-
-        todo.add_property("CREATED", ical_datetime(task.created));
-        todo.add_property("LAST-MODIFIED", ical_datetime(task.modified));
-
-        cal.push(todo);
-    }
-
-    cal.to_string()
-}
-
 #[cfg(feature = "export-ical")]
 fn ical_todo_status(status: TaskStatus) -> icalendar::TodoStatus {
     match status {
@@ -711,11 +719,6 @@ fn ical_todo_status(status: TaskStatus) -> icalendar::TodoStatus {
         TaskStatus::Completed => icalendar::TodoStatus::Completed,
         TaskStatus::Canceled | TaskStatus::Trashed => icalendar::TodoStatus::Cancelled,
     }
-}
-
-#[cfg(feature = "export-ical")]
-fn ical_datetime(dt: DateTime<Utc>) -> String {
-    dt.format("%Y%m%dT%H%M%SZ").to_string()
 }
 
 #[cfg(test)]
@@ -1562,8 +1565,14 @@ mod tests {
             .export(&data, ExportFormat::ICalendar)
             .unwrap();
 
-        assert!(ics.contains("20260430"), "DUE date in output:\n{ics}");
-        assert!(ics.contains("20260301"), "DTSTART date in output:\n{ics}");
+        assert!(
+            ics.contains("DUE;VALUE=DATE:20260430"),
+            "Expected DUE;VALUE=DATE:20260430:\n{ics}"
+        );
+        assert!(
+            ics.contains("DTSTART;VALUE=DATE:20260301"),
+            "Expected DTSTART;VALUE=DATE:20260301:\n{ics}"
+        );
     }
 
     #[test]
@@ -1664,6 +1673,83 @@ mod tests {
         assert!(
             ics.contains("RELATED-TO:12345678-0000-0000-0000-000000000000"),
             "Expected RELATED-TO with project UUID:\n{ics}"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "export-ical")]
+    fn test_export_icalendar_subtask_related_to() {
+        use crate::models::TaskType;
+
+        let parent_uuid = uuid::Uuid::parse_str("aaaaaaaa-0000-0000-0000-000000000001").unwrap();
+        let child_uuid = uuid::Uuid::parse_str("bbbbbbbb-0000-0000-0000-000000000002").unwrap();
+
+        let make_task = |uuid: uuid::Uuid, parent: Option<uuid::Uuid>| Task {
+            uuid,
+            title: "Task".to_string(),
+            task_type: TaskType::Todo,
+            status: TaskStatus::Incomplete,
+            notes: None,
+            start_date: None,
+            deadline: None,
+            created: Utc::now(),
+            modified: Utc::now(),
+            stop_date: None,
+            project_uuid: None,
+            area_uuid: None,
+            parent_uuid: parent,
+            tags: vec![],
+            children: vec![],
+        };
+        let tasks = vec![
+            make_task(parent_uuid, None),
+            make_task(child_uuid, Some(parent_uuid)),
+        ];
+        let data = ExportData::new(tasks, vec![], vec![]);
+        let ics = DataExporter::new_default()
+            .export(&data, ExportFormat::ICalendar)
+            .unwrap();
+
+        assert!(
+            ics.contains("RELATED-TO:aaaaaaaa-0000-0000-0000-000000000001"),
+            "Subtask should RELATED-TO its parent task:\n{ics}"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "export-ical")]
+    fn test_export_icalendar_categories_comma_escaped() {
+        use crate::models::TaskType;
+
+        let task = Task {
+            uuid: uuid::Uuid::parse_str("dddddddd-0000-0000-0000-000000000001").unwrap(),
+            title: "Task".to_string(),
+            task_type: TaskType::Todo,
+            status: TaskStatus::Incomplete,
+            notes: None,
+            start_date: None,
+            deadline: None,
+            created: Utc::now(),
+            modified: Utc::now(),
+            stop_date: None,
+            project_uuid: None,
+            area_uuid: None,
+            parent_uuid: None,
+            tags: vec!["design, UX".to_string(), "client\\work".to_string()],
+            children: vec![],
+        };
+        let data = ExportData::new(vec![task], vec![], vec![]);
+        let ics = DataExporter::new_default()
+            .export(&data, ExportFormat::ICalendar)
+            .unwrap();
+
+        assert!(
+            ics.contains("design\\, UX"),
+            "Comma in tag should be escaped as \\,:\n{ics}"
+        );
+        assert!(
+            ics.contains("client\\\\work"),
+            "Backslash in tag should be escaped as \\\\:\n{ics}"
         );
     }
 

--- a/libs/things3-core/src/lib.rs
+++ b/libs/things3-core/src/lib.rs
@@ -45,6 +45,7 @@
 //! - `export-csv`: Enable CSV export support
 //! - `export-opml`: Enable OPML export support
 //! - `export-taskpaper`: Enable TaskPaper export support
+//! - `export-ical`: Enable iCalendar (.ics) export support
 //! - `observability`: Enable metrics, tracing, and health checks
 //! - `full`: Enable all optional features
 //! - `test-utils`: Enable test utilities (for testing only)
@@ -71,7 +72,8 @@ pub mod cursor;
 #[cfg(any(
     feature = "export-csv",
     feature = "export-opml",
-    feature = "export-taskpaper"
+    feature = "export-taskpaper",
+    feature = "export-ical"
 ))]
 pub mod export;
 
@@ -116,7 +118,8 @@ pub use error::{Result, ThingsError};
 #[cfg(any(
     feature = "export-csv",
     feature = "export-opml",
-    feature = "export-taskpaper"
+    feature = "export-taskpaper",
+    feature = "export-ical"
 ))]
 pub use export::{DataExporter, ExportConfig, ExportData, ExportFormat};
 


### PR DESCRIPTION
Cuts the 1.3.0 release. Bumps workspace version `1.2.0 → 1.3.0` and adds a `[1.3.0] - 2026-04-27` entry to `CHANGELOG.md` covering the two export-formats children of [#74](https://github.com/GarthDB/rust-things3/issues/74). Closes parent epic #74.

## What ships in 1.3.0

### Added
- **TaskPaper export format** (#105 → #107) — new `export-taskpaper` feature flag adding an `ExportFormat::TaskPaper` variant plus `"taskpaper"` / `"tp"` in the `FromStr` parser. Areas → top-level project headers, projects nested at one tab, tasks at two; status / deadlines / start dates / tags map to `@done` / `@due` / `@start` / sanitized `@tag` tokens. No new external deps.
- **iCalendar (.ics) export format** (#106 → #108) — new `export-ical` feature flag adding an `ExportFormat::ICalendar` variant plus `"ical"` / `"ics"` / `"icalendar"` in `FromStr`. All Things tasks/projects → RFC 5545 `VTODO` components; areas → `CATEGORIES`; project + parent-task linkage via `RELATED-TO`; status maps to `NEEDS-ACTION` / `COMPLETED` / `CANCELLED`. Pulls in `icalendar` 0.17 as a new optional dep.

Both new features are additive behind their own flags. Default builds are unaffected. Existing exports (JSON, CSV, OPML, Markdown) are unchanged.

## Post-merge

After this merges to `main`:
1. `git tag v1.3.0 <merge-commit>`
2. `git push origin v1.3.0` — triggers `.github/workflows/release.yml` (cross-platform binary build + GitHub release) and `.github/workflows/publish.yml` (publishes things3-common → things3-core → things3-cli to crates.io).

## Test plan

- [x] `cargo build --workspace` clean at 1.3.0
- [x] `cargo test --features test-utils` passing
- [x] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)