### PR TITLE
feat(skills): things3 agent skills for v1.4.0 (#110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Foundational `things3` agent skill** — new `skills/things3/` directory with an [agentskills.io](https://agentskills.io/specification)-compliant `SKILL.md`, plus `references/TOOLS.md` (complete 46-tool catalog sourced from `mcp.rs`, superseding the outdated 21-tool list in `docs/MCP_INTEGRATION.md`) and `references/HOSTS.md` (copy-paste MCP config snippets for Claude Desktop, Claude Code, Cursor, VS Code, and Zed). Reconciles the tool-count discrepancy in `docs/MCP_INTEGRATION.md`. Closes #111.
+- **`things3-daily-review` workflow skill** — new `skills/things3-daily-review/SKILL.md` with a read-only daily-review recipe: pulls `get_today`, `get_inbox`, and `get_recent_tasks`; produces a structured Markdown summary grouped by area and project with overdue items flagged. References the foundational `things3` skill for MCP setup without duplicating install instructions. Closes #112.
 
 ## [1.3.0] - 2026-04-27
 

--- a/skills/things3-daily-review/SKILL.md
+++ b/skills/things3-daily-review/SKILL.md
@@ -9,13 +9,16 @@ A read-only workflow skill that drives a daily review over your Things 3 databas
 
 ## Claude Code slash command
 
-To register `/things3-daily-review` as a slash command in Claude Code, add a `trigger` key to the frontmatter:
+To use `/things3-daily-review` as a Claude Code slash command, copy the skill to your local skills directory and patch in a `trigger` key. The canonical file omits it because `skills-ref validate` rejects unknown frontmatter fields.
 
-```yaml
-trigger: /things3-daily-review
+```bash
+cp skills/things3-daily-review/SKILL.md ~/.claude/skills/things3-daily-review/SKILL.md
+python3 -c "
+import pathlib, re
+p = pathlib.Path('~/.claude/skills/things3-daily-review/SKILL.md').expanduser()
+p.write_text(re.sub(r'(?m)^---\$(?=\n\n)', 'trigger: /things3-daily-review\n---', p.read_text(), count=1))
+"
 ```
-
-This is a Claude Code extension field. The agentskills.io spec validator (`skills-ref validate`) currently flags it as unknown and will fail; add it only to your local working copy, not to the canonical `SKILL.md` in the repository.
 
 ## Prerequisites
 
@@ -62,7 +65,7 @@ Returns unscheduled, uncategorised tasks awaiting triage.
 }
 ```
 
-Returns recently modified tasks from the last `hours` window. To target **completed** tasks specifically, use `logbook_search` instead:
+Returns recently modified **incomplete** tasks from the last `hours` window — completed tasks are not included. For recently completed work, use `logbook_search` instead:
 
 ```json
 {
@@ -79,6 +82,8 @@ Returns recently modified tasks from the last `hours` window. To target **comple
 
 Produce a Markdown summary with these three sections, grouped by area then project. Omit empty sections.
 
+Tasks without an `area_uuid` fall under a **No area** top-level group; tasks without a `project_uuid` fall under a _No project_ sub-group within their area group.
+
 ```markdown
 ## Daily Review — YYYY-MM-DD
 
@@ -91,6 +96,12 @@ Produce a Markdown summary with these three sections, grouped by area then proje
 - _No project_
   - Task title
 
+**No area**
+- _Project Name_
+  - Task title
+- _No project_
+  - Task title
+
 ### Inbox (N)
 
 - Task title
@@ -99,6 +110,12 @@ Produce a Markdown summary with these three sections, grouped by area then proje
 ### Recent (N)
 
 **Area Name**
+- _Project Name_
+  - Task title
+- _No project_
+  - Task title
+
+**No area**
 - _Project Name_
   - Task title
 - _No project_
@@ -119,4 +136,3 @@ Flag overdue items in both the **Today** and **Recent** sections wherever they a
 
 - This skill is read-only — it makes no mutations. For processing inbox items, see the companion `things3-inbox-triage` skill (coming soon).
 - Things 3 must be running on macOS for the MCP server to reach its database.
-- Tasks without an `area_uuid` or `project_uuid` fall under a _No area_ or _No project_ group respectively.

--- a/skills/things3-daily-review/SKILL.md
+++ b/skills/things3-daily-review/SKILL.md
@@ -58,7 +58,7 @@ Returns unscheduled, uncategorised tasks awaiting triage.
 ```json
 {
   "name": "get_recent_tasks",
-  "arguments": { "limit": 20, "hours": 24 }
+  "arguments": { "limit": 50, "hours": 24 }
 }
 ```
 

--- a/skills/things3-daily-review/SKILL.md
+++ b/skills/things3-daily-review/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: things3-daily-review
+description: Daily review workflow for Things 3 — pulls today's tasks, inbox, and recent work; produces a structured Markdown summary grouped by area and project with overdue items flagged. Use for morning standups, end-of-day wrap-ups, or weekly reviews.
+---
+
+# /things3-daily-review
+
+A read-only workflow skill that drives a daily review over your Things 3 database via the [rust-things3](https://github.com/GarthDB/rust-things3) MCP server. It pulls three data sets, groups them by area and project, and flags any overdue items.
+
+## Claude Code slash command
+
+To register `/things3-daily-review` as a slash command in Claude Code, add a `trigger` key to the frontmatter:
+
+```yaml
+trigger: /things3-daily-review
+```
+
+This is a Claude Code extension field. The agentskills.io spec validator (`skills-ref validate`) currently flags it as unknown and will fail; add it only to your local working copy, not to the canonical `SKILL.md` in the repository.
+
+## Prerequisites
+
+The `things3` foundational skill must be installed and the MCP server configured before running this workflow — see [`../things3/SKILL.md`](../things3/SKILL.md) for setup instructions.
+
+## When to use this skill
+
+- Morning standup prep: see what's due today and what's sitting in your inbox
+- End-of-day wrap-up: review recent work and surface anything overdue
+- Weekly review: recent completions grouped by area and project
+
+## Recipe
+
+Run the following three tool calls in order, then render the output as described below.
+
+### Step 1 — Today's tasks
+
+```json
+{
+  "name": "get_today",
+  "arguments": { "limit": 50 }
+}
+```
+
+Returns tasks scheduled for today. Tasks with a `deadline` earlier than today are overdue.
+
+### Step 2 — Inbox
+
+```json
+{
+  "name": "get_inbox",
+  "arguments": { "limit": 50 }
+}
+```
+
+Returns unscheduled, uncategorised tasks awaiting triage.
+
+### Step 3 — Recent tasks
+
+```json
+{
+  "name": "get_recent_tasks",
+  "arguments": { "limit": 20, "hours": 24 }
+}
+```
+
+Returns recently modified tasks from the last `hours` window. To target **completed** tasks specifically, use `logbook_search` instead:
+
+```json
+{
+  "name": "logbook_search",
+  "arguments": {
+    "from_date": "<YYYY-MM-DD>",
+    "to_date": "<YYYY-MM-DD>",
+    "limit": 20
+  }
+}
+```
+
+## Output format
+
+Produce a Markdown summary with these three sections, grouped by area then project. Omit empty sections.
+
+```markdown
+## Daily Review — YYYY-MM-DD
+
+### Today (N)
+
+**Area Name**
+- _Project Name_
+  - **OVERDUE** Task title (deadline: YYYY-MM-DD)
+  - Task title
+- _No project_
+  - Task title
+
+### Inbox (N)
+
+- Task title
+- Task title
+
+### Recent (N)
+
+**Area Name**
+- _Project Name_
+  - Task title
+- _No project_
+  - Task title
+```
+
+## Overdue flagging
+
+A task is overdue when its `deadline` field is set and `deadline < today`. Mark it inline with bold **OVERDUE** and include the deadline date:
+
+```
+- **OVERDUE** Review Q3 budget (deadline: 2026-04-20)
+```
+
+Flag overdue items in both the **Today** and **Recent** sections wherever they appear.
+
+## Notes
+
+- This skill is read-only — it makes no mutations. For processing inbox items, see the companion `things3-inbox-triage` skill (coming soon).
+- Things 3 must be running on macOS for the MCP server to reach its database.
+- Tasks without an `area_uuid` or `project_uuid` fall under a _No area_ or _No project_ group respectively.

--- a/skills/things3/SKILL.md
+++ b/skills/things3/SKILL.md
@@ -9,13 +9,18 @@ Drive Things 3 from your AI agent via the [rust-things3](https://github.com/Gart
 
 ## Claude Code slash command
 
-To register `/things3` as a slash command in Claude Code, add a `trigger` key to the frontmatter:
+To use `/things3` as a Claude Code slash command, copy the skill to your local skills directory and patch in a `trigger` key. The canonical file omits it because `skills-ref validate` rejects unknown frontmatter fields.
 
-```yaml
-trigger: /things3
+```bash
+cp -r skills/things3 ~/.claude/skills/things3
+python3 -c "
+import pathlib, re
+p = pathlib.Path('~/.claude/skills/things3/SKILL.md').expanduser()
+p.write_text(re.sub(r'(?m)^---\$(?=\n\n)', 'trigger: /things3\n---', p.read_text(), count=1))
+"
 ```
 
-This is a Claude Code extension field. The agentskills.io spec validator (`skills-ref validate`) currently flags it as unknown and will fail; add it only to your local working copy, not to the canonical `SKILL.md` in the repository. See [`references/HOSTS.md`](references/HOSTS.md) for installation.
+See [`references/HOSTS.md`](references/HOSTS.md) for MCP server installation.
 
 ## Prerequisites
 

--- a/skills/things3/SKILL.md
+++ b/skills/things3/SKILL.md
@@ -86,7 +86,7 @@ Tools are grouped by domain. One-line signatures below; full parameter schemas i
 
 | Tool | Key params | When to use |
 |---|---|---|
-| `bulk_move` | `task_uuids*, project_uuid?, area_uuid?` | Move many tasks at once |
+| `bulk_move` | `task_uuids*, project_uuid?, area_uuid?` | Move many tasks at once (`project_uuid` and `area_uuid` are mutually exclusive — provide exactly one) |
 | `bulk_update_dates` | `task_uuids*, start_date?, deadline?, clear_start_date?, clear_deadline?` | Reschedule many tasks |
 | `bulk_complete` | `task_uuids*` | Complete many tasks |
 | `bulk_delete` | `task_uuids*` | Delete many tasks |

--- a/skills/things3/SKILL.md
+++ b/skills/things3/SKILL.md
@@ -152,7 +152,7 @@ Tools are grouped by domain. One-line signatures below; full parameter schemas i
 
 ## Prompts (4)
 
-The server also exposes five prompt templates: `task_review`, `project_planning`, `productivity_analysis`, `backup_strategy`. Call these via `prompts/get` in the MCP protocol, not `tools/call`.
+The server also exposes four prompt templates: `task_review`, `project_planning`, `productivity_analysis`, `backup_strategy`. Call these via `prompts/get` in the MCP protocol, not `tools/call`.
 
 ## Notes
 

--- a/skills/things3/references/TOOLS.md
+++ b/skills/things3/references/TOOLS.md
@@ -354,7 +354,7 @@ Create a database backup. No parameters.
 ### `restore_database`
 Restore from backup. No parameters in the current MCP API — the backup path cannot be specified via this tool. If you have multiple backups (see `list_backups`), you will need to restore the desired file to the default backup location before calling this tool, or restore manually outside the MCP server.
 
-> **Known gap**: `list_backups` accepts a `backup_dir` and implies multiple backups may exist, but `restore_database` provides no way to select among them. This is likely a missing parameter — tracked as a follow-up.
+> **Known gap**: `list_backups` accepts a `backup_dir` and implies multiple backups may exist, but `restore_database` provides no way to select among them. Tracked in #126.
 
 ### `list_backups`
 ```json

--- a/skills/things3/references/TOOLS.md
+++ b/skills/things3/references/TOOLS.md
@@ -2,9 +2,9 @@
 
 Complete parameter schemas for all 46 tools exposed by `things3 mcp`.
 
-Source of truth: `apps/things3-cli/src/mcp.rs` — `get_available_tools()` and the dispatch table at line 1907.
+Derived from `apps/things3-cli/src/mcp.rs` — `get_available_tools()` and its dispatch table. Last audited against the source at commit 5f99673. Tool count can be verified with `things3 mcp --list-tools | wc -l`; if the count drifts from 46, re-audit this file.
 
-> **Note:** `docs/MCP_INTEGRATION.md` documents a subset of these tools in narrative form. This file is the authoritative catalog.
+> **Note:** `docs/MCP_INTEGRATION.md` documents a subset of these tools in narrative form. This file is the more complete catalog.
 
 ---
 
@@ -352,7 +352,9 @@ Full data export. No parameters.
 Create a database backup. No parameters.
 
 ### `restore_database`
-Restore from backup. No parameters.
+Restore from backup. No parameters in the current MCP API — the backup path cannot be specified via this tool. If you have multiple backups (see `list_backups`), you will need to restore the desired file to the default backup location before calling this tool, or restore manually outside the MCP server.
+
+> **Known gap**: `list_backups` accepts a `backup_dir` and implies multiple backups may exist, but `restore_database` provides no way to select among them. This is likely a missing parameter — tracked as a follow-up.
 
 ### `list_backups`
 ```json


### PR DESCRIPTION
## Summary

- Adds the foundational `things3` skill (`skills/things3/SKILL.md`) with full tool catalog, host config snippets, and MCP setup instructions (#111)
- Adds the `things3-daily-review` workflow skill (`skills/things3-daily-review/SKILL.md`) — read-only daily review recipe over `get_today` / `get_inbox` / `get_recent_tasks` with area/project grouping and overdue flagging (#112)
- Fixes minor doc corrections (tool count, prompt count, Zed config key)

Both skills pass `skills-ref validate`.

## Test plan

- [x] `skills-ref validate skills/things3` passes
- [x] `skills-ref validate skills/things3-daily-review` passes
- [x] End-to-end: load `things3-daily-review` skill in Claude Code with Things 3 open; run the three-step recipe; confirm structured Markdown output with area/project grouping and overdue flags

Closes #111
Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)