### PR TITLE
fix(applescript): #142 review followups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bulk op runs as a single `osascript` invocation with per-item `try`/`on error` blocks; partial
   failures surface via `BulkOperationResult.message`. The 1000-item batch cap and empty-array
   validation mirror `SqlxBackend`. Tag operations remain stubbed (Phase D, #136).
+- **AppleScriptBackend Phase C followups** — post-merge hardening of #142:
+  - Document the fail-fast contract on the remaining cascade/orphan project
+    script builders (`cascade_delete_project_script`,
+    `orphan_complete_project_script`, `orphan_delete_project_script`) to
+    match `cascade_complete_project_script`.
+  - Cap project-cascade child counts at `MAX_BULK_BATCH_SIZE` in
+    `complete_project` and `delete_project` so the generated osascript
+    payload stays bounded for the same reason `bulk_*` operations cap.
+  - Replace the silent `bulk_wrap(&[])` no-op fallback in `bulk_move_script`
+    with `unreachable!`, asserting the destination invariant the caller
+    already validates.
+  - Clamp `parse_bulk_result`'s `processed` count against `total` so a
+    future script-generation bug cannot report more processed items than
+    were requested.
 - **`ThingsId` type** (#139) — `things3_core::ThingsId` is a transparent newtype over `String`
   that accepts both RFC-4122 UUIDs (from `SqlxBackend`-created entities, e.g.
   `550e8400-e29b-41d4-a716-446655440000`) and Things native IDs (21–22-char base62 strings the

--- a/libs/things3-core/src/mutations/applescript/mod.rs
+++ b/libs/things3-core/src/mutations/applescript/mod.rs
@@ -308,7 +308,7 @@ impl MutationBackend for AppleScriptBackend {
 
         if children.len() > MAX_BULK_BATCH_SIZE {
             return Err(ThingsError::validation(format!(
-                "project {id} has {} child task(s), which exceeds maximum of {MAX_BULK_BATCH_SIZE}",
+                "Batch size {} exceeds maximum of {MAX_BULK_BATCH_SIZE}",
                 children.len(),
             )));
         }
@@ -342,7 +342,7 @@ impl MutationBackend for AppleScriptBackend {
 
         if children.len() > MAX_BULK_BATCH_SIZE {
             return Err(ThingsError::validation(format!(
-                "project {id} has {} child task(s), which exceeds maximum of {MAX_BULK_BATCH_SIZE}",
+                "Batch size {} exceeds maximum of {MAX_BULK_BATCH_SIZE}",
                 children.len(),
             )));
         }

--- a/libs/things3-core/src/mutations/applescript/mod.rs
+++ b/libs/things3-core/src/mutations/applescript/mod.rs
@@ -306,6 +306,13 @@ impl MutationBackend for AppleScriptBackend {
             return Ok(());
         }
 
+        if children.len() > MAX_BULK_BATCH_SIZE {
+            return Err(ThingsError::validation(format!(
+                "project {id} has {} child task(s), which exceeds maximum of {MAX_BULK_BATCH_SIZE}",
+                children.len(),
+            )));
+        }
+
         let script = match child_handling {
             ProjectChildHandling::Error => {
                 return Err(ThingsError::applescript(format!(
@@ -331,6 +338,13 @@ impl MutationBackend for AppleScriptBackend {
             let script = script::delete_project_script(id);
             runner::run_script(&script).await?;
             return Ok(());
+        }
+
+        if children.len() > MAX_BULK_BATCH_SIZE {
+            return Err(ThingsError::validation(format!(
+                "project {id} has {} child task(s), which exceeds maximum of {MAX_BULK_BATCH_SIZE}",
+                children.len(),
+            )));
         }
 
         let script = match child_handling {

--- a/libs/things3-core/src/mutations/applescript/parse.rs
+++ b/libs/things3-core/src/mutations/applescript/parse.rs
@@ -70,6 +70,10 @@ pub(crate) fn parse_bulk_result(stdout: &str, total: usize) -> Result<BulkOperat
             ))
         })?;
 
+    // Clamp against `total` to keep the count coherent if a script-generation
+    // bug ever reports more processed items than were requested.
+    let processed = processed.min(total);
+
     let errors: Vec<String> = lines.map(|l| l.trim().to_string()).collect();
     let success = errors.is_empty();
     let message = if success {
@@ -195,6 +199,16 @@ mod tests {
         let res = parse_bulk_result("OK 0\n", 0).unwrap();
         assert!(res.success);
         assert_eq!(res.processed_count, 0);
+    }
+
+    #[test]
+    fn parse_bulk_clamps_processed_to_total() {
+        // Defensive: if a future script-generation bug ever reports more
+        // processed items than were requested, the parser must not return a
+        // count that exceeds `total`.
+        let res = parse_bulk_result("OK 10\n", 5).unwrap();
+        assert!(res.success);
+        assert_eq!(res.processed_count, 5);
     }
 
     #[test]

--- a/libs/things3-core/src/mutations/applescript/script.rs
+++ b/libs/things3-core/src/mutations/applescript/script.rs
@@ -307,6 +307,7 @@ pub(crate) fn cascade_complete_project_script(
 
 /// Build a cascading delete-project script: deletes every child task in
 /// `child_ids`, then deletes the project. Single osascript invocation.
+/// Fail-fast — if any sub-statement raises, the project is left untouched.
 #[allow(dead_code)] // Used by AppleScriptBackend, added in #135.
 pub(crate) fn cascade_delete_project_script(
     project_id: &ThingsId,
@@ -322,6 +323,7 @@ pub(crate) fn cascade_delete_project_script(
 
 /// Build an orphan-then-complete-project script: detaches every child task
 /// (`set project to missing value`), then completes the project.
+/// Fail-fast — if any sub-statement raises, the project is left untouched.
 #[allow(dead_code)] // Used by AppleScriptBackend, added in #135.
 pub(crate) fn orphan_complete_project_script(
     project_id: &ThingsId,
@@ -341,6 +343,7 @@ pub(crate) fn orphan_complete_project_script(
 
 /// Build an orphan-then-delete-project script: detaches every child task,
 /// then deletes the project.
+/// Fail-fast — if any sub-statement raises, the project is left untouched.
 #[allow(dead_code)] // Used by AppleScriptBackend, added in #135.
 pub(crate) fn orphan_delete_project_script(
     project_id: &ThingsId,
@@ -521,8 +524,10 @@ pub(crate) fn bulk_move_script(req: &BulkMoveRequest) -> String {
     } else if let Some(uuid) = &req.area_uuid {
         format!("area id \"{uuid}\"")
     } else {
-        // Caller validates this; emitting a no-op script keeps generation total.
-        return bulk_wrap(&[]);
+        unreachable!(
+            "bulk_move_script called without project_uuid or area_uuid; \
+             bulk_move() must validate before constructing the script"
+        );
     };
     let snippets: Vec<String> = req
         .task_uuids
@@ -1123,6 +1128,17 @@ mod tests {
             sample_uuid(),
             project_uuid()
         )));
+    }
+
+    #[test]
+    #[should_panic(expected = "bulk_move_script called without project_uuid or area_uuid")]
+    fn bulk_move_without_destination_panics() {
+        let req = BulkMoveRequest {
+            task_uuids: vec![sample_uuid()],
+            project_uuid: None,
+            area_uuid: None,
+        };
+        let _ = bulk_move_script(&req);
     }
 
     #[test]


### PR DESCRIPTION
## Description

Four post-merge hardening changes to the AppleScriptBackend Phase C work merged in #142. None alter behaviour for valid inputs; each codifies an invariant that was previously implicit.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [x] Code refactoring
- [x] Test improvements
- [ ] Build / CI improvements

## Related Issues

Relates to #142

## Changes Made

1. **Document fail-fast cascade contract on the remaining script builders**
   `cascade_complete_project_script` already documented its fail-fast (`wrap()`) contract; its three siblings did not. Adds the same one-liner to `cascade_delete_project_script`, `orphan_complete_project_script`, and `orphan_delete_project_script` so future maintainers comparing against `bulk_*_script` (which uses `bulk_wrap()` for partial success) see the contract difference at the call site. Doc-only.

   `libs/things3-core/src/mutations/applescript/script.rs` (lines 308-309, 323-324, 342-343).

2. **Cap project-cascade child count at `MAX_BULK_BATCH_SIZE`**
   `bulk_delete` / `bulk_move` / `bulk_complete` / `bulk_update_dates` already cap input batches at 1000. The cascade arms of `complete_project` and `delete_project` did not — `list_project_task_uuids` could return any number of children, and the generated osascript script grew with it. Adds the same validation check to both project handlers.

   `libs/things3-core/src/mutations/applescript/mod.rs` (after the empty-children early return in both `complete_project` and `delete_project`).

3. **Replace `bulk_wrap(&[])` no-op fallback with `unreachable!`**
   `bulk_move_script` had a fallback for the case where both `project_uuid` and `area_uuid` were `None`. The caller `bulk_move` already validates this and returns an error before constructing the script. The silent fallback turned a programmer error into a runtime no-op (`"OK 0"`). Replacing with `unreachable!` makes the invariant explicit.

   `libs/things3-core/src/mutations/applescript/script.rs:524-528`.

4. **Clamp `parse_bulk_result` `processed` count against `total`**
   `parse_bulk_result` parsed `processed` from `OK <count>` and used it raw in `BulkOperationResult::processed_count`. A future bug in script generation could report `processed > total`. Adds `processed.min(total)` so the counter cannot overshoot the requested batch size.

   `libs/things3-core/src/mutations/applescript/parse.rs:71-73`.

## Testing

- [x] All existing tests pass (`cargo test --workspace`)
- [x] Added new tests for new functionality
- [ ] Tested manually
- [x] Updated documentation

New tests:
- `bulk_move_without_destination_panics` — `#[should_panic]` covers the new `unreachable!`.
- `parse_bulk_clamps_processed_to_total` — feeds `"OK 10"` with `total=5` and asserts `processed_count == 5`.

```bash
cargo test -p things3-core --lib mutations::applescript
# → 76 passed; 0 failed; 1 ignored
cargo clippy -p things3-core --lib -- -D warnings
cargo fmt --check
```

## Documentation

- [x] Updated rustdoc comments
- [ ] Updated README.md
- [ ] Updated user documentation (docs/)
- [ ] Added/updated examples
- [x] Updated CHANGELOG.md
- [ ] No documentation needed

`CHANGELOG.md` gains an "AppleScriptBackend Phase C followups" entry under `[Unreleased]` describing the four changes.

## Performance Impact

- [x] No performance impact

## Breaking Changes

- [ ] This PR introduces breaking changes

The cascade cap is a new validation error for projects with >1000 children, which previously generated very large osascript payloads. Real-world Things 3 projects do not approach this size, so this should be observationally invisible.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.**