### PR TITLE
feat(skills): foundational things3 agent skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Foundational `things3` agent skill** — new `skills/things3/` directory with an [agentskills.io](https://agentskills.io/specification)-compliant `SKILL.md`, plus `references/TOOLS.md` (complete 45-tool catalog sourced from `mcp.rs`, superseding the outdated 21-tool list in `docs/MCP_INTEGRATION.md`) and `references/HOSTS.md` (copy-paste MCP config snippets for Claude Desktop, Claude Code, Cursor, VS Code, and Zed). Reconciles the tool-count discrepancy in `docs/MCP_INTEGRATION.md`. Closes #111.
+- **Foundational `things3` agent skill** — new `skills/things3/` directory with an [agentskills.io](https://agentskills.io/specification)-compliant `SKILL.md`, plus `references/TOOLS.md` (complete 46-tool catalog sourced from `mcp.rs`, superseding the outdated 21-tool list in `docs/MCP_INTEGRATION.md`) and `references/HOSTS.md` (copy-paste MCP config snippets for Claude Desktop, Claude Code, Cursor, VS Code, and Zed). Reconciles the tool-count discrepancy in `docs/MCP_INTEGRATION.md`. Closes #111.
 
 ## [1.3.0] - 2026-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Foundational `things3` agent skill** — new `skills/things3/` directory with an [agentskills.io](https://agentskills.io/specification)-compliant `SKILL.md`, plus `references/TOOLS.md` (complete 45-tool catalog sourced from `mcp.rs`, superseding the outdated 21-tool list in `docs/MCP_INTEGRATION.md`) and `references/HOSTS.md` (copy-paste MCP config snippets for Claude Desktop, Claude Code, Cursor, VS Code, and Zed). Reconciles the tool-count discrepancy in `docs/MCP_INTEGRATION.md`. Closes #111.
+
 ## [1.3.0] - 2026-04-27
 
 ### Added

--- a/docs/MCP_INTEGRATION.md
+++ b/docs/MCP_INTEGRATION.md
@@ -27,7 +27,7 @@ graph LR
 ```
 
 ### Key Features
-- **21 Tools**: Comprehensive Things 3 operations including bulk operations
+- **45 Tools**: Comprehensive Things 3 operations including bulk operations (see [`skills/things3/references/TOOLS.md`](../skills/things3/references/TOOLS.md) for the complete catalog)
 - **Middleware System**: Logging, validation, auth, rate limiting
 - **Async I/O**: Non-blocking request handling
 - **Type-Safe**: Compile-time validation

--- a/docs/MCP_INTEGRATION.md
+++ b/docs/MCP_INTEGRATION.md
@@ -27,7 +27,7 @@ graph LR
 ```
 
 ### Key Features
-- **45 Tools**: Comprehensive Things 3 operations including bulk operations (see [`skills/things3/references/TOOLS.md`](../skills/things3/references/TOOLS.md) for the complete catalog)
+- **46 Tools**: Comprehensive Things 3 operations including bulk operations (see [`skills/things3/references/TOOLS.md`](../skills/things3/references/TOOLS.md) for the complete catalog)
 - **Middleware System**: Logging, validation, auth, rate limiting
 - **Async I/O**: Non-blocking request handling
 - **Type-Safe**: Compile-time validation
@@ -90,13 +90,13 @@ RUST_LOG=debug things3 mcp
 ```json
 // .zed/settings.json
 {
-  "mcp": {
+  "context_servers": {
     "things3": {
-      "command": "things3",
-      "args": ["mcp"],
-      "env": {
-        "THINGS_DB_PATH": "/path/to/things.db"
-      }
+      "command": {
+        "path": "things3",
+        "args": ["mcp"]
+      },
+      "settings": {}
     }
   }
 }

--- a/skills/things3/SKILL.md
+++ b/skills/things3/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: things3
+description: Interact with Things 3 (read tasks, create and update tasks and projects, manage tags, triage inbox) via the rust-things3 MCP server. Use when the user wants to work with their Things 3 task manager from an AI agent.
+---
+
+# /things3
+
+Drive Things 3 from your AI agent via the [rust-things3](https://github.com/GarthDB/rust-things3) MCP server. Read tasks and projects, create and update items, manage tags, search the logbook, and bulk-process your inbox — all over stdio JSON-RPC.
+
+## Claude Code slash command
+
+To register `/things3` as a slash command in Claude Code, add a `trigger` key to the frontmatter:
+
+```yaml
+trigger: /things3
+```
+
+This is a Claude Code extension field. The agentskills.io spec validator (`skills-ref validate`) currently flags it as unknown and will fail; add it only to your local working copy, not to the canonical `SKILL.md` in the repository. See [`references/HOSTS.md`](references/HOSTS.md) for installation.
+
+## Prerequisites
+
+The `things3` CLI must be installed and the MCP server must be configured in your host. See [`references/HOSTS.md`](references/HOSTS.md) for copy-paste config snippets for Claude Desktop, Cursor, VS Code, and Zed.
+
+**Things 3 must be running** on macOS for the MCP server to reach its database.
+
+## When to use this skill
+
+- Reading inbox, today, or project task lists
+- Creating, updating, or completing tasks and projects
+- GTD workflows (see the companion `things3-inbox-triage` skill)
+- Daily reviews (see the companion `things3-daily-review` skill)
+- Tag management — searching, deduplicating, or reorganising tags
+- Querying the logbook for completed work
+- Exporting data or pulling performance / cache diagnostics
+
+## Tool catalog (45 tools)
+
+Tools are grouped by domain. One-line signatures below; full parameter schemas in [`references/TOOLS.md`](references/TOOLS.md).
+
+### Read — task lists
+
+| Tool | Key params | When to use |
+|---|---|---|
+| `get_inbox` | `limit?` | Unscheduled, uncategorised tasks |
+| `get_today` | `limit?` | Tasks scheduled for today |
+| `get_recent_tasks` | `limit?, hours?` | Recently created or modified tasks |
+| `search_tasks` | `query*, limit?` | Full-text search across all tasks |
+| `logbook_search` | `search_text?, from_date?, to_date?, project_uuid?, area_uuid?, tags?, limit?` | Completed tasks in the logbook |
+
+### Read — structure
+
+| Tool | Key params | When to use |
+|---|---|---|
+| `get_projects` | `area_uuid?, limit?` | All projects (optionally filtered by area) |
+| `get_areas` | — | All areas |
+
+### Task mutations
+
+| Tool | Key params | When to use |
+|---|---|---|
+| `create_task` | `title*, notes?, start_date?, deadline?, project_uuid?, area_uuid?, tags?, status?` | Add a new task |
+| `update_task` | `uuid*, title?, notes?, start_date?, deadline?, status?, project_uuid?, area_uuid?, tags?` | Edit any field on an existing task |
+| `complete_task` | `uuid*` | Mark a task done |
+| `uncomplete_task` | `uuid*` | Reopen a completed task |
+| `delete_task` | `uuid*, child_handling?` | Soft-delete (trashed); `child_handling`: error/cascade/orphan |
+| `bulk_create_tasks` | `tasks*[]` | Create multiple tasks in one call |
+
+### Project mutations
+
+| Tool | Key params | When to use |
+|---|---|---|
+| `create_project` | `title*, notes?, area_uuid?, start_date?, deadline?, tags?` | New project |
+| `update_project` | `uuid*, title?, notes?, area_uuid?, start_date?, deadline?` | Edit a project |
+| `complete_project` | `uuid*` | Mark a project done |
+| `delete_project` | `uuid*` | Soft-delete a project |
+
+### Area mutations
+
+| Tool | Key params | When to use |
+|---|---|---|
+| `create_area` | `title*` | New area |
+| `update_area` | `uuid*, title?` | Rename an area |
+| `delete_area` | `uuid*` | Delete an area |
+
+### Bulk operations (transactional)
+
+| Tool | Key params | When to use |
+|---|---|---|
+| `bulk_move` | `task_uuids*, project_uuid?, area_uuid?` | Move many tasks at once |
+| `bulk_update_dates` | `task_uuids*, start_date?, deadline?, clear_start_date?, clear_deadline?` | Reschedule many tasks |
+| `bulk_complete` | `task_uuids*` | Complete many tasks |
+| `bulk_delete` | `task_uuids*` | Delete many tasks |
+
+### Tag discovery
+
+| Tool | Key params | When to use |
+|---|---|---|
+| `search_tags` | `query*, include_similar?, min_similarity?` | Find existing tags before creating |
+| `get_tag_suggestions` | `title*` | Prevent duplicates when creating a tag |
+| `get_popular_tags` | `limit?` | Most-used tags |
+| `get_recent_tags` | `limit?` | Recently-used tags |
+| `get_tag_completions` | `partial_input*` | Autocomplete for partial tag input |
+
+### Tag CRUD
+
+| Tool | Key params | When to use |
+|---|---|---|
+| `create_tag` | `title*, shortcut?, parent_uuid?, force?` | New tag (dedup-checked by default) |
+| `update_tag` | `uuid*, title?, shortcut?, parent_uuid?` | Rename or re-nest a tag |
+| `delete_tag` | `uuid*, remove_from_tasks?` | Delete a tag |
+| `merge_tags` | `source_uuid*, target_uuid*` | Consolidate duplicate tags |
+
+### Tag assignment
+
+| Tool | Key params | When to use |
+|---|---|---|
+| `add_tag_to_task` | `task_uuid*, tag_title*` | Add one tag |
+| `remove_tag_from_task` | `task_uuid*, tag_title*` | Remove one tag |
+| `set_task_tags` | `task_uuid*, tag_titles*[]` | Replace all tags on a task |
+
+### Tag analytics
+
+| Tool | Key params | When to use |
+|---|---|---|
+| `get_tag_statistics` | `uuid*` | Usage stats for a specific tag |
+| `find_duplicate_tags` | `min_similarity?` | Surface near-duplicate tags |
+
+### Analytics & export
+
+| Tool | Key params | When to use |
+|---|---|---|
+| `get_productivity_metrics` | — | Task completion rates and trends |
+| `export_data` | — | Full data export |
+
+### Backup
+
+| Tool | Key params | When to use |
+|---|---|---|
+| `backup_database` | — | Create a database backup |
+| `restore_database` | — | Restore from backup |
+| `list_backups` | `backup_dir*` | List available backups |
+
+### System / observability
+
+| Tool | Key params | When to use |
+|---|---|---|
+| `get_performance_stats` | — | Query performance metrics |
+| `get_system_metrics` | — | Current resource usage |
+| `get_cache_stats` | — | Cache hit rates |
+
+`*` = required. Full schemas: [`references/TOOLS.md`](references/TOOLS.md).
+
+## Prompts (5)
+
+The server also exposes five prompt templates: `task_review`, `project_planning`, `productivity_analysis`, `backup_strategy`. Call these via `prompts/get` in the MCP protocol, not `tools/call`.
+
+## Notes
+
+- **Things 3 must be open** on macOS. The server reads directly from the SQLite database at `~/Library/Group Containers/JLMPQHK86H.com.culturedcode.ThingsMac/ThingsData-*/Containers/com.culturedcode.ThingsMac/Data/Library/Application Support/Cultured Code/Things 3/Things Database.thingsdatabase/main.sqlite`.
+- Override the path with `THINGS_DB_PATH` env var.
+- `delete_task` / `delete_project` are soft-deletes (move to Trash). There is no MCP tool to permanently purge or restore from Trash.
+- For full parameter schemas and advanced configuration, see [`docs/MCP_INTEGRATION.md`](../../docs/MCP_INTEGRATION.md).

--- a/skills/things3/SKILL.md
+++ b/skills/things3/SKILL.md
@@ -33,7 +33,7 @@ The `things3` CLI must be installed and the MCP server must be configured in you
 - Querying the logbook for completed work
 - Exporting data or pulling performance / cache diagnostics
 
-## Tool catalog (45 tools)
+## Tool catalog (46 tools)
 
 Tools are grouped by domain. One-line signatures below; full parameter schemas in [`references/TOOLS.md`](references/TOOLS.md).
 
@@ -148,9 +148,9 @@ Tools are grouped by domain. One-line signatures below; full parameter schemas i
 | `get_system_metrics` | — | Current resource usage |
 | `get_cache_stats` | — | Cache hit rates |
 
-`*` = required. Full schemas: [`references/TOOLS.md`](references/TOOLS.md).
+`*` = required. Full schemas: [`references/TOOLS.md`](references/TOOLS.md). (46 tools total)
 
-## Prompts (5)
+## Prompts (4)
 
 The server also exposes five prompt templates: `task_review`, `project_planning`, `productivity_analysis`, `backup_strategy`. Call these via `prompts/get` in the MCP protocol, not `tools/call`.
 

--- a/skills/things3/references/HOSTS.md
+++ b/skills/things3/references/HOSTS.md
@@ -111,17 +111,19 @@ Or add to `.claude/settings.json` manually:
 
 ```json
 {
-  "mcp": {
+  "context_servers": {
     "things3": {
-      "command": "things3",
-      "args": ["mcp"],
-      "env": {
-        "THINGS_DB_PATH": "/path/to/main.sqlite"
-      }
+      "command": {
+        "path": "things3",
+        "args": ["mcp"]
+      },
+      "settings": {}
     }
   }
 }
 ```
+
+Set `THINGS_DB_PATH` via the shell environment (e.g. in `~/.zshenv`) or wrap `things3` in a small shell script that sets it before exec.
 
 ---
 

--- a/skills/things3/references/HOSTS.md
+++ b/skills/things3/references/HOSTS.md
@@ -1,0 +1,136 @@
+# things3 MCP — Host Configuration
+
+Copy-paste config for each supported host. In every snippet, replace `THINGS_DB_PATH` with the path to your Things 3 database, or omit `env` entirely to use the auto-detected default.
+
+**Default database path** (typical macOS install):
+```
+~/Library/Group Containers/JLMPQHK86H.com.culturedcode.ThingsMac/ThingsData-*/Containers/com.culturedcode.ThingsMac/Data/Library/Application Support/Cultured Code/Things 3/Things Database.thingsdatabase/main.sqlite
+```
+
+The glob `ThingsData-*` means the exact path includes a random suffix. Either expand it manually or let the CLI auto-detect it (default when `THINGS_DB_PATH` is unset).
+
+---
+
+## Claude Desktop
+
+`~/Library/Application Support/Claude/claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "things3": {
+      "command": "things3",
+      "args": ["mcp"],
+      "env": {
+        "THINGS_DB_PATH": "/path/to/main.sqlite"
+      }
+    }
+  }
+}
+```
+
+Restart Claude Desktop after editing.
+
+---
+
+## Claude Code
+
+```bash
+# From your project directory (or globally with --global)
+claude mcp add things3 -- things3 mcp
+```
+
+To set the database path:
+```bash
+claude mcp add things3 -e THINGS_DB_PATH=/path/to/main.sqlite -- things3 mcp
+```
+
+Or add to `.claude/settings.json` manually:
+```json
+{
+  "mcpServers": {
+    "things3": {
+      "command": "things3",
+      "args": ["mcp"],
+      "env": {
+        "THINGS_DB_PATH": "/path/to/main.sqlite"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Cursor
+
+`.cursor/mcp.json` (project) or `~/.cursor/mcp.json` (global):
+
+```json
+{
+  "mcpServers": {
+    "things3": {
+      "command": "things3",
+      "args": ["mcp"],
+      "env": {
+        "THINGS_DB_PATH": "/path/to/main.sqlite",
+        "RUST_LOG": "info"
+      }
+    }
+  }
+}
+```
+
+---
+
+## VS Code
+
+`.vscode/mcp.json`:
+
+```json
+{
+  "servers": {
+    "things3": {
+      "type": "stdio",
+      "command": "things3",
+      "args": ["mcp"],
+      "cwd": "${workspaceFolder}",
+      "env": {
+        "THINGS_DB_PATH": "/path/to/main.sqlite"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Zed
+
+`.zed/settings.json`:
+
+```json
+{
+  "mcp": {
+    "things3": {
+      "command": "things3",
+      "args": ["mcp"],
+      "env": {
+        "THINGS_DB_PATH": "/path/to/main.sqlite"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Environment variables
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `THINGS_DB_PATH` | Auto-detected | Path to `main.sqlite` |
+| `THINGS_DATABASE_PATH` | — | Deprecated alias (logs warning) |
+| `RUST_LOG` | `warn` | Log verbosity (`error`/`warn`/`info`/`debug`/`trace`) |
+
+For the full configuration reference including `mcp_config.json` and middleware options, see [`docs/MCP_INTEGRATION.md`](../../../docs/MCP_INTEGRATION.md).

--- a/skills/things3/references/TOOLS.md
+++ b/skills/things3/references/TOOLS.md
@@ -1,0 +1,385 @@
+# things3 MCP Tool Reference
+
+Complete parameter schemas for all 45 tools exposed by `things3 mcp`.
+
+Source of truth: `apps/things3-cli/src/mcp.rs` — `get_available_tools()` and the dispatch table at line 1907.
+
+> **Note:** `docs/MCP_INTEGRATION.md` documents a subset of these tools in narrative form. This file is the authoritative catalog.
+
+---
+
+## Data retrieval
+
+### `get_inbox`
+Get tasks from the inbox.
+```json
+{ "limit": 50 }
+```
+
+### `get_today`
+Get tasks scheduled for today.
+```json
+{ "limit": 50 }
+```
+
+### `get_projects`
+Get all projects, optionally filtered by area.
+```json
+{ "area_uuid": "<uuid>", "limit": 50 }
+```
+
+### `get_areas`
+Get all areas. No parameters.
+
+### `search_tasks`
+Search tasks by title or notes.
+```json
+{ "query": "meeting", "limit": 20 }
+```
+`query` is required.
+
+### `get_recent_tasks`
+Get recently created or modified tasks.
+```json
+{ "limit": 20, "hours": 24 }
+```
+
+### `logbook_search`
+Search completed tasks in the logbook.
+```json
+{
+  "search_text": "report",
+  "from_date": "2026-01-01",
+  "to_date": "2026-04-28",
+  "project_uuid": "<uuid>",
+  "area_uuid": "<uuid>",
+  "tags": ["work"],
+  "limit": 50
+}
+```
+All fields optional. `limit` max 500, default 50.
+
+---
+
+## Task mutations
+
+### `create_task`
+Create a new task.
+```json
+{
+  "title": "Buy groceries",
+  "task_type": "to-do",
+  "notes": "Milk, eggs, bread",
+  "start_date": "2026-04-28",
+  "deadline": "2026-04-30",
+  "project_uuid": "<uuid>",
+  "area_uuid": "<uuid>",
+  "parent_uuid": "<uuid>",
+  "tags": ["errands"],
+  "status": "incomplete"
+}
+```
+`title` required. `task_type`: `to-do` | `project` | `heading`.
+
+### `update_task`
+Update an existing task (patch — only provided fields change).
+```json
+{
+  "uuid": "<uuid>",
+  "title": "Buy groceries and wine",
+  "notes": "Updated list",
+  "start_date": "2026-04-29",
+  "deadline": "2026-05-01",
+  "status": "incomplete",
+  "project_uuid": "<uuid>",
+  "area_uuid": "<uuid>",
+  "tags": ["errands", "weekend"]
+}
+```
+`uuid` required.
+
+### `complete_task`
+Mark a task as completed.
+```json
+{ "uuid": "<uuid>" }
+```
+
+### `uncomplete_task`
+Reopen a completed task.
+```json
+{ "uuid": "<uuid>" }
+```
+
+### `delete_task`
+Soft-delete a task (moves to Trash).
+```json
+{
+  "uuid": "<uuid>",
+  "child_handling": "error"
+}
+```
+`child_handling`: `error` (fail if children exist) | `cascade` (delete children too) | `orphan` (delete parent only). Default: `error`.
+
+### `bulk_create_tasks`
+Create multiple tasks in one call.
+```json
+{
+  "tasks": [
+    { "title": "Task A", "project_uuid": "<uuid>" },
+    { "title": "Task B", "notes": "Details", "area_uuid": "<uuid>" }
+  ]
+}
+```
+Each item requires `title`.
+
+---
+
+## Project mutations
+
+### `create_project`
+```json
+{
+  "title": "Website redesign",
+  "notes": "Q2 initiative",
+  "area_uuid": "<uuid>",
+  "start_date": "2026-05-01",
+  "deadline": "2026-06-30",
+  "tags": ["work"]
+}
+```
+`title` required.
+
+### `update_project`
+Patch update — only provided fields change.
+```json
+{
+  "uuid": "<uuid>",
+  "title": "Website redesign v2",
+  "notes": "Updated scope",
+  "area_uuid": "<uuid>",
+  "start_date": "2026-05-15",
+  "deadline": "2026-07-31"
+}
+```
+`uuid` required.
+
+### `complete_project`
+```json
+{ "uuid": "<uuid>" }
+```
+
+### `delete_project`
+Soft-delete a project.
+```json
+{ "uuid": "<uuid>" }
+```
+
+---
+
+## Area mutations
+
+### `create_area`
+```json
+{ "title": "Personal" }
+```
+
+### `update_area`
+```json
+{ "uuid": "<uuid>", "title": "Personal Projects" }
+```
+
+### `delete_area`
+```json
+{ "uuid": "<uuid>" }
+```
+
+---
+
+## Bulk operations (all transactional — all-or-nothing)
+
+### `bulk_move`
+Move multiple tasks to a project or area.
+```json
+{
+  "task_uuids": ["<uuid1>", "<uuid2>"],
+  "project_uuid": "<uuid>"
+}
+```
+`task_uuids` required. Provide `project_uuid` or `area_uuid` (not both).
+
+### `bulk_update_dates`
+Reschedule multiple tasks.
+```json
+{
+  "task_uuids": ["<uuid1>", "<uuid2>"],
+  "start_date": "2026-05-01",
+  "deadline": "2026-05-07",
+  "clear_start_date": false,
+  "clear_deadline": false
+}
+```
+
+### `bulk_complete`
+```json
+{ "task_uuids": ["<uuid1>", "<uuid2>"] }
+```
+
+### `bulk_delete`
+Soft-delete multiple tasks.
+```json
+{ "task_uuids": ["<uuid1>", "<uuid2>"] }
+```
+
+---
+
+## Tag discovery
+
+### `search_tags`
+Find existing tags (exact + fuzzy).
+```json
+{ "query": "work", "include_similar": true, "min_similarity": 0.7 }
+```
+
+### `get_tag_suggestions`
+Dedup-safe suggestions before creating a tag.
+```json
+{ "title": "Work Projects" }
+```
+
+### `get_popular_tags`
+```json
+{ "limit": 20 }
+```
+
+### `get_recent_tags`
+```json
+{ "limit": 20 }
+```
+
+### `get_tag_completions`
+Autocomplete for partial input.
+```json
+{ "partial_input": "wo" }
+```
+
+---
+
+## Tag CRUD
+
+### `create_tag`
+```json
+{
+  "title": "work",
+  "shortcut": "w",
+  "parent_uuid": "<uuid>",
+  "force": false
+}
+```
+`title` required. `force: true` skips duplicate check.
+
+### `update_tag`
+```json
+{
+  "uuid": "<uuid>",
+  "title": "Work",
+  "shortcut": "W",
+  "parent_uuid": "<uuid>"
+}
+```
+
+### `delete_tag`
+```json
+{ "uuid": "<uuid>", "remove_from_tasks": false }
+```
+
+### `merge_tags`
+Combine source into target; source is deleted.
+```json
+{ "source_uuid": "<uuid>", "target_uuid": "<uuid>" }
+```
+
+---
+
+## Tag assignment
+
+### `add_tag_to_task`
+```json
+{ "task_uuid": "<uuid>", "tag_title": "work" }
+```
+
+### `remove_tag_from_task`
+```json
+{ "task_uuid": "<uuid>", "tag_title": "work" }
+```
+
+### `set_task_tags`
+Replace all tags on a task.
+```json
+{ "task_uuid": "<uuid>", "tag_titles": ["work", "urgent"] }
+```
+
+---
+
+## Tag analytics
+
+### `get_tag_statistics`
+Usage stats for a specific tag.
+```json
+{ "uuid": "<uuid>" }
+```
+
+### `find_duplicate_tags`
+Surface near-duplicate tags.
+```json
+{ "min_similarity": 0.85 }
+```
+
+---
+
+## Analytics & export
+
+### `get_productivity_metrics`
+Task completion rates and trends. No parameters.
+
+### `export_data`
+Full data export. No parameters.
+
+---
+
+## Backup
+
+### `backup_database`
+Create a database backup. No parameters.
+
+### `restore_database`
+Restore from backup. No parameters.
+
+### `list_backups`
+```json
+{ "backup_dir": "/path/to/backups" }
+```
+`backup_dir` required.
+
+---
+
+## System / observability
+
+### `get_performance_stats`
+Query performance metrics. No parameters.
+
+### `get_system_metrics`
+Current resource usage. No parameters.
+
+### `get_cache_stats`
+Cache hit rates. No parameters.
+
+---
+
+## Prompts (not tools)
+
+These are MCP prompts, not tools — invoke via `prompts/get`, not `tools/call`:
+
+- `task_review`
+- `project_planning`
+- `productivity_analysis`
+- `backup_strategy`

--- a/skills/things3/references/TOOLS.md
+++ b/skills/things3/references/TOOLS.md
@@ -1,6 +1,6 @@
 # things3 MCP Tool Reference
 
-Complete parameter schemas for all 45 tools exposed by `things3 mcp`.
+Complete parameter schemas for all 46 tools exposed by `things3 mcp`.
 
 Source of truth: `apps/things3-cli/src/mcp.rs` — `get_available_tools()` and the dispatch table at line 1907.
 


### PR DESCRIPTION
Adds `skills/things3/` conforming to the [agentskills.io specification](https://agentskills.io/specification). `skills-ref validate skills/things3` passes.

## What's included

- **`skills/things3/SKILL.md`** — spec-compliant frontmatter (`name`, `description`) plus a body with a compact per-domain tool table, prerequisites, and pointers to `references/`.
- **`skills/things3/references/TOOLS.md`** — authoritative 45-tool catalog sourced directly from `apps/things3-cli/src/mcp.rs` (dispatch table + `get_available_tools()`). Supersedes the outdated 21-tool count in `docs/MCP_INTEGRATION.md`.
- **`skills/things3/references/HOSTS.md`** — copy-paste MCP config snippets for Claude Desktop, Claude Code, Cursor, VS Code, and Zed.
- **`docs/MCP_INTEGRATION.md`** — tool count corrected 21 → 45 with a link to `references/TOOLS.md` as the maintained catalog.

## Note on `trigger:` field

The agentskills.io spec states `skills-ref` should ignore unknown frontmatter, but `skills-ref 0.1.5` rejects `trigger:` as an error. The `trigger: /things3` field (needed for Claude Code slash-command registration) is documented in the SKILL.md body with instructions to add it locally. The CI workflow PR (#114) will decide how to handle this — either pin a version of `skills-ref` that matches spec intent, or accept the field omission in the canonical file.

## Test plan

- [x] `npx skills-ref validate skills/things3` → `Valid skill`
- [ ] Manual end-to-end: symlink `skills/things3` into `~/.claude/skills/`, add `trigger: /things3` to local frontmatter, invoke `/things3` in Claude Code, call `get_inbox` against a real Things 3 DB

Closes #111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)