### PR TITLE
feat(mutations): AppleScriptBackend Phase D — tag operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **AppleScriptBackend Phase D: tag operations** (#136) — implements the remaining 7
+  `MutationBackend` stubs in `AppleScriptBackend`: `create_tag` (with `force` flag, smart-flow
+  read via `find_tag_by_normalized_title` + `find_similar_tags` ≥0.8 before any AS write),
+  `update_tag`, `delete_tag` (`remove_from_tasks=true` rewrites each affected task's `tag names`
+  in a single bulk osascript invocation, then deletes the tag — a strict capability improvement
+  over `SqlxBackend`, which has this branch as a TODO), `merge_tags` (replaces source with target
+  in every affected task's `tag names`, then deletes source), `add_tag_to_task`,
+  `remove_tag_from_task`, `set_task_tags`. Three methods are read+write hybrids: the read side
+  computes similarity scores from the live DB and short-circuits with `Suggestions` /
+  `SimilarFound` before any AS spawn, while only the unambiguous-write path routes through
+  osascript. Things AppleScript does not expose `shortcut` or `parent` properties on `tag`, so
+  `CreateTagRequest::shortcut` / `parent_uuid` and the equivalents on `UpdateTagRequest` are
+  silently dropped with a `tracing::debug!` log. Closes #124 once Phase E (#137) lands.
 - **AppleScriptBackend Phase C: projects, areas, bulk operations** (#135) — implements 12 of the 16
   remaining `MutationBackend` stubs in `AppleScriptBackend`: `create_project`, `update_project`,
   `complete_project`, `delete_project` (all three `ProjectChildHandling` modes — Error, Cascade,

--- a/libs/things3-core/src/mutations/applescript/mod.rs
+++ b/libs/things3-core/src/mutations/applescript/mod.rs
@@ -151,12 +151,18 @@ impl AppleScriptBackend {
     ) -> ThingsResult<Vec<(ThingsId, Vec<String>)>> {
         use crate::database::tag_utils::normalize_tag_title;
 
-        let escaped = tag_title.replace('%', "\\%").replace('_', "\\_");
+        // SQLite LIKE only treats `\` as an escape when paired with an explicit
+        // ESCAPE clause; without it `\_` is a literal two-char sequence and a
+        // tag containing `_` or `%` would silently skip its tasks.
+        let escaped = tag_title
+            .replace('\\', "\\\\")
+            .replace('%', "\\%")
+            .replace('_', "\\_");
         let pattern = format!("%\"{escaped}\"%");
         let rows = sqlx::query(
-            "SELECT uuid, cachedTags FROM TMTask
+            r"SELECT uuid, cachedTags FROM TMTask
              WHERE cachedTags IS NOT NULL
-             AND json_extract(cachedTags, '$') LIKE ?
+             AND json_extract(cachedTags, '$') LIKE ? ESCAPE '\'
              AND trashed = 0",
         )
         .bind(&pattern)
@@ -912,6 +918,43 @@ mod tests {
             .await
             .expect("query nonexistent");
         assert!(not_found.is_empty(), "no tasks should match an absent tag");
+    }
+
+    /// Tag titles containing SQL LIKE wildcards (`_`, `%`) must still match
+    /// their exact tasks — the pre-filter escapes wildcards via `ESCAPE '\'`.
+    /// Regression: previously `replace('_', "\\_")` produced a literal `\_`
+    /// that didn't match because the LIKE clause had no `ESCAPE`.
+    #[tokio::test]
+    async fn list_tasks_with_tag_title_handles_underscore_in_tag_name() {
+        let (db, _tmp) = crate::test_utils::create_test_database_and_connect()
+            .await
+            .expect("test db");
+
+        let task_id = ThingsId::new_v4();
+        let blob =
+            crate::database::serialize_tags_to_blob(&["to_do".to_string()]).expect("serialize");
+        let now = 1_700_000_000.0_f64;
+        sqlx::query(
+            "INSERT INTO TMTask \
+             (uuid, title, type, status, trashed, cachedTags, creationDate, userModificationDate) \
+             VALUES (?, 'Task with underscored tag', 0, 0, 0, ?, ?, ?)",
+        )
+        .bind(task_id.as_str())
+        .bind(&blob)
+        .bind(now)
+        .bind(now)
+        .execute(&db.pool)
+        .await
+        .expect("insert");
+
+        let backend = AppleScriptBackend::new(Arc::new(db));
+
+        let found = backend
+            .list_tasks_with_tag_title("to_do")
+            .await
+            .expect("query");
+        assert_eq!(found.len(), 1, "should match tag name with underscore");
+        assert_eq!(found[0].0.as_str(), task_id.as_str());
     }
 
     /// `merge_tags` rejects identical source/target with a Validation error.

--- a/libs/things3-core/src/mutations/applescript/mod.rs
+++ b/libs/things3-core/src/mutations/applescript/mod.rs
@@ -151,7 +151,8 @@ impl AppleScriptBackend {
     ) -> ThingsResult<Vec<(ThingsId, Vec<String>)>> {
         use crate::database::tag_utils::normalize_tag_title;
 
-        let pattern = format!("%\"{tag_title}\"%");
+        let escaped = tag_title.replace('%', "\\%").replace('_', "\\_");
+        let pattern = format!("%\"{escaped}\"%");
         let rows = sqlx::query(
             "SELECT uuid, cachedTags FROM TMTask
              WHERE cachedTags IS NOT NULL
@@ -686,10 +687,14 @@ impl MutationBackend for AppleScriptBackend {
 
         let normalized = normalize_tag_title(tag_title);
         let current = self.read_task_tag_titles(task_id).await?;
+        let original_len = current.len();
         let new_list: Vec<String> = current
             .into_iter()
             .filter(|t| normalize_tag_title(t) != normalized)
             .collect();
+        if new_list.len() == original_len {
+            return Ok(());
+        }
         let joined = new_list.join(", ");
         let script = script::set_task_tag_names_script(task_id, &joined);
         runner::run_script(&script).await?;
@@ -703,6 +708,9 @@ impl MutationBackend for AppleScriptBackend {
     ) -> ThingsResult<Vec<TagMatch>> {
         use crate::database::tag_utils::normalize_tag_title;
 
+        // Intentionally asymmetric with add_tag_to_task: similar-tag suggestions
+        // accumulate for the caller but never block the write — every title is
+        // auto-created if absent, matching ThingsDatabase::set_task_tags semantics.
         let mut suggestions: Vec<TagMatch> = Vec::new();
         let mut resolved: Vec<String> = Vec::with_capacity(tag_titles.len());
 
@@ -857,6 +865,53 @@ mod tests {
             }
             other => panic!("expected Suggestions, got {other:?}"),
         }
+    }
+
+    /// `list_tasks_with_tag_title` (the read-side helper backing
+    /// `delete_tag(remove_from_tasks=true)`) correctly finds tasks whose
+    /// `cachedTags` blob contains the target tag, and deserializes the full
+    /// tag list per task. Also confirms that an unrelated tag name returns
+    /// no results.
+    #[tokio::test]
+    async fn delete_tag_remove_from_tasks_finds_tagged_tasks() {
+        let (db, _tmp) = crate::test_utils::create_test_database_and_connect()
+            .await
+            .expect("test db");
+
+        let task_id = ThingsId::new_v4();
+        let blob =
+            crate::database::serialize_tags_to_blob(&["Work".to_string(), "Personal".to_string()])
+                .expect("serialize");
+        let now = 1_700_000_000.0_f64;
+        sqlx::query(
+            "INSERT INTO TMTask \
+             (uuid, title, type, status, trashed, cachedTags, creationDate, userModificationDate) \
+             VALUES (?, 'Tagged Task', 0, 0, 0, ?, ?, ?)",
+        )
+        .bind(task_id.as_str())
+        .bind(&blob)
+        .bind(now)
+        .bind(now)
+        .execute(&db.pool)
+        .await
+        .expect("insert tagged task");
+
+        let backend = AppleScriptBackend::new(Arc::new(db));
+
+        let found = backend
+            .list_tasks_with_tag_title("Work")
+            .await
+            .expect("query");
+        assert_eq!(found.len(), 1, "should find exactly one tagged task");
+        let (found_id, found_tags) = &found[0];
+        assert_eq!(found_id.as_str(), task_id.as_str());
+        assert_eq!(found_tags, &["Work", "Personal"]);
+
+        let not_found = backend
+            .list_tasks_with_tag_title("Nonexistent")
+            .await
+            .expect("query nonexistent");
+        assert!(not_found.is_empty(), "no tasks should match an absent tag");
     }
 
     /// `merge_tags` rejects identical source/target with a Validation error.

--- a/libs/things3-core/src/mutations/applescript/mod.rs
+++ b/libs/things3-core/src/mutations/applescript/mod.rs
@@ -16,14 +16,13 @@
 //! - This module ([`AppleScriptBackend`]) — wires the four together behind the
 //!   [`crate::mutations::MutationBackend`] trait. Gated `#[cfg(target_os = "macos")]`.
 //!
-//! ## Phase B scope (#134)
+//! ## Implementation status
 //!
-//! Only the five most-used task methods are implemented end-to-end:
-//! `create_task`, `update_task`, `complete_task`, `uncomplete_task`,
-//! `delete_task`. The remaining 16 trait methods return
-//! [`ThingsError::AppleScript`] with a message pointing at the issue tracking
-//! the relevant phase. Until #125 ships, no production code constructs an
-//! `AppleScriptBackend`, so these stubs are unreachable in the default config.
+//! All 21 [`MutationBackend`] methods are implemented end-to-end:
+//! tasks (Phase B, #134), projects/areas/bulk ops (Phase C, #135), and tags
+//! (Phase D, #136). Live integration tests + the production default-switch
+//! land in Phase E (#137) and #125 respectively. Until #125 ships, no
+//! production code constructs an `AppleScriptBackend`.
 
 pub(crate) mod escape;
 pub(crate) mod parse;
@@ -102,17 +101,105 @@ impl AppleScriptBackend {
             })
             .collect())
     }
+
+    /// Read the title of a tag by UUID. Errors if the tag doesn't exist.
+    /// Used by `merge_tags` and `delete_tag(remove_from_tasks=true)` to find
+    /// what tag-name to look for in tasks' `cachedTags`.
+    async fn read_tag_title(&self, id: &ThingsId) -> ThingsResult<String> {
+        let row = sqlx::query("SELECT title FROM TMTag WHERE uuid = ?")
+            .bind(id.as_str())
+            .fetch_optional(&self.db.pool)
+            .await
+            .map_err(|e| ThingsError::applescript(format!("failed to read tag {id}: {e}")))?;
+        let row = row.ok_or_else(|| ThingsError::applescript(format!("tag not found: {id}")))?;
+        Ok(row.get("title"))
+    }
+
+    /// Read a task's current tag-title list from the DB's `cachedTags` blob.
+    /// Returns an empty list if the task has no tags. Errors if the task
+    /// doesn't exist.
+    ///
+    /// CulturedCode-safe: read-only access.
+    async fn read_task_tag_titles(&self, task_id: &ThingsId) -> ThingsResult<Vec<String>> {
+        let row = sqlx::query("SELECT cachedTags FROM TMTask WHERE uuid = ?")
+            .bind(task_id.as_str())
+            .fetch_optional(&self.db.pool)
+            .await
+            .map_err(|e| {
+                ThingsError::applescript(format!("failed to read tags for task {task_id}: {e}"))
+            })?;
+        let row =
+            row.ok_or_else(|| ThingsError::applescript(format!("task not found: {task_id}")))?;
+        let blob: Option<Vec<u8>> = row.get("cachedTags");
+        match blob {
+            None => Ok(Vec::new()),
+            Some(b) => crate::database::deserialize_tags_from_blob(&b),
+        }
+    }
+
+    /// List `(task_id, current_tag_titles)` for every non-trashed task whose
+    /// `cachedTags` contains a tag matching `tag_title` (case-insensitive
+    /// after `normalize_tag_title`). Used by `merge_tags` and
+    /// `delete_tag(remove_from_tasks=true)` to plan per-task rewrites.
+    ///
+    /// Pre-filters via `json_extract(cachedTags, '$') LIKE` to narrow the
+    /// candidate set, then deserializes each blob and re-checks the
+    /// normalized title to drop false positives.
+    async fn list_tasks_with_tag_title(
+        &self,
+        tag_title: &str,
+    ) -> ThingsResult<Vec<(ThingsId, Vec<String>)>> {
+        use crate::database::tag_utils::normalize_tag_title;
+
+        let pattern = format!("%\"{tag_title}\"%");
+        let rows = sqlx::query(
+            "SELECT uuid, cachedTags FROM TMTask
+             WHERE cachedTags IS NOT NULL
+             AND json_extract(cachedTags, '$') LIKE ?
+             AND trashed = 0",
+        )
+        .bind(&pattern)
+        .fetch_all(&self.db.pool)
+        .await
+        .map_err(|e| {
+            ThingsError::applescript(format!("failed to query tasks with tag '{tag_title}': {e}"))
+        })?;
+
+        let normalized_target = normalize_tag_title(tag_title);
+        let mut out = Vec::new();
+        for row in rows {
+            let id_str: String = row.get("uuid");
+            let blob: Vec<u8> = row.get("cachedTags");
+            let tags = crate::database::deserialize_tags_from_blob(&blob)?;
+            if tags
+                .iter()
+                .any(|t| normalize_tag_title(t) == normalized_target)
+            {
+                out.push((ThingsId::from_trusted(id_str), tags));
+            }
+        }
+        Ok(out)
+    }
+
+    /// Create a tag via osascript and parse its returned UUID. Used by
+    /// `create_tag(force=true)` and the auto-create branches of
+    /// `add_tag_to_task` / `set_task_tags`.
+    async fn create_tag_via_as(&self, request: &CreateTagRequest) -> ThingsResult<ThingsId> {
+        if request.shortcut.is_some() || request.parent_uuid.is_some() {
+            tracing::debug!(
+                tag = %request.title,
+                "shortcut and/or parent_uuid set on CreateTagRequest; \
+                 Things AppleScript does not expose those properties on `tag`, \
+                 so they are silently dropped (#136)"
+            );
+        }
+        let script = script::create_tag_script(request);
+        let stdout = runner::run_script(&script).await?;
+        parse::extract_id(&stdout)
+    }
 }
 
 const MAX_BULK_BATCH_SIZE: usize = 1000;
-
-/// Helper: every stub method gets the same error shape so callers can grep
-/// for the phase that adds it.
-fn not_yet_implemented(method: &str, phase: &str, issue: &str) -> ThingsError {
-    ThingsError::applescript(format!(
-        "{method} is not yet implemented in AppleScriptBackend ({phase} — {issue})"
-    ))
-}
 
 #[async_trait]
 impl MutationBackend for AppleScriptBackend {
@@ -381,54 +468,270 @@ impl MutationBackend for AppleScriptBackend {
         Ok(())
     }
 
-    // ---- Tags (Phase D — stubbed) ----
+    // ---- Tags (Phase D — implemented) ----
 
     async fn create_tag(
         &self,
-        _request: CreateTagRequest,
-        _force: bool,
+        request: CreateTagRequest,
+        force: bool,
     ) -> ThingsResult<TagCreationResult> {
-        Err(not_yet_implemented("create_tag", "Phase D", "#136"))
+        use crate::database::tag_utils::normalize_tag_title;
+
+        if force {
+            let uuid = self.create_tag_via_as(&request).await?;
+            return Ok(TagCreationResult::Created { uuid, is_new: true });
+        }
+
+        // Smart flow: exact-match → similar → create.
+        let normalized = normalize_tag_title(&request.title);
+        if let Some(existing) = self.db.find_tag_by_normalized_title(&normalized).await? {
+            return Ok(TagCreationResult::Existing {
+                tag: existing,
+                is_new: false,
+            });
+        }
+        let similar = self.db.find_similar_tags(&normalized, 0.8).await?;
+        if !similar.is_empty() {
+            return Ok(TagCreationResult::SimilarFound {
+                similar_tags: similar,
+                requested_title: request.title.clone(),
+            });
+        }
+        let uuid = self.create_tag_via_as(&request).await?;
+        Ok(TagCreationResult::Created { uuid, is_new: true })
     }
 
-    async fn update_tag(&self, _request: UpdateTagRequest) -> ThingsResult<()> {
-        Err(not_yet_implemented("update_tag", "Phase D", "#136"))
+    async fn update_tag(&self, request: UpdateTagRequest) -> ThingsResult<()> {
+        if request.shortcut.is_some() || request.parent_uuid.is_some() {
+            tracing::debug!(
+                tag = %request.uuid,
+                "shortcut and/or parent_uuid set on UpdateTagRequest; \
+                 Things AppleScript does not expose those properties on `tag`, \
+                 so they are silently dropped (#136)"
+            );
+        }
+        let script = script::update_tag_script(&request);
+        runner::run_script(&script).await?;
+        Ok(())
     }
 
-    async fn delete_tag(&self, _id: &ThingsId, _remove_from_tasks: bool) -> ThingsResult<()> {
-        Err(not_yet_implemented("delete_tag", "Phase D", "#136"))
+    async fn delete_tag(&self, id: &ThingsId, remove_from_tasks: bool) -> ThingsResult<()> {
+        if !remove_from_tasks {
+            let script = script::delete_tag_script(id);
+            runner::run_script(&script).await?;
+            return Ok(());
+        }
+
+        // Find the tag's title and the tasks that hold it. AppleScriptBackend
+        // implements `remove_from_tasks=true` correctly, while the sqlx path
+        // has this as a TODO — divergent capability, called out in the PR.
+        use crate::database::tag_utils::normalize_tag_title;
+        let title = self.read_tag_title(id).await?;
+        let normalized = normalize_tag_title(&title);
+        let candidates = self.list_tasks_with_tag_title(&title).await?;
+
+        if !candidates.is_empty() {
+            if candidates.len() > MAX_BULK_BATCH_SIZE {
+                return Err(ThingsError::validation(format!(
+                    "Cannot remove tag from {} tasks; exceeds maximum of {MAX_BULK_BATCH_SIZE}",
+                    candidates.len(),
+                )));
+            }
+            let items: Vec<(ThingsId, String)> = candidates
+                .into_iter()
+                .map(|(task_id, tags)| {
+                    let new_tags: Vec<String> = tags
+                        .into_iter()
+                        .filter(|t| normalize_tag_title(t) != normalized)
+                        .collect();
+                    (task_id, new_tags.join(", "))
+                })
+                .collect();
+
+            let total = items.len();
+            let rewrite_script = script::bulk_set_task_tag_names_script(&items);
+            let stdout = runner::run_script(&rewrite_script).await?;
+            let result = parse::parse_bulk_result(&stdout, total)?;
+            if !result.success {
+                return Err(ThingsError::applescript(format!(
+                    "delete_tag(remove_from_tasks=true): per-task rewrite failed; \
+                     tag {id} was NOT deleted. {}",
+                    result.message
+                )));
+            }
+        }
+
+        let delete_script = script::delete_tag_script(id);
+        runner::run_script(&delete_script).await?;
+        Ok(())
     }
 
-    async fn merge_tags(&self, _source_id: &ThingsId, _target_id: &ThingsId) -> ThingsResult<()> {
-        Err(not_yet_implemented("merge_tags", "Phase D", "#136"))
+    async fn merge_tags(&self, source_id: &ThingsId, target_id: &ThingsId) -> ThingsResult<()> {
+        use crate::database::tag_utils::normalize_tag_title;
+
+        if source_id == target_id {
+            return Err(ThingsError::validation(
+                "merge_tags: source and target must differ",
+            ));
+        }
+
+        let source_title = self.read_tag_title(source_id).await?;
+        let target_title = self.read_tag_title(target_id).await?;
+        let source_normalized = normalize_tag_title(&source_title);
+        let target_normalized = normalize_tag_title(&target_title);
+
+        let candidates = self.list_tasks_with_tag_title(&source_title).await?;
+        if !candidates.is_empty() {
+            if candidates.len() > MAX_BULK_BATCH_SIZE {
+                return Err(ThingsError::validation(format!(
+                    "Cannot merge tag across {} tasks; exceeds maximum of {MAX_BULK_BATCH_SIZE}",
+                    candidates.len(),
+                )));
+            }
+            let items: Vec<(ThingsId, String)> = candidates
+                .into_iter()
+                .map(|(task_id, tags)| {
+                    let mut new_tags: Vec<String> = Vec::with_capacity(tags.len());
+                    for t in tags {
+                        let n = normalize_tag_title(&t);
+                        if n == source_normalized {
+                            // Replace source with target, deduping.
+                            if !new_tags
+                                .iter()
+                                .any(|nt| normalize_tag_title(nt) == target_normalized)
+                            {
+                                new_tags.push(target_title.clone());
+                            }
+                        } else if n == target_normalized {
+                            // Keep an existing target reference, but de-dup
+                            // against any earlier insertion.
+                            if !new_tags
+                                .iter()
+                                .any(|nt| normalize_tag_title(nt) == target_normalized)
+                            {
+                                new_tags.push(t);
+                            }
+                        } else {
+                            new_tags.push(t);
+                        }
+                    }
+                    (task_id, new_tags.join(", "))
+                })
+                .collect();
+
+            let total = items.len();
+            let rewrite_script = script::bulk_set_task_tag_names_script(&items);
+            let stdout = runner::run_script(&rewrite_script).await?;
+            let result = parse::parse_bulk_result(&stdout, total)?;
+            if !result.success {
+                return Err(ThingsError::applescript(format!(
+                    "merge_tags: per-task rewrite failed; source tag {source_id} was NOT deleted. {}",
+                    result.message
+                )));
+            }
+        }
+
+        // Source tag is no longer referenced by any task — safe to delete.
+        let delete_script = script::delete_tag_script(source_id);
+        runner::run_script(&delete_script).await?;
+        Ok(())
     }
 
     async fn add_tag_to_task(
         &self,
-        _task_id: &ThingsId,
-        _tag_title: &str,
+        task_id: &ThingsId,
+        tag_title: &str,
     ) -> ThingsResult<TagAssignmentResult> {
-        Err(not_yet_implemented("add_tag_to_task", "Phase D", "#136"))
+        use crate::database::tag_utils::normalize_tag_title;
+
+        let normalized = normalize_tag_title(tag_title);
+
+        let (resolved_title, resolved_uuid) =
+            if let Some(existing) = self.db.find_tag_by_normalized_title(&normalized).await? {
+                (existing.title, existing.uuid)
+            } else {
+                let similar = self.db.find_similar_tags(&normalized, 0.8).await?;
+                if !similar.is_empty() {
+                    return Ok(TagAssignmentResult::Suggestions {
+                        similar_tags: similar,
+                    });
+                }
+                // No existing match and no similar tags — auto-create. Mirrors
+                // `ThingsDatabase::add_tag_to_task` (`database/core.rs:2792-2802`).
+                let create_req = CreateTagRequest {
+                    title: tag_title.to_string(),
+                    shortcut: None,
+                    parent_uuid: None,
+                };
+                let new_id = self.create_tag_via_as(&create_req).await?;
+                (tag_title.to_string(), new_id)
+            };
+
+        let current = self.read_task_tag_titles(task_id).await?;
+        let already_present = current.iter().any(|t| normalize_tag_title(t) == normalized);
+        if !already_present {
+            let mut new_list = current;
+            new_list.push(resolved_title);
+            let joined = new_list.join(", ");
+            let script = script::set_task_tag_names_script(task_id, &joined);
+            runner::run_script(&script).await?;
+        }
+        Ok(TagAssignmentResult::Assigned {
+            tag_uuid: resolved_uuid,
+        })
     }
 
-    async fn remove_tag_from_task(
-        &self,
-        _task_id: &ThingsId,
-        _tag_title: &str,
-    ) -> ThingsResult<()> {
-        Err(not_yet_implemented(
-            "remove_tag_from_task",
-            "Phase D",
-            "#136",
-        ))
+    async fn remove_tag_from_task(&self, task_id: &ThingsId, tag_title: &str) -> ThingsResult<()> {
+        use crate::database::tag_utils::normalize_tag_title;
+
+        let normalized = normalize_tag_title(tag_title);
+        let current = self.read_task_tag_titles(task_id).await?;
+        let new_list: Vec<String> = current
+            .into_iter()
+            .filter(|t| normalize_tag_title(t) != normalized)
+            .collect();
+        let joined = new_list.join(", ");
+        let script = script::set_task_tag_names_script(task_id, &joined);
+        runner::run_script(&script).await?;
+        Ok(())
     }
 
     async fn set_task_tags(
         &self,
-        _task_id: &ThingsId,
-        _tag_titles: Vec<String>,
+        task_id: &ThingsId,
+        tag_titles: Vec<String>,
     ) -> ThingsResult<Vec<TagMatch>> {
-        Err(not_yet_implemented("set_task_tags", "Phase D", "#136"))
+        use crate::database::tag_utils::normalize_tag_title;
+
+        let mut suggestions: Vec<TagMatch> = Vec::new();
+        let mut resolved: Vec<String> = Vec::with_capacity(tag_titles.len());
+
+        for title in tag_titles {
+            let normalized = normalize_tag_title(&title);
+            if let Some(existing) = self.db.find_tag_by_normalized_title(&normalized).await? {
+                resolved.push(existing.title);
+                continue;
+            }
+            let similar = self.db.find_similar_tags(&normalized, 0.8).await?;
+            if !similar.is_empty() {
+                suggestions.extend(similar);
+            }
+            // Auto-create on miss — mirrors `ThingsDatabase::set_task_tags`
+            // (`database/core.rs:2966-2981`). Suggestions are accumulated
+            // for the caller's review but do not block creation.
+            let create_req = CreateTagRequest {
+                title: title.clone(),
+                shortcut: None,
+                parent_uuid: None,
+            };
+            self.create_tag_via_as(&create_req).await?;
+            resolved.push(title);
+        }
+
+        let joined = resolved.join(", ");
+        let script = script::set_task_tag_names_script(task_id, &joined);
+        runner::run_script(&script).await?;
+        Ok(suggestions)
     }
 }
 
@@ -447,37 +750,131 @@ mod tests {
         let _backend = AppleScriptBackend::new(db);
     }
 
-    /// Every remaining Phase-D stub returns AppleScript error pointing at the
-    /// tracking issue. Phase B (tasks) and Phase C (projects/areas/bulk) are
-    /// fully implemented; tags remain stubbed.
+    /// `create_tag(force=false)` returns `Existing` for a case-insensitive
+    /// exact match without ever spawning osascript. Read-side decision is
+    /// pure DB.
     #[tokio::test]
-    async fn unimplemented_tag_methods_return_phase_error() {
-        let db = Arc::new(
-            ThingsDatabase::from_connection_string("sqlite::memory:")
-                .await
-                .expect("in-memory db"),
-        );
-        let backend = AppleScriptBackend::new(db);
+    async fn create_tag_returns_existing_on_exact_case_insensitive_match() {
+        let (db, _tmp) = crate::test_utils::create_test_database_and_connect()
+            .await
+            .expect("test db");
+        db.create_tag_force(CreateTagRequest {
+            title: "Work".into(),
+            shortcut: None,
+            parent_uuid: None,
+        })
+        .await
+        .expect("seed tag");
+        let backend = AppleScriptBackend::new(Arc::new(db));
 
-        let err = backend
+        let result = backend
             .create_tag(
                 CreateTagRequest {
-                    title: "x".into(),
+                    title: "WORK".into(),
                     shortcut: None,
                     parent_uuid: None,
                 },
                 false,
             )
             .await
-            .expect_err("stub");
-        match err {
-            ThingsError::AppleScript { message } => {
-                assert!(message.contains("create_tag"));
-                assert!(message.contains("Phase D"));
-                assert!(message.contains("#136"));
+            .expect("smart flow");
+        match result {
+            TagCreationResult::Existing { tag, is_new } => {
+                assert_eq!(tag.title, "Work");
+                assert!(!is_new);
             }
-            _ => panic!("expected AppleScript error, got {err:?}"),
+            other => panic!("expected Existing, got {other:?}"),
         }
+    }
+
+    /// `create_tag(force=false)` returns `SimilarFound` when no exact match
+    /// but Levenshtein-≥0.8 candidates exist. Pure DB read; no osascript.
+    #[tokio::test]
+    async fn create_tag_returns_similar_found_on_fuzzy_match() {
+        let (db, _tmp) = crate::test_utils::create_test_database_and_connect()
+            .await
+            .expect("test db");
+        db.create_tag_force(CreateTagRequest {
+            title: "important".into(),
+            shortcut: None,
+            parent_uuid: None,
+        })
+        .await
+        .expect("seed tag");
+        let backend = AppleScriptBackend::new(Arc::new(db));
+
+        let result = backend
+            .create_tag(
+                CreateTagRequest {
+                    // 1-char typo from "important".
+                    title: "importnt".into(),
+                    shortcut: None,
+                    parent_uuid: None,
+                },
+                false,
+            )
+            .await
+            .expect("smart flow");
+        match result {
+            TagCreationResult::SimilarFound {
+                similar_tags,
+                requested_title,
+            } => {
+                assert_eq!(requested_title, "importnt");
+                assert!(
+                    similar_tags.iter().any(|m| m.tag.title == "important"),
+                    "should suggest 'important' as similar"
+                );
+            }
+            other => panic!("expected SimilarFound, got {other:?}"),
+        }
+    }
+
+    /// `add_tag_to_task` returns `Suggestions` and does NOT spawn osascript
+    /// when the requested title is ambiguous against existing tags.
+    #[tokio::test]
+    async fn add_tag_to_task_returns_suggestions_when_ambiguous() {
+        let (db, _tmp) = crate::test_utils::create_test_database_and_connect()
+            .await
+            .expect("test db");
+        db.create_tag_force(CreateTagRequest {
+            title: "important".into(),
+            shortcut: None,
+            parent_uuid: None,
+        })
+        .await
+        .expect("seed tag");
+        let backend = AppleScriptBackend::new(Arc::new(db));
+
+        let task_id = ThingsId::new_v4();
+        let result = backend
+            .add_tag_to_task(&task_id, "importnt")
+            .await
+            .expect("smart flow");
+        match result {
+            TagAssignmentResult::Suggestions { similar_tags } => {
+                assert!(similar_tags.iter().any(|m| m.tag.title == "important"));
+            }
+            other => panic!("expected Suggestions, got {other:?}"),
+        }
+    }
+
+    /// `merge_tags` rejects identical source/target with a Validation error.
+    /// No DB read or osascript invocation needed.
+    #[tokio::test]
+    async fn merge_tags_rejects_identical_source_and_target() {
+        let db = Arc::new(
+            ThingsDatabase::from_connection_string("sqlite::memory:")
+                .await
+                .expect("in-memory db"),
+        );
+        let backend = AppleScriptBackend::new(db);
+        let id = ThingsId::new_v4();
+        let err = backend
+            .merge_tags(&id, &id)
+            .await
+            .expect_err("same source/target");
+        assert!(matches!(err, ThingsError::Validation { .. }));
     }
 
     /// Validation errors fire before osascript spawn for empty / oversize bulk requests.

--- a/libs/things3-core/src/mutations/applescript/script.rs
+++ b/libs/things3-core/src/mutations/applescript/script.rs
@@ -25,8 +25,9 @@ use chrono::{Datelike, NaiveDate};
 use super::escape::as_applescript_string;
 use crate::models::{
     BulkCompleteRequest, BulkCreateTasksRequest, BulkDeleteRequest, BulkMoveRequest,
-    BulkUpdateDatesRequest, CreateAreaRequest, CreateProjectRequest, CreateTaskRequest, TaskStatus,
-    ThingsId, UpdateAreaRequest, UpdateProjectRequest, UpdateTaskRequest,
+    BulkUpdateDatesRequest, CreateAreaRequest, CreateProjectRequest, CreateTagRequest,
+    CreateTaskRequest, TaskStatus, ThingsId, UpdateAreaRequest, UpdateProjectRequest,
+    UpdateTagRequest, UpdateTaskRequest,
 };
 
 /// Wrap a script body in the standard `tell application` + `with timeout`
@@ -559,6 +560,80 @@ pub(crate) fn bulk_update_dates_script(req: &BulkUpdateDatesRequest) -> String {
                 snippet.push_str("\t\t\tset due date of t to missing value\n");
             }
             snippet
+        })
+        .collect();
+    bulk_wrap(&snippets)
+}
+
+// =====================================================================
+// Tags (Phase D — #136)
+// =====================================================================
+
+/// Build the `make new tag` script for a [`CreateTagRequest`].
+///
+/// Returns the new tag's UUID via `return id of newTag`.
+///
+/// **Note:** Things AppleScript does not expose `shortcut` or `parent`
+/// properties on `tag`, so [`CreateTagRequest::shortcut`] and
+/// [`CreateTagRequest::parent_uuid`] are silently dropped here. The caller
+/// is responsible for `tracing::debug!`-logging that drop. This is a known
+/// divergence from `SqlxBackend` — see Phase D PR notes (#136).
+#[allow(dead_code)] // Used by AppleScriptBackend, added in #136.
+pub(crate) fn create_tag_script(req: &CreateTagRequest) -> String {
+    let body = format!(
+        "\t\tset newTag to make new tag with properties {{name:{}}}\n\
+         \t\treturn id of newTag\n",
+        as_applescript_string(&req.title),
+    );
+    wrap(&body)
+}
+
+/// Build the partial-update script for an [`UpdateTagRequest`].
+///
+/// Same `shortcut` / `parent_uuid` caveat as [`create_tag_script`] — those
+/// fields are silently ignored.
+#[allow(dead_code)] // Used by AppleScriptBackend, added in #136.
+pub(crate) fn update_tag_script(req: &UpdateTagRequest) -> String {
+    let mut body = format!("\t\tset t to tag id \"{}\"\n", req.uuid);
+    if let Some(title) = &req.title {
+        body.push_str(&format!(
+            "\t\tset name of t to {}\n",
+            as_applescript_string(title),
+        ));
+    }
+    wrap(&body)
+}
+
+#[allow(dead_code)] // Used by AppleScriptBackend, added in #136.
+pub(crate) fn delete_tag_script(id: &ThingsId) -> String {
+    wrap(&format!("\t\tdelete tag id \"{id}\"\n"))
+}
+
+/// Set a task's `tag names` property to the provided comma-joined string.
+///
+/// Things AS treats `tag names` as a single text value: a comma-separated
+/// list that Things parses internally. Caller is responsible for joining
+/// titles with `", "` and for any deduplication.
+#[allow(dead_code)] // Used by AppleScriptBackend, added in #136.
+pub(crate) fn set_task_tag_names_script(task_id: &ThingsId, joined: &str) -> String {
+    wrap(&format!(
+        "\t\tset tag names of to do id \"{task_id}\" to {}\n",
+        as_applescript_string(joined),
+    ))
+}
+
+/// Bulk variant of [`set_task_tag_names_script`] — one osascript invocation
+/// rewrites tag names for many tasks. Each item runs in its own try block
+/// via [`bulk_wrap`]. Used by `merge_tags` and `delete_tag(remove_from_tasks=true)`.
+#[allow(dead_code)] // Used by AppleScriptBackend, added in #136.
+pub(crate) fn bulk_set_task_tag_names_script(items: &[(ThingsId, String)]) -> String {
+    let snippets: Vec<String> = items
+        .iter()
+        .map(|(task_id, joined)| {
+            format!(
+                "\t\t\tset tag names of to do id \"{task_id}\" to {}\n",
+                as_applescript_string(joined),
+            )
         })
         .collect();
     bulk_wrap(&snippets)
@@ -1167,5 +1242,117 @@ mod tests {
         let script = bulk_update_dates_script(&req);
         assert!(script.contains("set activation date of t to activationDate"));
         assert!(script.contains("set due date of t to dueDate"));
+    }
+
+    // -----------------------------------------------------------------
+    // Phase D — Tags
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn create_tag_emits_make_new_with_name_only() {
+        let req = CreateTagRequest {
+            title: "Work".into(),
+            shortcut: Some("w".into()),
+            parent_uuid: Some(sample_uuid()),
+        };
+        let script = create_tag_script(&req);
+        assert!(script.contains("make new tag with properties {name:\"Work\"}"));
+        assert!(script.contains("return id of newTag"));
+        // shortcut and parent are intentionally dropped — Things AS does not
+        // expose them. The Rust backend logs the drop at debug level.
+        assert!(!script.contains("shortcut"));
+        assert!(!script.contains("parent"));
+    }
+
+    #[test]
+    fn create_tag_escapes_title() {
+        let req = CreateTagRequest {
+            title: "Has \"quotes\" and\nnewline".into(),
+            shortcut: None,
+            parent_uuid: None,
+        };
+        let script = create_tag_script(&req);
+        assert!(script.contains("name:\"Has \\\"quotes\\\" and\\nnewline\""));
+    }
+
+    #[test]
+    fn update_tag_no_fields_only_resolves_target() {
+        let req = UpdateTagRequest {
+            uuid: sample_uuid(),
+            title: None,
+            shortcut: Some("w".into()),
+            parent_uuid: Some(project_uuid()),
+        };
+        let script = update_tag_script(&req);
+        assert!(script.contains(&format!("set t to tag id \"{}\"", sample_uuid())));
+        assert!(!script.contains("set name"));
+        // shortcut/parent silently dropped
+        assert!(!script.contains("shortcut"));
+        assert!(!script.contains("parent"));
+    }
+
+    #[test]
+    fn update_tag_renames_when_title_set() {
+        let req = UpdateTagRequest {
+            uuid: sample_uuid(),
+            title: Some("Renamed".into()),
+            shortcut: None,
+            parent_uuid: None,
+        };
+        let script = update_tag_script(&req);
+        assert!(script.contains("set name of t to \"Renamed\""));
+    }
+
+    #[test]
+    fn delete_tag_script_shape() {
+        let script = delete_tag_script(&sample_uuid());
+        assert!(script.contains(&format!("delete tag id \"{}\"", sample_uuid())));
+    }
+
+    #[test]
+    fn set_task_tag_names_emits_set_with_joined_string() {
+        let script = set_task_tag_names_script(&sample_uuid(), "work, urgent");
+        assert!(script.contains(&format!(
+            "set tag names of to do id \"{}\" to \"work, urgent\"",
+            sample_uuid()
+        )));
+    }
+
+    #[test]
+    fn set_task_tag_names_escapes_joined_string() {
+        let script = set_task_tag_names_script(&sample_uuid(), "has \"quote\"");
+        assert!(script.contains("\"has \\\"quote\\\"\""));
+    }
+
+    #[test]
+    fn bulk_set_task_tag_names_wraps_each_in_try_block() {
+        let items = vec![
+            (sample_uuid(), "a, b".to_string()),
+            (project_uuid(), "c".to_string()),
+        ];
+        let script = bulk_set_task_tag_names_script(&items);
+        // Each item gets its own try block.
+        assert_eq!(script.matches("\t\ttry\n").count(), 2);
+        assert_eq!(script.matches("on error errMsg").count(), 2);
+        assert_eq!(script.matches("end try").count(), 2);
+        assert!(script.contains(&format!(
+            "set tag names of to do id \"{}\" to \"a, b\"",
+            sample_uuid()
+        )));
+        assert!(script.contains(&format!(
+            "set tag names of to do id \"{}\" to \"c\"",
+            project_uuid()
+        )));
+        // Per-item error tagging.
+        assert!(script.contains("\"item 0: \" & errMsg"));
+        assert!(script.contains("\"item 1: \" & errMsg"));
+    }
+
+    #[test]
+    fn bulk_set_task_tag_names_empty_items_still_returns_ok() {
+        let script = bulk_set_task_tag_names_script(&[]);
+        assert!(script.contains("set okCount to 0"));
+        assert!(script.contains("return \"OK \" & okCount"));
+        assert_eq!(script.matches("\t\ttry\n").count(), 0);
     }
 }


### PR DESCRIPTION
Closes #136. Part of #124.

## Summary

- Implements all 7 remaining `MutationBackend` tag stubs in `AppleScriptBackend`. After this lands, only Phase E (#137 — live tests + docs) is left in the #124 epic.
- Three methods are read+write hybrids: `create_tag(force=false)`, `add_tag_to_task`, `set_task_tags` use `Arc<ThingsDatabase>` for similarity scoring, then route the actual write through `osascript`.
- The other four are pure AS writes: `update_tag`, `delete_tag`, `merge_tags`, `remove_tag_from_task`.

## Key design decisions

**Smart-flow read paths never spawn osascript.** `create_tag(force=false)` resolves exact matches via `db.find_tag_by_normalized_title` → `Existing`, fuzzy ≥0.8 via `db.find_similar_tags` → `SimilarFound`, falls through to AS create only when no candidate exists. `add_tag_to_task` returns `Suggestions` without writing when ambiguous. Mirrors `SqlxBackend`'s contract exactly.

**Bulk per-task rewrites.** `delete_tag(remove_from_tasks=true)` and `merge_tags` batch every affected task's `set tag names` rewrite into one `bulk_wrap`'d osascript invocation, then issue the final `delete tag` only if all rewrites succeeded. If any rewrite failed, the source/target tag is left intact rather than orphaning its title in tasks' `cachedTags`. This is a strict capability improvement over `SqlxBackend` — those branches are TODOs in `database/core.rs` today.

**Tag-names property model.** Things AS exposes `tag names` as text (a comma-joined list Things parses internally), not a list. So `add_tag_to_task` / `remove_tag_from_task` / `set_task_tags` read existing tags via DB `cachedTags`, mutate the list in Rust (deduped via `normalize_tag_title`), then write the joined string back via one AS call.

## Documented divergence from SqlxBackend

Things AS does **not** expose `shortcut` or `parent` properties on `tag` (per the [Things scripting reference](https://culturedcode.com/things/support/articles/4562654/)). So:

- `CreateTagRequest::shortcut` / `parent_uuid` — silently dropped, with a `tracing::debug!` log noting the drop. The tag is created with `name` only.
- `UpdateTagRequest::shortcut` / `parent_uuid` — same treatment.
- `update_tag` rename collisions — DB pre-validates duplicates; AS surfaces the Things-side error via `ThingsError::AppleScript`. Same end-user outcome (rename rejected), different error path.
- `delete_tag(remove_from_tasks=true)` and `merge_tags` `cachedTags` rewrites — DB has these as TODOs; AS implements them correctly.

If a future Things release exposes `shortcut`/`parent` to AS, wiring them through is a straightforward addition to `script::create_tag_script` and `script::update_tag_script`.

## Test plan

- [x] `cargo test -p things3-core --lib` — 519 tests pass (88 in `mutations::applescript`)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test --workspace` — clean
- [ ] Live (Mac + Things 3 + Automation grant): create tag → assign to task → merge into another tag → delete merged tag — covered by Phase E (#137)

### New tests in this PR

Script builders (in `script.rs::tests`):
- `create_tag_emits_make_new_with_name_only` (verifies shortcut/parent dropped)
- `create_tag_escapes_title`
- `update_tag_no_fields_only_resolves_target`, `update_tag_renames_when_title_set`
- `delete_tag_script_shape`
- `set_task_tag_names_emits_set_with_joined_string`, `set_task_tag_names_escapes_joined_string`
- `bulk_set_task_tag_names_wraps_each_in_try_block`, `bulk_set_task_tag_names_empty_items_still_returns_ok`

Read-side decision logic (in `mod.rs::tests`, uses `create_test_database_and_connect`):
- `create_tag_returns_existing_on_exact_case_insensitive_match`
- `create_tag_returns_similar_found_on_fuzzy_match`
- `add_tag_to_task_returns_suggestions_when_ambiguous`
- `merge_tags_rejects_identical_source_and_target`

🤖 Generated with [Claude Code](https://claude.com/claude-code)