### PR TITLE
feat(mutations): introduce MutationBackend trait and SqlxBackend

### DIFF
--- a/apps/things3-cli/src/mcp.rs
+++ b/apps/things3-cli/src/mcp.rs
@@ -4,8 +4,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::sync::Arc;
 use things3_core::{
-    BackupManager, DataExporter, DeleteChildHandling, McpServerConfig, PerformanceMonitor,
-    ThingsCache, ThingsConfig, ThingsDatabase, ThingsError,
+    BackupManager, DataExporter, DeleteChildHandling, McpServerConfig, MutationBackend,
+    PerformanceMonitor, SqlxBackend, ThingsCache, ThingsConfig, ThingsDatabase, ThingsError,
 };
 use thiserror::Error;
 use tokio::sync::Mutex;
@@ -532,6 +532,12 @@ pub struct GetPromptResult {
 pub struct ThingsMcpServer {
     #[allow(dead_code)]
     pub db: Arc<ThingsDatabase>,
+    /// Mutation backend used for all write operations.
+    ///
+    /// Defaults to `SqlxBackend` (direct DB writes — current behavior). Production
+    /// will switch to `AppleScriptBackend` once #124/#125 land; tests and the
+    /// `--unsafe-direct-db` opt-in continue to use `SqlxBackend`.
+    mutations: Arc<dyn MutationBackend>,
     #[allow(dead_code)]
     cache: Arc<Mutex<ThingsCache>>,
     #[allow(dead_code)]
@@ -701,6 +707,20 @@ pub async fn start_mcp_server_with_config_generic<I: McpIo>(
 impl ThingsMcpServer {
     #[must_use]
     pub fn new(db: Arc<ThingsDatabase>, config: ThingsConfig) -> Self {
+        let mutations: Arc<dyn MutationBackend> = Arc::new(SqlxBackend::new(Arc::clone(&db)));
+        Self::with_mutation_backend(db, mutations, config)
+    }
+
+    /// Create a new MCP server with a caller-provided mutation backend.
+    ///
+    /// Use this to inject `AppleScriptBackend` (issue #124) or a test double
+    /// without taking the default `SqlxBackend`.
+    #[must_use]
+    pub fn with_mutation_backend(
+        db: Arc<ThingsDatabase>,
+        mutations: Arc<dyn MutationBackend>,
+        config: ThingsConfig,
+    ) -> Self {
         let cache = ThingsCache::new_default();
         let performance_monitor = PerformanceMonitor::new_default();
         let exporter = DataExporter::new_default();
@@ -712,6 +732,7 @@ impl ThingsMcpServer {
 
         Self {
             db,
+            mutations,
             cache: Arc::new(Mutex::new(cache)),
             performance_monitor: Arc::new(Mutex::new(performance_monitor)),
             exporter,
@@ -727,6 +748,8 @@ impl ThingsMcpServer {
         config: ThingsConfig,
         middleware_config: MiddlewareConfig,
     ) -> Self {
+        let db = Arc::new(db);
+        let mutations: Arc<dyn MutationBackend> = Arc::new(SqlxBackend::new(Arc::clone(&db)));
         let cache = ThingsCache::new_default();
         let performance_monitor = PerformanceMonitor::new_default();
         let exporter = DataExporter::new_default();
@@ -734,7 +757,8 @@ impl ThingsMcpServer {
         let middleware_chain = middleware_config.build_chain();
 
         Self {
-            db: Arc::new(db),
+            db,
+            mutations,
             cache: Arc::new(Mutex::new(cache)),
             performance_monitor: Arc::new(Mutex::new(performance_monitor)),
             exporter,
@@ -750,6 +774,7 @@ impl ThingsMcpServer {
         config: ThingsConfig,
         mcp_config: McpServerConfig,
     ) -> Self {
+        let mutations: Arc<dyn MutationBackend> = Arc::new(SqlxBackend::new(Arc::clone(&db)));
         let cache = ThingsCache::new_default();
         let performance_monitor = PerformanceMonitor::new_default();
         let exporter = DataExporter::new_default();
@@ -812,6 +837,7 @@ impl ThingsMcpServer {
 
         Self {
             db,
+            mutations,
             cache: Arc::new(Mutex::new(cache)),
             performance_monitor: Arc::new(Mutex::new(performance_monitor)),
             exporter,
@@ -2157,7 +2183,7 @@ impl ThingsMcpServer {
 
         // Create task
         let uuid = self
-            .db
+            .mutations
             .create_task(request)
             .await
             .map_err(|e| McpError::database_operation_failed("create_task", e))?;
@@ -2188,7 +2214,7 @@ impl ThingsMcpServer {
             })?;
 
         // Update task
-        self.db
+        self.mutations
             .update_task(request)
             .await
             .map_err(|e| McpError::database_operation_failed("update_task", e))?;
@@ -2216,7 +2242,7 @@ impl ThingsMcpServer {
         let uuid = uuid::Uuid::parse_str(uuid_str)
             .map_err(|e| McpError::invalid_parameter("uuid", format!("Invalid UUID: {e}")))?;
 
-        self.db
+        self.mutations
             .complete_task(&uuid)
             .await
             .map_err(|e| McpError::database_operation_failed("complete_task", e))?;
@@ -2244,7 +2270,7 @@ impl ThingsMcpServer {
         let uuid = uuid::Uuid::parse_str(uuid_str)
             .map_err(|e| McpError::invalid_parameter("uuid", format!("Invalid UUID: {e}")))?;
 
-        self.db
+        self.mutations
             .uncomplete_task(&uuid)
             .await
             .map_err(|e| McpError::database_operation_failed("uncomplete_task", e))?;
@@ -2283,7 +2309,7 @@ impl ThingsMcpServer {
             _ => DeleteChildHandling::Error,
         };
 
-        self.db
+        self.mutations
             .delete_task(&uuid, child_handling)
             .await
             .map_err(|e| McpError::database_operation_failed("delete_task", e))?;
@@ -2354,7 +2380,7 @@ impl ThingsMcpServer {
         };
 
         let result = self
-            .db
+            .mutations
             .bulk_move(request)
             .await
             .map_err(|e| McpError::database_operation_failed("bulk_move", e))?;
@@ -2435,7 +2461,7 @@ impl ThingsMcpServer {
         };
 
         let result = self
-            .db
+            .mutations
             .bulk_update_dates(request)
             .await
             .map_err(|e| McpError::database_operation_failed("bulk_update_dates", e))?;
@@ -2477,7 +2503,7 @@ impl ThingsMcpServer {
         let request = things3_core::models::BulkCompleteRequest { task_uuids };
 
         let result = self
-            .db
+            .mutations
             .bulk_complete(request)
             .await
             .map_err(|e| McpError::database_operation_failed("bulk_complete", e))?;
@@ -2519,7 +2545,7 @@ impl ThingsMcpServer {
         let request = things3_core::models::BulkDeleteRequest { task_uuids };
 
         let result = self
-            .db
+            .mutations
             .bulk_delete(request)
             .await
             .map_err(|e| McpError::database_operation_failed("bulk_delete", e))?;
@@ -2594,7 +2620,7 @@ impl ThingsMcpServer {
         };
 
         let uuid = self
-            .db
+            .mutations
             .create_project(request)
             .await
             .map_err(|e| McpError::database_operation_failed("create_project", e))?;
@@ -2671,7 +2697,7 @@ impl ThingsMcpServer {
             tags,
         };
 
-        self.db
+        self.mutations
             .update_project(request)
             .await
             .map_err(|e| McpError::database_operation_failed("update_project", e))?;
@@ -2710,7 +2736,7 @@ impl ThingsMcpServer {
             _ => things3_core::models::ProjectChildHandling::Error,
         };
 
-        self.db
+        self.mutations
             .complete_project(&uuid, child_handling)
             .await
             .map_err(|e| McpError::database_operation_failed("complete_project", e))?;
@@ -2749,7 +2775,7 @@ impl ThingsMcpServer {
             _ => things3_core::models::ProjectChildHandling::Error,
         };
 
-        self.db
+        self.mutations
             .delete_project(&uuid, child_handling)
             .await
             .map_err(|e| McpError::database_operation_failed("delete_project", e))?;
@@ -2778,7 +2804,7 @@ impl ThingsMcpServer {
         let request = things3_core::models::CreateAreaRequest { title };
 
         let uuid = self
-            .db
+            .mutations
             .create_area(request)
             .await
             .map_err(|e| McpError::database_operation_failed("create_area", e))?;
@@ -2814,7 +2840,7 @@ impl ThingsMcpServer {
 
         let request = things3_core::models::UpdateAreaRequest { uuid, title };
 
-        self.db
+        self.mutations
             .update_area(request)
             .await
             .map_err(|e| McpError::database_operation_failed("update_area", e))?;
@@ -2842,7 +2868,7 @@ impl ThingsMcpServer {
         let uuid = uuid::Uuid::parse_str(uuid_str)
             .map_err(|e| McpError::invalid_parameter("uuid", format!("Invalid UUID: {e}")))?;
 
-        self.db
+        self.mutations
             .delete_area(&uuid)
             .await
             .map_err(|e| McpError::database_operation_failed("delete_area", e))?;
@@ -3354,50 +3380,42 @@ impl ThingsMcpServer {
             parent_uuid,
         };
 
-        let result = if force {
-            let uuid = self
-                .db
-                .create_tag_force(request)
-                .await
-                .map_err(|e| McpError::database_operation_failed("create_tag", e))?;
-            serde_json::json!({
-                "status": "created",
-                "uuid": uuid,
-                "message": "Tag created successfully (duplicate check skipped)"
-            })
-        } else {
-            match self
-                .db
-                .create_tag_smart(request)
-                .await
-                .map_err(|e| McpError::database_operation_failed("create_tag", e))?
-            {
-                things3_core::models::TagCreationResult::Created { uuid, .. } => {
-                    serde_json::json!({
-                        "status": "created",
-                        "uuid": uuid,
-                        "message": "Tag created successfully"
-                    })
-                }
-                things3_core::models::TagCreationResult::Existing { tag, .. } => {
-                    serde_json::json!({
-                        "status": "existing",
-                        "uuid": tag.uuid,
-                        "tag": tag,
-                        "message": "Tag already exists"
-                    })
-                }
-                things3_core::models::TagCreationResult::SimilarFound {
-                    similar_tags,
-                    requested_title,
-                } => {
-                    serde_json::json!({
-                        "status": "similar_found",
-                        "similar_tags": similar_tags,
-                        "requested_title": requested_title,
-                        "message": "Similar tags found. Use force=true to create anyway."
-                    })
-                }
+        let result = match self
+            .mutations
+            .create_tag(request, force)
+            .await
+            .map_err(|e| McpError::database_operation_failed("create_tag", e))?
+        {
+            things3_core::models::TagCreationResult::Created { uuid, .. } => {
+                let message = if force {
+                    "Tag created successfully (duplicate check skipped)"
+                } else {
+                    "Tag created successfully"
+                };
+                serde_json::json!({
+                    "status": "created",
+                    "uuid": uuid,
+                    "message": message,
+                })
+            }
+            things3_core::models::TagCreationResult::Existing { tag, .. } => {
+                serde_json::json!({
+                    "status": "existing",
+                    "uuid": tag.uuid,
+                    "tag": tag,
+                    "message": "Tag already exists"
+                })
+            }
+            things3_core::models::TagCreationResult::SimilarFound {
+                similar_tags,
+                requested_title,
+            } => {
+                serde_json::json!({
+                    "status": "similar_found",
+                    "similar_tags": similar_tags,
+                    "requested_title": requested_title,
+                    "message": "Similar tags found. Use force=true to create anyway."
+                })
             }
         };
 
@@ -3441,7 +3459,7 @@ impl ThingsMcpServer {
             parent_uuid,
         };
 
-        self.db
+        self.mutations
             .update_tag(request)
             .await
             .map_err(|e| McpError::database_operation_failed("update_tag", e))?;
@@ -3474,7 +3492,7 @@ impl ThingsMcpServer {
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
 
-        self.db
+        self.mutations
             .delete_tag(&uuid, remove_from_tasks)
             .await
             .map_err(|e| McpError::database_operation_failed("delete_tag", e))?;
@@ -3516,7 +3534,7 @@ impl ThingsMcpServer {
                 )
             })?;
 
-        self.db
+        self.mutations
             .merge_tags(&source_uuid, &target_uuid)
             .await
             .map_err(|e| McpError::database_operation_failed("merge_tags", e))?;
@@ -3554,7 +3572,7 @@ impl ThingsMcpServer {
             .to_string();
 
         let result = self
-            .db
+            .mutations
             .add_tag_to_task(&task_uuid, &tag_title)
             .await
             .map_err(|e| McpError::database_operation_failed("add_tag_to_task", e))?;
@@ -3602,7 +3620,7 @@ impl ThingsMcpServer {
             })?
             .to_string();
 
-        self.db
+        self.mutations
             .remove_tag_from_task(&task_uuid, &tag_title)
             .await
             .map_err(|e| McpError::database_operation_failed("remove_tag_from_task", e))?;
@@ -3643,7 +3661,7 @@ impl ThingsMcpServer {
             .collect();
 
         let suggestions = self
-            .db
+            .mutations
             .set_task_tags(&task_uuid, tag_titles.clone())
             .await
             .map_err(|e| McpError::database_operation_failed("set_task_tags", e))?;

--- a/libs/things3-core/src/lib.rs
+++ b/libs/things3-core/src/lib.rs
@@ -80,6 +80,7 @@ pub mod export;
 pub mod mcp_cache_middleware;
 pub mod mcp_config;
 pub mod models;
+pub mod mutations;
 
 #[cfg(feature = "observability")]
 pub mod observability;
@@ -126,6 +127,7 @@ pub use export::{DataExporter, ExportConfig, ExportData, ExportFormat};
 pub use mcp_cache_middleware::{MCPCacheConfig, MCPCacheEntry, MCPCacheMiddleware, MCPCacheStats};
 pub use mcp_config::McpServerConfig;
 pub use models::*;
+pub use mutations::{MutationBackend, SqlxBackend};
 // Explicitly re-export DeleteChildHandling for clarity
 pub use models::DeleteChildHandling;
 

--- a/libs/things3-core/src/mutations/mod.rs
+++ b/libs/things3-core/src/mutations/mod.rs
@@ -1,0 +1,110 @@
+//! Mutation backend abstraction.
+//!
+//! This module defines [`MutationBackend`], a trait that abstracts every Things 3
+//! mutation operation behind a single interface. The MCP server holds an
+//! `Arc<dyn MutationBackend>` and dispatches all writes through it. This unblocks
+//! issue #120's migration from direct SQLite writes (which CulturedCode warns can
+//! corrupt the user's database) to AppleScript-based mutations.
+//!
+//! Two implementations are planned:
+//! - [`SqlxBackend`] — wraps the existing direct-DB writes on [`crate::ThingsDatabase`].
+//!   Today's behavior; useful for offline tests and CI.
+//! - `AppleScriptBackend` — to be added in #124. The default in production after #125.
+//!
+//! ## Why `#[async_trait]` instead of native `async fn` in traits
+//!
+//! The trait must be object-safe so the server can hold `Arc<dyn MutationBackend>`
+//! and choose between backends at runtime. Native async-fn-in-trait (Rust 1.75+)
+//! requires `#[trait_variant]` shims for `dyn` dispatch and produces unnameable
+//! opaque return types — too much friction for marginal benefit. `#[async_trait]`
+//! boxes the future, which is exactly what `dyn` needs.
+
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use crate::error::Result as ThingsResult;
+use crate::models::{
+    BulkCompleteRequest, BulkDeleteRequest, BulkMoveRequest, BulkOperationResult,
+    BulkUpdateDatesRequest, CreateAreaRequest, CreateProjectRequest, CreateTagRequest,
+    CreateTaskRequest, DeleteChildHandling, ProjectChildHandling, TagAssignmentResult,
+    TagCreationResult, TagMatch, UpdateAreaRequest, UpdateProjectRequest, UpdateTagRequest,
+    UpdateTaskRequest,
+};
+
+mod sqlx;
+pub use sqlx::SqlxBackend;
+
+/// Abstraction over every Things 3 mutation operation exposed as an MCP tool.
+///
+/// All implementations must be `Send + Sync` so the server can share them across
+/// async tasks via `Arc<dyn MutationBackend>`.
+#[async_trait]
+pub trait MutationBackend: Send + Sync {
+    // ---- Tasks ----
+
+    async fn create_task(&self, request: CreateTaskRequest) -> ThingsResult<Uuid>;
+    async fn update_task(&self, request: UpdateTaskRequest) -> ThingsResult<()>;
+    async fn complete_task(&self, uuid: &Uuid) -> ThingsResult<()>;
+    async fn uncomplete_task(&self, uuid: &Uuid) -> ThingsResult<()>;
+    async fn delete_task(
+        &self,
+        uuid: &Uuid,
+        child_handling: DeleteChildHandling,
+    ) -> ThingsResult<()>;
+    async fn bulk_delete(&self, request: BulkDeleteRequest) -> ThingsResult<BulkOperationResult>;
+    async fn bulk_move(&self, request: BulkMoveRequest) -> ThingsResult<BulkOperationResult>;
+    async fn bulk_update_dates(
+        &self,
+        request: BulkUpdateDatesRequest,
+    ) -> ThingsResult<BulkOperationResult>;
+    async fn bulk_complete(
+        &self,
+        request: BulkCompleteRequest,
+    ) -> ThingsResult<BulkOperationResult>;
+
+    // ---- Projects ----
+
+    async fn create_project(&self, request: CreateProjectRequest) -> ThingsResult<Uuid>;
+    async fn update_project(&self, request: UpdateProjectRequest) -> ThingsResult<()>;
+    async fn complete_project(
+        &self,
+        uuid: &Uuid,
+        child_handling: ProjectChildHandling,
+    ) -> ThingsResult<()>;
+    async fn delete_project(
+        &self,
+        uuid: &Uuid,
+        child_handling: ProjectChildHandling,
+    ) -> ThingsResult<()>;
+
+    // ---- Areas ----
+
+    async fn create_area(&self, request: CreateAreaRequest) -> ThingsResult<Uuid>;
+    async fn update_area(&self, request: UpdateAreaRequest) -> ThingsResult<()>;
+    async fn delete_area(&self, uuid: &Uuid) -> ThingsResult<()>;
+
+    // ---- Tags ----
+
+    /// Create a tag. When `force` is true, skip duplicate / similarity checks
+    /// (mirrors the legacy `create_tag_force` path); otherwise run the smart
+    /// flow that may return `Existing` or `SimilarFound`.
+    async fn create_tag(
+        &self,
+        request: CreateTagRequest,
+        force: bool,
+    ) -> ThingsResult<TagCreationResult>;
+    async fn update_tag(&self, request: UpdateTagRequest) -> ThingsResult<()>;
+    async fn delete_tag(&self, uuid: &Uuid, remove_from_tasks: bool) -> ThingsResult<()>;
+    async fn merge_tags(&self, source_uuid: &Uuid, target_uuid: &Uuid) -> ThingsResult<()>;
+    async fn add_tag_to_task(
+        &self,
+        task_uuid: &Uuid,
+        tag_title: &str,
+    ) -> ThingsResult<TagAssignmentResult>;
+    async fn remove_tag_from_task(&self, task_uuid: &Uuid, tag_title: &str) -> ThingsResult<()>;
+    async fn set_task_tags(
+        &self,
+        task_uuid: &Uuid,
+        tag_titles: Vec<String>,
+    ) -> ThingsResult<Vec<TagMatch>>;
+}

--- a/libs/things3-core/src/mutations/sqlx.rs
+++ b/libs/things3-core/src/mutations/sqlx.rs
@@ -1,0 +1,171 @@
+//! `SqlxBackend` — direct-SQLite implementation of [`MutationBackend`].
+//!
+//! Forwards every call to the corresponding method on [`ThingsDatabase`]. Behavior
+//! is byte-for-byte identical to calling the database directly. Kept around after
+//! AppleScript becomes the default (#125) for offline tests, CI, and the
+//! `--unsafe-direct-db` opt-in.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use super::MutationBackend;
+use crate::database::ThingsDatabase;
+use crate::error::Result as ThingsResult;
+use crate::models::{
+    BulkCompleteRequest, BulkDeleteRequest, BulkMoveRequest, BulkOperationResult,
+    BulkUpdateDatesRequest, CreateAreaRequest, CreateProjectRequest, CreateTagRequest,
+    CreateTaskRequest, DeleteChildHandling, ProjectChildHandling, TagAssignmentResult,
+    TagCreationResult, TagMatch, UpdateAreaRequest, UpdateProjectRequest, UpdateTagRequest,
+    UpdateTaskRequest,
+};
+
+pub struct SqlxBackend {
+    db: Arc<ThingsDatabase>,
+}
+
+impl SqlxBackend {
+    #[must_use]
+    pub fn new(db: Arc<ThingsDatabase>) -> Self {
+        Self { db }
+    }
+}
+
+#[async_trait]
+impl MutationBackend for SqlxBackend {
+    // ---- Tasks ----
+
+    async fn create_task(&self, request: CreateTaskRequest) -> ThingsResult<Uuid> {
+        self.db.create_task(request).await
+    }
+
+    async fn update_task(&self, request: UpdateTaskRequest) -> ThingsResult<()> {
+        self.db.update_task(request).await
+    }
+
+    async fn complete_task(&self, uuid: &Uuid) -> ThingsResult<()> {
+        self.db.complete_task(uuid).await
+    }
+
+    async fn uncomplete_task(&self, uuid: &Uuid) -> ThingsResult<()> {
+        self.db.uncomplete_task(uuid).await
+    }
+
+    async fn delete_task(
+        &self,
+        uuid: &Uuid,
+        child_handling: DeleteChildHandling,
+    ) -> ThingsResult<()> {
+        self.db.delete_task(uuid, child_handling).await
+    }
+
+    async fn bulk_delete(&self, request: BulkDeleteRequest) -> ThingsResult<BulkOperationResult> {
+        self.db.bulk_delete(request).await
+    }
+
+    async fn bulk_move(&self, request: BulkMoveRequest) -> ThingsResult<BulkOperationResult> {
+        self.db.bulk_move(request).await
+    }
+
+    async fn bulk_update_dates(
+        &self,
+        request: BulkUpdateDatesRequest,
+    ) -> ThingsResult<BulkOperationResult> {
+        self.db.bulk_update_dates(request).await
+    }
+
+    async fn bulk_complete(
+        &self,
+        request: BulkCompleteRequest,
+    ) -> ThingsResult<BulkOperationResult> {
+        self.db.bulk_complete(request).await
+    }
+
+    // ---- Projects ----
+
+    async fn create_project(&self, request: CreateProjectRequest) -> ThingsResult<Uuid> {
+        self.db.create_project(request).await
+    }
+
+    async fn update_project(&self, request: UpdateProjectRequest) -> ThingsResult<()> {
+        self.db.update_project(request).await
+    }
+
+    async fn complete_project(
+        &self,
+        uuid: &Uuid,
+        child_handling: ProjectChildHandling,
+    ) -> ThingsResult<()> {
+        self.db.complete_project(uuid, child_handling).await
+    }
+
+    async fn delete_project(
+        &self,
+        uuid: &Uuid,
+        child_handling: ProjectChildHandling,
+    ) -> ThingsResult<()> {
+        self.db.delete_project(uuid, child_handling).await
+    }
+
+    // ---- Areas ----
+
+    async fn create_area(&self, request: CreateAreaRequest) -> ThingsResult<Uuid> {
+        self.db.create_area(request).await
+    }
+
+    async fn update_area(&self, request: UpdateAreaRequest) -> ThingsResult<()> {
+        self.db.update_area(request).await
+    }
+
+    async fn delete_area(&self, uuid: &Uuid) -> ThingsResult<()> {
+        self.db.delete_area(uuid).await
+    }
+
+    // ---- Tags ----
+
+    async fn create_tag(
+        &self,
+        request: CreateTagRequest,
+        force: bool,
+    ) -> ThingsResult<TagCreationResult> {
+        if force {
+            let uuid = self.db.create_tag_force(request).await?;
+            Ok(TagCreationResult::Created { uuid, is_new: true })
+        } else {
+            self.db.create_tag_smart(request).await
+        }
+    }
+
+    async fn update_tag(&self, request: UpdateTagRequest) -> ThingsResult<()> {
+        self.db.update_tag(request).await
+    }
+
+    async fn delete_tag(&self, uuid: &Uuid, remove_from_tasks: bool) -> ThingsResult<()> {
+        self.db.delete_tag(uuid, remove_from_tasks).await
+    }
+
+    async fn merge_tags(&self, source_uuid: &Uuid, target_uuid: &Uuid) -> ThingsResult<()> {
+        self.db.merge_tags(source_uuid, target_uuid).await
+    }
+
+    async fn add_tag_to_task(
+        &self,
+        task_uuid: &Uuid,
+        tag_title: &str,
+    ) -> ThingsResult<TagAssignmentResult> {
+        self.db.add_tag_to_task(task_uuid, tag_title).await
+    }
+
+    async fn remove_tag_from_task(&self, task_uuid: &Uuid, tag_title: &str) -> ThingsResult<()> {
+        self.db.remove_tag_from_task(task_uuid, tag_title).await
+    }
+
+    async fn set_task_tags(
+        &self,
+        task_uuid: &Uuid,
+        tag_titles: Vec<String>,
+    ) -> ThingsResult<Vec<TagMatch>> {
+        self.db.set_task_tags(task_uuid, tag_titles).await
+    }
+}


### PR DESCRIPTION
## Summary

- Introduces `MutationBackend` trait in `libs/things3-core/src/mutations/` with 22 async methods covering every Things 3 write operation exposed as an MCP tool (tasks, projects, areas, tags)
- Adds `SqlxBackend` wrapping the existing `ThingsDatabase` direct-DB methods — behavior is byte-for-byte identical to before
- Wires `ThingsMcpServer` to hold `Arc<dyn MutationBackend>`; all 22 MCP write handlers now dispatch through the trait instead of `self.db.*`
- Adds `ThingsMcpServer::with_mutation_backend()` constructor so #124 can inject `AppleScriptBackend` without touching existing callers

## Context

Part of #121, which is the architecture-scaffold step of the CulturedCode-safe migration tracked in #120. This PR is refactor-only — no behavior change. It unblocks:
- #124 (`AppleScriptBackend` for all 23 mutation ops)
- #125 (make AppleScript the default; gate SqlxBackend behind `--unsafe-direct-db`)

`bulk_create_tasks` is intentionally excluded — its MCP handler is still a placeholder mock that doesn't touch core. It will join the trait in #124 alongside its real AppleScript implementation.

## Test plan

- [x] `cargo build --workspace --all-features` — clean
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings` — clean
- [x] `cargo test -p things3-core --lib` — 420 passed
- [x] `cargo test -p things3-core --lib --features advanced-queries` — 497 passed
- [x] `cargo test -p things3-cli --all-features` — all suites passed (including legacy `test_bulk_create_tasks_tool`)
- [x] `cargo test -p things3-core --no-default-features` — clean
- [x] `cargo test -p things3-cli --no-default-features --features mcp-server` — clean
- [x] Pre-push hook (full test suite + `cargo audit`) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)