### PR TITLE
feat(mutations): AppleScriptBackend Phase A — escape, runner, error variant

### DIFF
--- a/apps/things3-cli/src/mcp.rs
+++ b/apps/things3-cli/src/mcp.rs
@@ -417,6 +417,9 @@ impl From<ThingsError> for McpError {
             ThingsError::DateConversion(e) => {
                 McpError::validation_error(format!("Date conversion failed: {e}"))
             }
+            ThingsError::AppleScript { message } => {
+                McpError::internal_error(format!("AppleScript automation failed: {message}"))
+            }
             ThingsError::Unknown { message } => McpError::internal_error(message),
         }
     }

--- a/libs/things3-core/src/error.rs
+++ b/libs/things3-core/src/error.rs
@@ -50,6 +50,9 @@ pub enum ThingsError {
     #[error("Configuration error: {message}")]
     Configuration { message: String },
 
+    #[error("AppleScript automation failed: {message}")]
+    AppleScript { message: String },
+
     #[error("Unknown error: {message}")]
     Unknown { message: String },
 }
@@ -72,6 +75,13 @@ impl ThingsError {
     /// Create an unknown error
     pub fn unknown(message: impl Into<String>) -> Self {
         Self::Unknown {
+            message: message.into(),
+        }
+    }
+
+    /// Create an AppleScript error
+    pub fn applescript(message: impl Into<String>) -> Self {
+        Self::AppleScript {
             message: message.into(),
         }
     }
@@ -198,6 +208,30 @@ mod tests {
 
         assert!(error.to_string().contains("Unknown error"));
         assert!(error.to_string().contains("Something went wrong"));
+    }
+
+    #[test]
+    fn test_applescript_error() {
+        let error = ThingsError::AppleScript {
+            message: "macOS Automation permission denied".to_string(),
+        };
+
+        assert!(error.to_string().contains("AppleScript automation failed"));
+        assert!(error
+            .to_string()
+            .contains("macOS Automation permission denied"));
+    }
+
+    #[test]
+    fn test_applescript_helper() {
+        let error = ThingsError::applescript("osascript not available");
+
+        match error {
+            ThingsError::AppleScript { message } => {
+                assert_eq!(message, "osascript not available");
+            }
+            _ => panic!("Expected AppleScript error"),
+        }
     }
 
     #[test]

--- a/libs/things3-core/src/mutations/applescript/escape.rs
+++ b/libs/things3-core/src/mutations/applescript/escape.rs
@@ -1,0 +1,159 @@
+//! AppleScript string-literal escaping.
+//!
+//! Every untrusted string (task title, notes, tag name, …) flowing into a
+//! script must pass through [`as_applescript_string`]. Without escaping, a
+//! title containing `"` ends the literal early — at best a syntax error, at
+//! worst arbitrary AppleScript injection.
+//!
+//! The returned value includes the surrounding `"` characters so callers can
+//! splice it directly into a script template:
+//!
+//! ```ignore
+//! let script = format!(
+//!     "make new to do with properties {{name:{}}}",
+//!     escape::as_applescript_string(title),
+//! );
+//! ```
+
+/// Escape `s` as an AppleScript string literal, with surrounding quotes.
+///
+/// The escape sequences `\\`, `\"`, `\n`, `\r`, `\t` are recognised by
+/// AppleScript on every macOS version Things 3 supports.
+#[allow(dead_code)] // Used by AppleScriptBackend, added in #134 (Phase B).
+#[must_use]
+pub(crate) fn as_applescript_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for ch in s.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::as_applescript_string;
+
+    #[test]
+    fn empty() {
+        assert_eq!(as_applescript_string(""), "\"\"");
+    }
+
+    #[test]
+    fn plain_ascii() {
+        assert_eq!(as_applescript_string("Hello world"), "\"Hello world\"");
+    }
+
+    #[test]
+    fn double_quote() {
+        assert_eq!(as_applescript_string("a\"b"), "\"a\\\"b\"");
+    }
+
+    #[test]
+    fn backslash() {
+        assert_eq!(as_applescript_string("a\\b"), "\"a\\\\b\"");
+    }
+
+    #[test]
+    fn newline() {
+        assert_eq!(as_applescript_string("a\nb"), "\"a\\nb\"");
+    }
+
+    #[test]
+    fn carriage_return() {
+        assert_eq!(as_applescript_string("a\rb"), "\"a\\rb\"");
+    }
+
+    #[test]
+    fn tab() {
+        assert_eq!(as_applescript_string("a\tb"), "\"a\\tb\"");
+    }
+
+    #[test]
+    fn mixed_whitespace() {
+        assert_eq!(
+            as_applescript_string("line1\n\tindented \"quoted\"\\\r"),
+            "\"line1\\n\\tindented \\\"quoted\\\"\\\\\\r\""
+        );
+    }
+
+    #[test]
+    fn unicode_passes_through() {
+        // Cyrillic, CJK, emoji — all valid inside an AppleScript string literal
+        assert_eq!(as_applescript_string("café"), "\"café\"");
+        assert_eq!(as_applescript_string("日本語"), "\"日本語\"");
+        assert_eq!(as_applescript_string("🚀"), "\"🚀\"");
+    }
+
+    #[test]
+    fn unicode_line_separators_pass_through() {
+        // U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR have no
+        // dedicated AppleScript escape; they're valid inside string literals
+        // so we leave them as-is.
+        assert_eq!(as_applescript_string("a\u{2028}b"), "\"a\u{2028}b\"");
+        assert_eq!(as_applescript_string("a\u{2029}b"), "\"a\u{2029}b\"");
+    }
+
+    #[test]
+    fn injection_attempt_is_neutralised() {
+        // The classic shell-style injection vector: a quote that breaks the
+        // string, then arbitrary AppleScript, then a continuation. After
+        // escaping, every special character is inside the string literal —
+        // no execution outside it is possible.
+        let payload = r#""); do shell script "rm -rf /"; (""#;
+        let escaped = as_applescript_string(payload);
+        // Output is one balanced literal — every interior `"` is escaped.
+        assert!(escaped.starts_with('"') && escaped.ends_with('"'));
+        // Count of unescaped quotes (preceded by even number of backslashes)
+        // is exactly 2 — the outer pair.
+        let body = &escaped[1..escaped.len() - 1];
+        for (i, ch) in body.char_indices() {
+            if ch == '"' {
+                // Must be preceded by an odd number of backslashes,
+                // i.e. escaped.
+                let preceding_backslashes =
+                    body[..i].chars().rev().take_while(|c| *c == '\\').count();
+                assert!(
+                    preceding_backslashes % 2 == 1,
+                    "unescaped quote at byte {i} in {escaped:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn long_runs_of_specials() {
+        assert_eq!(as_applescript_string("\\\\\\\""), "\"\\\\\\\\\\\\\\\"\"");
+    }
+
+    #[test]
+    fn round_trip_via_pure_concat() {
+        // A practical test: build a synthetic script, count escaped quotes,
+        // confirm balance.
+        let title = "Buy \"organic\" milk\nand \\bread\t";
+        let snippet = format!(
+            "make new to do with properties {{name:{}, notes:{}}}",
+            as_applescript_string(title),
+            as_applescript_string("multi\nline\nnote"),
+        );
+        // Quotes in the snippet, excluding escaped ones, should be exactly
+        // 4 — the bounding pair around each of the two literals.
+        let mut unescaped_quotes = 0;
+        let mut prev = '\0';
+        for ch in snippet.chars() {
+            if ch == '"' && prev != '\\' {
+                unescaped_quotes += 1;
+            }
+            prev = ch;
+        }
+        assert_eq!(unescaped_quotes, 4, "snippet was: {snippet:?}");
+    }
+}

--- a/libs/things3-core/src/mutations/applescript/mod.rs
+++ b/libs/things3-core/src/mutations/applescript/mod.rs
@@ -1,0 +1,19 @@
+//! AppleScript-based mutation backend.
+//!
+//! Drives Things 3 via `osascript` — CulturedCode's [documented Mac-only
+//! scripting API](https://culturedcode.com/things/support/articles/4562654/).
+//! Replaces direct-SQLite writes (which CulturedCode warns can corrupt the
+//! user's database — see [the safety
+//! article](https://culturedcode.com/things/support/articles/5510170/)) for
+//! every mutation operation rust-things3 exposes.
+//!
+//! ## Layout
+//!
+//! - [`escape`] — pure string-literal escaping; the script-injection guard
+//! - [`runner`] — `osascript` process spawn + error mapping
+//! - The `AppleScriptBackend` struct and `MutationBackend` impl land in #134
+//!   (Phase B); this module is gated `#[cfg(target_os = "macos")]` and
+//!   currently only exposes the foundation pieces.
+
+pub(crate) mod escape;
+pub(crate) mod runner;

--- a/libs/things3-core/src/mutations/applescript/runner.rs
+++ b/libs/things3-core/src/mutations/applescript/runner.rs
@@ -42,6 +42,9 @@ pub(crate) async fn run_script(script: &str) -> Result<String> {
         .shutdown()
         .await
         .map_err(|e| ThingsError::applescript(format!("failed to close stdin: {e}")))?;
+    // Explicitly drop stdin to close the write end of the pipe. shutdown() marks
+    // the stream done but does not close the fd on Unix pipes — osascript hangs
+    // waiting for more input until the write end is closed.
     drop(stdin);
 
     let output = child
@@ -165,5 +168,21 @@ mod tests {
             .await
             .expect("osascript should run");
         assert!(out.contains("hello"));
+    }
+
+    #[tokio::test]
+    async fn run_script_escaped_string_round_trips() {
+        use crate::mutations::applescript::escape::as_applescript_string;
+
+        let title = "Buy \"organic\" milk\nand \\bread";
+        let escaped = as_applescript_string(title);
+        let script = format!("return {escaped}");
+        let out = run_script(&script).await.expect("osascript should run");
+        // Inner double-quote didn't break the string literal — "organic" is present
+        assert!(out.contains("organic"), "output was: {out:?}");
+        // Text after embedded newline survived
+        assert!(out.contains("bread"), "output was: {out:?}");
+        // Backslash round-tripped: \\ in source → single \ in output
+        assert!(out.contains('\\'), "output was: {out:?}");
     }
 }

--- a/libs/things3-core/src/mutations/applescript/runner.rs
+++ b/libs/things3-core/src/mutations/applescript/runner.rs
@@ -1,0 +1,169 @@
+//! `osascript` runner.
+//!
+//! Spawns `osascript -` and feeds the script via stdin. Piping through stdin
+//! sidesteps every shell-escaping vector — the script bytes are not
+//! interpreted by any shell.
+
+use std::process::Stdio;
+
+use tokio::io::AsyncWriteExt;
+use tokio::process::Command;
+
+use crate::error::{Result, ThingsError};
+
+/// Spawn `osascript`, pipe `script` via stdin, and return the captured stdout.
+///
+/// On non-zero exit, errors are mapped to [`ThingsError::AppleScript`] with
+/// messages tailored to the failure mode (TCC denied, Things 3 not running,
+/// osascript missing, generic).
+#[allow(dead_code)] // Used by AppleScriptBackend, added in #134 (Phase B).
+pub(crate) async fn run_script(script: &str) -> Result<String> {
+    let mut child = Command::new("osascript")
+        .arg("-")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| {
+            ThingsError::applescript(format!(
+                "osascript not available — AppleScriptBackend is macOS-only ({e})"
+            ))
+        })?;
+
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| ThingsError::applescript("osascript stdin not piped"))?;
+    stdin
+        .write_all(script.as_bytes())
+        .await
+        .map_err(|e| ThingsError::applescript(format!("failed to write script: {e}")))?;
+    stdin
+        .shutdown()
+        .await
+        .map_err(|e| ThingsError::applescript(format!("failed to close stdin: {e}")))?;
+    drop(stdin);
+
+    let output = child
+        .wait_with_output()
+        .await
+        .map_err(|e| ThingsError::applescript(format!("osascript wait failed: {e}")))?;
+
+    if output.status.success() {
+        return Ok(String::from_utf8_lossy(&output.stdout).into_owned());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    Err(map_failure(&stderr))
+}
+
+fn map_failure(stderr: &str) -> ThingsError {
+    let lowered = stderr.to_lowercase();
+    if stderr.contains("-1743") || lowered.contains("not authori") {
+        return ThingsError::applescript(
+            "macOS Automation permission denied. Grant access in \
+             System Settings → Privacy & Security → Automation, then retry.",
+        );
+    }
+    if stderr.contains("-600") || stderr.contains("Application isn't running") {
+        return ThingsError::applescript("Things 3 is not running. Launch Things 3 and retry.");
+    }
+    if stderr.contains("-10810") || stderr.contains("NSWorkspaceNotFound") {
+        return ThingsError::applescript("Things 3 is not installed at the expected location.");
+    }
+    ThingsError::applescript(format!("osascript failed: {}", stderr.trim()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn map_failure_tcc_denied() {
+        let err = map_failure("execution error: Not authorized to send Apple events. (-1743)");
+        match err {
+            ThingsError::AppleScript { message } => {
+                assert!(message.contains("Automation permission denied"));
+                assert!(message.contains("System Settings"));
+            }
+            _ => panic!("expected AppleScript error"),
+        }
+    }
+
+    #[test]
+    fn map_failure_not_running() {
+        let err =
+            map_failure("execution error: Things3 got an error: Application isn't running. (-600)");
+        match err {
+            ThingsError::AppleScript { message } => {
+                assert!(message.contains("Things 3 is not running"));
+            }
+            _ => panic!("expected AppleScript error"),
+        }
+    }
+
+    #[test]
+    fn map_failure_not_installed() {
+        let err = map_failure("execution error: NSWorkspaceNotFound (-10810)");
+        match err {
+            ThingsError::AppleScript { message } => {
+                assert!(message.contains("not installed"));
+            }
+            _ => panic!("expected AppleScript error"),
+        }
+    }
+
+    #[test]
+    fn map_failure_generic() {
+        let err = map_failure("syntax error: bad keyword");
+        match err {
+            ThingsError::AppleScript { message } => {
+                assert!(message.contains("osascript failed"));
+                assert!(message.contains("syntax error"));
+            }
+            _ => panic!("expected AppleScript error"),
+        }
+    }
+
+    #[test]
+    fn map_failure_trims_whitespace() {
+        let err = map_failure("  some error\n");
+        match err {
+            ThingsError::AppleScript { message } => {
+                assert_eq!(message, "osascript failed: some error");
+            }
+            _ => panic!("expected AppleScript error"),
+        }
+    }
+
+    #[tokio::test]
+    async fn run_script_returns_stdout_for_arithmetic() {
+        let out = run_script("return 1 + 1")
+            .await
+            .expect("osascript should run");
+        assert_eq!(out.trim(), "2");
+    }
+
+    #[tokio::test]
+    async fn run_script_maps_runtime_error() {
+        // Force AppleScript to raise an error number we don't special-case.
+        let err = run_script("error \"deliberate failure\" number 99")
+            .await
+            .expect_err("script should fail");
+        match err {
+            ThingsError::AppleScript { message } => {
+                assert!(message.contains("osascript failed"));
+                assert!(message.contains("deliberate failure"));
+            }
+            _ => panic!("expected AppleScript error, got {err:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn run_script_handles_string_return() {
+        let out = run_script("return \"hello\"")
+            .await
+            .expect("osascript should run");
+        assert!(out.contains("hello"));
+    }
+}

--- a/libs/things3-core/src/mutations/mod.rs
+++ b/libs/things3-core/src/mutations/mod.rs
@@ -34,6 +34,9 @@ use crate::models::{
 mod sqlx;
 pub use sqlx::SqlxBackend;
 
+#[cfg(target_os = "macos")]
+mod applescript;
+
 /// Abstraction over every Things 3 mutation operation exposed as an MCP tool.
 ///
 /// All implementations must be `Send + Sync` so the server can share them across


### PR DESCRIPTION
## Summary

Foundation pieces for the AppleScript backend (#124), landing in Phase A (#133). **No behavior change for users** — this PR adds plumbing only; no `MutationBackend` impl yet.

- **`libs/things3-core/src/mutations/applescript/`** (new, `#[cfg(target_os = "macos")]`):
  - `escape.rs` — `as_applescript_string` builds quoted AppleScript string literals with full escaping (`\\`, `\"`, `\n`, `\r`, `\t`); 13 unit tests including injection-attempt round-trip
  - `runner.rs` — async `run_script` spawns `osascript -` with script fed via stdin (no shell-escape vector); stderr mapped to `ThingsError::AppleScript` with tailored messages for TCC denial, Things 3 not running, and missing osascript
- **`ThingsError::AppleScript { message }`** — new error variant + `applescript()` helper
- **`mcp.rs`** — `From<ThingsError>` match covers the new variant

## Test plan

- [x] `cargo test --workspace` — all 520 tests pass (21 new)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] Live `osascript` integration tests: arithmetic return, runtime error mapping, string return — all pass against real osascript on macOS
- [x] Pre-push hook passed (full test suite + `cargo audit`)

Closes #133. Unblocks #134 (Phase B — task ops via `AppleScriptBackend`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)