### PR TITLE
feat(mutations): promote bulk_create_tasks to MutationBackend trait

### DIFF
--- a/apps/things3-cli/src/mcp.rs
+++ b/apps/things3-cli/src/mcp.rs
@@ -1970,7 +1970,7 @@ impl ThingsMcpServer {
             "delete_area" => self.handle_delete_area(arguments).await,
             "get_productivity_metrics" => self.handle_get_productivity_metrics(arguments).await,
             "export_data" => self.handle_export_data(arguments).await,
-            "bulk_create_tasks" => Self::handle_bulk_create_tasks(&arguments),
+            "bulk_create_tasks" => self.handle_bulk_create_tasks(arguments).await,
             "get_recent_tasks" => self.handle_get_recent_tasks(arguments).await,
             "backup_database" => self.handle_backup_database(arguments).await,
             "restore_database" => self.handle_restore_database(arguments).await,
@@ -3016,16 +3016,32 @@ impl ThingsMcpServer {
         })
     }
 
-    fn handle_bulk_create_tasks(args: &Value) -> McpResult<CallToolResult> {
-        let tasks = args
-            .get("tasks")
+    async fn handle_bulk_create_tasks(&self, args: Value) -> McpResult<CallToolResult> {
+        // Validate top-level shape before delegating so we keep the historical
+        // "missing tasks" error contract — `serde_json::from_value` would also
+        // reject this, but with a less actionable error.
+        args.get("tasks")
             .and_then(|v| v.as_array())
             .ok_or_else(|| McpError::missing_parameter("tasks"))?;
 
+        let request: things3_core::models::BulkCreateTasksRequest = serde_json::from_value(args)
+            .map_err(|e| {
+                McpError::invalid_parameter(
+                    "tasks",
+                    format!("Failed to parse bulk_create_tasks request: {e}"),
+                )
+            })?;
+
+        let result = self
+            .mutations
+            .bulk_create_tasks(request)
+            .await
+            .map_err(|e| McpError::database_operation_failed("bulk_create_tasks", e))?;
+
         let response = serde_json::json!({
-            "message": "Bulk task creation not yet implemented",
-            "tasks_count": tasks.len(),
-            "status": "placeholder"
+            "success": result.success,
+            "processed_count": result.processed_count,
+            "message": result.message,
         });
 
         Ok(CallToolResult {

--- a/apps/things3-cli/src/mcp.rs
+++ b/apps/things3-cli/src/mcp.rs
@@ -1268,14 +1268,60 @@ impl ThingsMcpServer {
                     "properties": {
                         "tasks": {
                             "type": "array",
-                            "description": "Array of task objects to create",
+                            "description": "Array of task objects to create (1–1000 items)",
+                            "minItems": 1,
+                            "maxItems": 1000,
                             "items": {
                                 "type": "object",
                                 "properties": {
-                                    "title": {"type": "string"},
-                                    "notes": {"type": "string"},
-                                    "project_uuid": {"type": "string"},
-                                    "area_uuid": {"type": "string"}
+                                    "title": {
+                                        "type": "string",
+                                        "description": "Task title (required)"
+                                    },
+                                    "task_type": {
+                                        "type": "string",
+                                        "enum": ["to-do", "project", "heading"],
+                                        "description": "Task type (default: to-do)"
+                                    },
+                                    "notes": {
+                                        "type": "string",
+                                        "description": "Task notes"
+                                    },
+                                    "start_date": {
+                                        "type": "string",
+                                        "format": "date",
+                                        "description": "Start date (YYYY-MM-DD)"
+                                    },
+                                    "deadline": {
+                                        "type": "string",
+                                        "format": "date",
+                                        "description": "Deadline (YYYY-MM-DD)"
+                                    },
+                                    "project_uuid": {
+                                        "type": "string",
+                                        "format": "uuid",
+                                        "description": "Project UUID"
+                                    },
+                                    "area_uuid": {
+                                        "type": "string",
+                                        "format": "uuid",
+                                        "description": "Area UUID"
+                                    },
+                                    "parent_uuid": {
+                                        "type": "string",
+                                        "format": "uuid",
+                                        "description": "Parent task UUID (for subtasks)"
+                                    },
+                                    "tags": {
+                                        "type": "array",
+                                        "items": {"type": "string"},
+                                        "description": "Tag names"
+                                    },
+                                    "status": {
+                                        "type": "string",
+                                        "enum": ["incomplete", "completed", "canceled", "trashed"],
+                                        "description": "Initial status (default: incomplete)"
+                                    }
                                 },
                                 "required": ["title"]
                             }

--- a/apps/things3-cli/tests/mcp_tests_legacy.rs
+++ b/apps/things3-cli/tests/mcp_tests_legacy.rs
@@ -588,8 +588,8 @@ async fn test_bulk_create_tasks_tool() {
     match &result.content[0] {
         Content::Text { text } => {
             let parsed: serde_json::Value = serde_json::from_str(text).unwrap();
-            assert_eq!(parsed["tasks_count"], 2);
-            assert_eq!(parsed["status"], "placeholder");
+            assert_eq!(parsed["success"], true);
+            assert_eq!(parsed["processed_count"], 2);
         }
     }
 }

--- a/libs/things3-core/src/models.rs
+++ b/libs/things3-core/src/models.rs
@@ -479,6 +479,16 @@ pub struct BulkDeleteRequest {
     pub task_uuids: Vec<Uuid>,
 }
 
+/// Request to create multiple tasks in one call.
+///
+/// Bulk creation is best-effort and non-atomic — each task is attempted
+/// independently and per-item failures are surfaced via `BulkOperationResult`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BulkCreateTasksRequest {
+    /// Tasks to create
+    pub tasks: Vec<CreateTaskRequest>,
+}
+
 /// Result of a bulk operation
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BulkOperationResult {

--- a/libs/things3-core/src/mutations/mod.rs
+++ b/libs/things3-core/src/mutations/mod.rs
@@ -24,11 +24,11 @@ use uuid::Uuid;
 
 use crate::error::Result as ThingsResult;
 use crate::models::{
-    BulkCompleteRequest, BulkDeleteRequest, BulkMoveRequest, BulkOperationResult,
-    BulkUpdateDatesRequest, CreateAreaRequest, CreateProjectRequest, CreateTagRequest,
-    CreateTaskRequest, DeleteChildHandling, ProjectChildHandling, TagAssignmentResult,
-    TagCreationResult, TagMatch, UpdateAreaRequest, UpdateProjectRequest, UpdateTagRequest,
-    UpdateTaskRequest,
+    BulkCompleteRequest, BulkCreateTasksRequest, BulkDeleteRequest, BulkMoveRequest,
+    BulkOperationResult, BulkUpdateDatesRequest, CreateAreaRequest, CreateProjectRequest,
+    CreateTagRequest, CreateTaskRequest, DeleteChildHandling, ProjectChildHandling,
+    TagAssignmentResult, TagCreationResult, TagMatch, UpdateAreaRequest, UpdateProjectRequest,
+    UpdateTagRequest, UpdateTaskRequest,
 };
 
 mod sqlx;
@@ -43,6 +43,12 @@ pub trait MutationBackend: Send + Sync {
     // ---- Tasks ----
 
     async fn create_task(&self, request: CreateTaskRequest) -> ThingsResult<Uuid>;
+    /// Create multiple tasks in one call. Best-effort and non-atomic — per-item
+    /// failures are reported via `BulkOperationResult`.
+    async fn bulk_create_tasks(
+        &self,
+        request: BulkCreateTasksRequest,
+    ) -> ThingsResult<BulkOperationResult>;
     async fn update_task(&self, request: UpdateTaskRequest) -> ThingsResult<()>;
     async fn complete_task(&self, uuid: &Uuid) -> ThingsResult<()>;
     async fn uncomplete_task(&self, uuid: &Uuid) -> ThingsResult<()>;

--- a/libs/things3-core/src/mutations/sqlx.rs
+++ b/libs/things3-core/src/mutations/sqlx.rs
@@ -14,11 +14,11 @@ use super::MutationBackend;
 use crate::database::ThingsDatabase;
 use crate::error::Result as ThingsResult;
 use crate::models::{
-    BulkCompleteRequest, BulkDeleteRequest, BulkMoveRequest, BulkOperationResult,
-    BulkUpdateDatesRequest, CreateAreaRequest, CreateProjectRequest, CreateTagRequest,
-    CreateTaskRequest, DeleteChildHandling, ProjectChildHandling, TagAssignmentResult,
-    TagCreationResult, TagMatch, UpdateAreaRequest, UpdateProjectRequest, UpdateTagRequest,
-    UpdateTaskRequest,
+    BulkCompleteRequest, BulkCreateTasksRequest, BulkDeleteRequest, BulkMoveRequest,
+    BulkOperationResult, BulkUpdateDatesRequest, CreateAreaRequest, CreateProjectRequest,
+    CreateTagRequest, CreateTaskRequest, DeleteChildHandling, ProjectChildHandling,
+    TagAssignmentResult, TagCreationResult, TagMatch, UpdateAreaRequest, UpdateProjectRequest,
+    UpdateTagRequest, UpdateTaskRequest,
 };
 
 pub struct SqlxBackend {
@@ -38,6 +38,32 @@ impl MutationBackend for SqlxBackend {
 
     async fn create_task(&self, request: CreateTaskRequest) -> ThingsResult<Uuid> {
         self.db.create_task(request).await
+    }
+
+    async fn bulk_create_tasks(
+        &self,
+        request: BulkCreateTasksRequest,
+    ) -> ThingsResult<BulkOperationResult> {
+        let total = request.tasks.len();
+        let mut processed = 0usize;
+        let mut errors: Vec<String> = Vec::new();
+        for (idx, task) in request.tasks.into_iter().enumerate() {
+            match self.db.create_task(task).await {
+                Ok(_) => processed += 1,
+                Err(e) => errors.push(format!("task {idx}: {e}")),
+            }
+        }
+        let success = errors.is_empty();
+        let message = if success {
+            format!("Successfully created {processed} task(s)")
+        } else {
+            format!("Created {processed}/{total}; errors: {}", errors.join("; "))
+        };
+        Ok(BulkOperationResult {
+            success,
+            processed_count: processed,
+            message,
+        })
     }
 
     async fn update_task(&self, request: UpdateTaskRequest) -> ThingsResult<()> {

--- a/libs/things3-core/src/mutations/sqlx.rs
+++ b/libs/things3-core/src/mutations/sqlx.rs
@@ -44,6 +44,19 @@ impl MutationBackend for SqlxBackend {
         &self,
         request: BulkCreateTasksRequest,
     ) -> ThingsResult<BulkOperationResult> {
+        const MAX_BULK_BATCH_SIZE: usize = 1000;
+        if request.tasks.is_empty() {
+            return Err(crate::error::ThingsError::validation(
+                "Tasks array cannot be empty",
+            ));
+        }
+        if request.tasks.len() > MAX_BULK_BATCH_SIZE {
+            return Err(crate::error::ThingsError::validation(format!(
+                "Batch size {} exceeds maximum of {}",
+                request.tasks.len(),
+                MAX_BULK_BATCH_SIZE
+            )));
+        }
         let total = request.tasks.len();
         let mut processed = 0usize;
         let mut errors: Vec<String> = Vec::new();


### PR DESCRIPTION
## Summary

- Adds `BulkCreateTasksRequest` model (`{ tasks: Vec<CreateTaskRequest> }`) in `things3-core`
- Promotes `bulk_create_tasks` from a sync placeholder mock to a real `async fn` on the `MutationBackend` trait (partial #124)
- Implements `SqlxBackend::bulk_create_tasks` as a best-effort sequential loop — non-atomic, per-item failures surfaced via `BulkOperationResult`
- Rewires the MCP handler from the old sync placeholder to `self.mutations.bulk_create_tasks(req).await`
- Updates the legacy test assertion from `{status: "placeholder", tasks_count: N}` to `{success: true, processed_count: N}`

This is **PR A** of the two-part #124 split. PR B will add the full `AppleScriptBackend` for all 23 mutation operations.

## Test plan

- [ ] `cargo test -p things3-core --lib` — 420 tests pass
- [ ] `cargo test -p things3-cli --all-features` — all suites pass including both `bulk_create_tasks` legacy tests
- [ ] `cargo test -p things3-cli --no-default-features --features mcp-server` — passes
- [ ] `cargo clippy --workspace --all-features --all-targets -- -D warnings` — clean

Closes partial #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)