### PR TITLE
feat(mutations): default to AppleScriptBackend; gate restore_database (#125, #126)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`MutationBackend` trait** — all 21 method signatures updated to use `ThingsId` for entity
   IDs. Existing impls of `MutationBackend` must update their method signatures to match.
 
+### Changed
+
+- **Default mutation backend on macOS is now `AppleScriptBackend`** (#125). All MCP write
+  tools route through the Things 3 app via osascript per CulturedCode's safety guidance
+  (https://culturedcode.com/things/support/articles/5510170/), eliminating the
+  data-corruption risk of direct SQLite writes. Linux/CI continues to use `SqlxBackend` as
+  the default (no Things 3 install to corrupt). **Closes #120.**
+
+### Deprecated
+
+- **`SqlxBackend` (direct SQLite writes) is gated behind `--unsafe-direct-db`** /
+  `THINGS_UNSAFE_DIRECT_DB=1`. Setting the flag emits a loud multi-line startup banner
+  (suppressed in MCP mode for JSON-RPC purity). The flag will be removed in a future
+  release; integrations writing directly to the database should migrate to AppleScript.
+- **`restore_database` MCP tool now requires both `--unsafe-direct-db` AND that Things 3 is
+  not running** (`pgrep -x Things3` returns nothing). The argument-parse error
+  (`backup_path` missing) still fires before the gate so client error handling stays
+  unchanged for that case. **Closes #126.**
+
 ### Added
 
 - **AppleScriptBackend Phase E: live integration tests + docs** (#137) — closes #124. New

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ futures-core = "0.3"
 futures-util = "0.3"
 
 # CLI
-clap = { version = "4.0", features = ["derive"] }
+clap = { version = "4.0", features = ["derive", "env"] }
 
 # MCP
 mcp = "0.1"

--- a/apps/things3-cli/src/lib.rs
+++ b/apps/things3-cli/src/lib.rs
@@ -51,6 +51,15 @@ pub struct Cli {
     #[arg(long, short)]
     pub verbose: bool,
 
+    /// Use the deprecated direct-SQLite mutation backend instead of AppleScript.
+    ///
+    /// CulturedCode warns against direct database writes
+    /// (https://culturedcode.com/things/support/articles/5510170/). This flag
+    /// re-enables the deprecated SqlxBackend and is required to use
+    /// `restore_database`. Will be removed in a future release.
+    #[arg(long, env = "THINGS_UNSAFE_DIRECT_DB")]
+    pub unsafe_direct_db: bool,
+
     #[command(subcommand)]
     pub command: Commands,
 }
@@ -425,7 +434,7 @@ mod tests {
 
         // Note: We can't actually run start_mcp_server in a test because it's an infinite
         // loop that reads from stdin. Instead, we verify the server can be created.
-        let _server = crate::mcp::ThingsMcpServer::new(db.into(), config);
+        let _server = crate::mcp::ThingsMcpServer::new(db.into(), config, true);
         // Server created successfully
     }
 

--- a/apps/things3-cli/src/main.rs
+++ b/apps/things3-cli/src/main.rs
@@ -61,6 +61,27 @@ async fn main() -> Result<()> {
         Some(Arc::new(obs))
     };
 
+    // Loud opt-in warning when the user re-enables direct-DB writes. MCP mode
+    // intentionally skips this — stderr must stay empty for JSON-RPC purity
+    // (the user already typed --unsafe-direct-db, so the silence is fine).
+    #[cfg(feature = "observability")]
+    let emit_unsafe_warning = !is_mcp_mode && cli.unsafe_direct_db;
+    #[cfg(not(feature = "observability"))]
+    let emit_unsafe_warning = cli.unsafe_direct_db;
+    if emit_unsafe_warning {
+        let banner = "\
+================================================================================
+WARNING: --unsafe-direct-db / THINGS_UNSAFE_DIRECT_DB is set.
+Mutations write directly to the Things 3 SQLite database, bypassing the
+safe AppleScript path. CulturedCode warns this can corrupt your data and
+break syncs:
+  https://culturedcode.com/things/support/articles/5510170/
+This flag exists for emergency recovery only and will be removed.
+================================================================================";
+        tracing::warn!("{banner}");
+        eprintln!("{banner}");
+    }
+
     // Create configuration
     let config = if let Some(db_path) = cli.database {
         ThingsConfig::new(db_path, cli.fallback_to_default)
@@ -115,16 +136,17 @@ async fn main() -> Result<()> {
             #[cfg(feature = "observability")]
             match load_config() {
                 Ok(mcp_config) => {
-                    start_mcp_server_with_config(Arc::clone(&db), mcp_config).await?;
+                    start_mcp_server_with_config(Arc::clone(&db), mcp_config, cli.unsafe_direct_db)
+                        .await?;
                 }
                 Err(_e) => {
                     // Silently fall back to basic config - no logging in MCP mode
-                    start_mcp_server(Arc::clone(&db), config).await?;
+                    start_mcp_server(Arc::clone(&db), config, cli.unsafe_direct_db).await?;
                 }
             }
             #[cfg(not(feature = "observability"))]
             {
-                start_mcp_server(Arc::clone(&db), config).await?;
+                start_mcp_server(Arc::clone(&db), config, cli.unsafe_direct_db).await?;
             }
         }
         Commands::Health => {
@@ -348,7 +370,7 @@ mod tests {
             Commands::Mcp => {
                 // Note: This test doesn't actually run the server loop since stdin would block
                 // In a real test, you'd need to provide mock stdin/stdout or test the handler directly
-                let _server = things3_cli::mcp::ThingsMcpServer::new(db.into(), config);
+                let _server = things3_cli::mcp::ThingsMcpServer::new(db.into(), config, true);
                 // Server created successfully
             }
             _ => panic!("Expected MCP command"),

--- a/apps/things3-cli/src/main.rs
+++ b/apps/things3-cli/src/main.rs
@@ -62,14 +62,10 @@ async fn main() -> Result<()> {
     };
 
     // Loud opt-in warning when the user re-enables direct-DB writes. MCP mode
-    // intentionally skips this — stderr must stay empty for JSON-RPC purity
-    // (the user already typed --unsafe-direct-db, so the silence is fine).
-    #[cfg(feature = "observability")]
-    let emit_unsafe_warning = !is_mcp_mode && cli.unsafe_direct_db;
-    #[cfg(not(feature = "observability"))]
-    let emit_unsafe_warning = cli.unsafe_direct_db;
-    if emit_unsafe_warning {
-        let banner = "\
+    // intentionally skips this — stderr must stay empty for JSON-RPC purity.
+    if !is_mcp_mode && cli.unsafe_direct_db {
+        eprintln!(
+            "\
 ================================================================================
 WARNING: --unsafe-direct-db / THINGS_UNSAFE_DIRECT_DB is set.
 Mutations write directly to the Things 3 SQLite database, bypassing the
@@ -77,9 +73,8 @@ safe AppleScript path. CulturedCode warns this can corrupt your data and
 break syncs:
   https://culturedcode.com/things/support/articles/5510170/
 This flag exists for emergency recovery only and will be removed.
-================================================================================";
-        tracing::warn!("{banner}");
-        eprintln!("{banner}");
+================================================================================"
+        );
     }
 
     // Create configuration

--- a/apps/things3-cli/src/main.rs
+++ b/apps/things3-cli/src/main.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<()> {
     #[cfg(all(feature = "observability", not(feature = "mcp-server")))]
     let is_mcp_mode = false;
     #[cfg(not(feature = "observability"))]
-    let _is_mcp_mode = false;
+    let is_mcp_mode = false;
 
     // Initialize observability (skip entirely for MCP mode to ensure zero stderr output)
     #[cfg(feature = "observability")]

--- a/apps/things3-cli/src/mcp.rs
+++ b/apps/things3-cli/src/mcp.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::str::FromStr;
 use std::sync::Arc;
+#[cfg(target_os = "macos")]
+use things3_core::AppleScriptBackend;
 use things3_core::{
     models::ThingsId, BackupManager, DataExporter, DeleteChildHandling, McpServerConfig,
     MutationBackend, PerformanceMonitor, SqlxBackend, ThingsCache, ThingsConfig, ThingsDatabase,
@@ -538,10 +540,17 @@ pub struct ThingsMcpServer {
     pub db: Arc<ThingsDatabase>,
     /// Mutation backend used for all write operations.
     ///
-    /// Defaults to `SqlxBackend` (direct DB writes — current behavior). Production
-    /// will switch to `AppleScriptBackend` once #124/#125 land; tests and the
-    /// `--unsafe-direct-db` opt-in continue to use `SqlxBackend`.
+    /// On macOS the default is `AppleScriptBackend` (CulturedCode-supported);
+    /// `--unsafe-direct-db` falls back to `SqlxBackend`. On non-macOS the
+    /// default is always `SqlxBackend` (no Things 3 install to corrupt).
     mutations: Arc<dyn MutationBackend>,
+    /// Whether the user opted into the deprecated direct-DB path. Required to
+    /// run `restore_database` — see `handle_restore_database` for the gate.
+    unsafe_direct_db: bool,
+    /// Stub-able predicate for "is Things 3 currently running?". Defaults to
+    /// `is_things3_running`; tests inject a constant function instead of
+    /// shelling out to `pgrep`.
+    process_check: fn() -> bool,
     #[allow(dead_code)]
     cache: Arc<Mutex<ThingsCache>>,
     #[allow(dead_code)]
@@ -562,9 +571,10 @@ pub struct ThingsMcpServer {
 pub async fn start_mcp_server(
     db: Arc<ThingsDatabase>,
     config: ThingsConfig,
+    unsafe_direct_db: bool,
 ) -> things3_core::Result<()> {
     let io = StdIo::new();
-    start_mcp_server_generic(db, config, io).await
+    start_mcp_server_generic(db, config, io, unsafe_direct_db).await
 }
 
 /// Generic MCP server implementation that works with any I/O implementation
@@ -575,8 +585,13 @@ pub async fn start_mcp_server_generic<I: McpIo>(
     db: Arc<ThingsDatabase>,
     config: ThingsConfig,
     mut io: I,
+    unsafe_direct_db: bool,
 ) -> things3_core::Result<()> {
-    let server = Arc::new(tokio::sync::Mutex::new(ThingsMcpServer::new(db, config)));
+    let server = Arc::new(tokio::sync::Mutex::new(ThingsMcpServer::new(
+        db,
+        config,
+        unsafe_direct_db,
+    )));
 
     // Read JSON-RPC requests line by line
     loop {
@@ -638,9 +653,10 @@ pub async fn start_mcp_server_generic<I: McpIo>(
 pub async fn start_mcp_server_with_config(
     db: Arc<ThingsDatabase>,
     mcp_config: McpServerConfig,
+    unsafe_direct_db: bool,
 ) -> things3_core::Result<()> {
     let io = StdIo::new();
-    start_mcp_server_with_config_generic(db, mcp_config, io).await
+    start_mcp_server_with_config_generic(db, mcp_config, io, unsafe_direct_db).await
 }
 
 /// Generic MCP server with config implementation that works with any I/O implementation
@@ -648,6 +664,7 @@ pub async fn start_mcp_server_with_config_generic<I: McpIo>(
     db: Arc<ThingsDatabase>,
     mcp_config: McpServerConfig,
     mut io: I,
+    unsafe_direct_db: bool,
 ) -> things3_core::Result<()> {
     // Convert McpServerConfig to ThingsConfig for backward compatibility
     let things_config = ThingsConfig::new(
@@ -656,7 +673,7 @@ pub async fn start_mcp_server_with_config_generic<I: McpIo>(
     );
 
     let server = Arc::new(tokio::sync::Mutex::new(
-        ThingsMcpServer::new_with_mcp_config(db, things_config, mcp_config),
+        ThingsMcpServer::new_with_mcp_config(db, things_config, mcp_config, unsafe_direct_db),
     ));
 
     // Read JSON-RPC requests line by line
@@ -708,17 +725,68 @@ pub async fn start_mcp_server_with_config_generic<I: McpIo>(
     Ok(())
 }
 
+/// Pick the default `MutationBackend` for a server invocation.
+///
+/// On macOS the safe default is `AppleScriptBackend`. `--unsafe-direct-db` /
+/// `THINGS_UNSAFE_DIRECT_DB=1` falls back to the deprecated `SqlxBackend`.
+/// On non-macOS the default is always `SqlxBackend` — there's no Things 3
+/// install to corrupt, and `AppleScriptBackend` is platform-gated.
+fn select_default_backend(
+    db: Arc<ThingsDatabase>,
+    unsafe_direct_db: bool,
+) -> Arc<dyn MutationBackend> {
+    #[cfg(target_os = "macos")]
+    {
+        if unsafe_direct_db {
+            Arc::new(SqlxBackend::new(db))
+        } else {
+            Arc::new(AppleScriptBackend::new(db))
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = unsafe_direct_db;
+        Arc::new(SqlxBackend::new(db))
+    }
+}
+
+/// Returns `true` if Things 3 is currently running (macOS only).
+///
+/// Used as a precondition for `restore_database` — overwriting the live
+/// SQLite file under a running Things 3 process is the highest-corruption
+/// scenario CulturedCode warns about. On non-macOS we always return `false`
+/// because there is no Things 3 process to detect.
+fn is_things3_running() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        std::process::Command::new("pgrep")
+            .args(["-x", "Things3"])
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        false
+    }
+}
+
 impl ThingsMcpServer {
     #[must_use]
-    pub fn new(db: Arc<ThingsDatabase>, config: ThingsConfig) -> Self {
-        let mutations: Arc<dyn MutationBackend> = Arc::new(SqlxBackend::new(Arc::clone(&db)));
-        Self::with_mutation_backend(db, mutations, config)
+    pub fn new(db: Arc<ThingsDatabase>, config: ThingsConfig, unsafe_direct_db: bool) -> Self {
+        let mutations = select_default_backend(Arc::clone(&db), unsafe_direct_db);
+        let mut server = Self::with_mutation_backend(db, mutations, config);
+        server.unsafe_direct_db = unsafe_direct_db;
+        server
     }
 
     /// Create a new MCP server with a caller-provided mutation backend.
     ///
     /// Use this to inject `AppleScriptBackend` (issue #124) or a test double
-    /// without taking the default `SqlxBackend`.
+    /// without taking the default `SqlxBackend`. The `unsafe_direct_db` flag
+    /// defaults to `false`; callers gating `restore_database` should use
+    /// [`Self::new`] or set it after construction via the test-only
+    /// `set_unsafe_direct_db` helper.
     #[must_use]
     pub fn with_mutation_backend(
         db: Arc<ThingsDatabase>,
@@ -737,6 +805,8 @@ impl ThingsMcpServer {
         Self {
             db,
             mutations,
+            unsafe_direct_db: false,
+            process_check: is_things3_running,
             cache: Arc::new(Mutex::new(cache)),
             performance_monitor: Arc::new(Mutex::new(performance_monitor)),
             exporter,
@@ -751,9 +821,10 @@ impl ThingsMcpServer {
         db: ThingsDatabase,
         config: ThingsConfig,
         middleware_config: MiddlewareConfig,
+        unsafe_direct_db: bool,
     ) -> Self {
         let db = Arc::new(db);
-        let mutations: Arc<dyn MutationBackend> = Arc::new(SqlxBackend::new(Arc::clone(&db)));
+        let mutations = select_default_backend(Arc::clone(&db), unsafe_direct_db);
         let cache = ThingsCache::new_default();
         let performance_monitor = PerformanceMonitor::new_default();
         let exporter = DataExporter::new_default();
@@ -763,6 +834,8 @@ impl ThingsMcpServer {
         Self {
             db,
             mutations,
+            unsafe_direct_db,
+            process_check: is_things3_running,
             cache: Arc::new(Mutex::new(cache)),
             performance_monitor: Arc::new(Mutex::new(performance_monitor)),
             exporter,
@@ -777,8 +850,9 @@ impl ThingsMcpServer {
         db: Arc<ThingsDatabase>,
         config: ThingsConfig,
         mcp_config: McpServerConfig,
+        unsafe_direct_db: bool,
     ) -> Self {
-        let mutations: Arc<dyn MutationBackend> = Arc::new(SqlxBackend::new(Arc::clone(&db)));
+        let mutations = select_default_backend(Arc::clone(&db), unsafe_direct_db);
         let cache = ThingsCache::new_default();
         let performance_monitor = PerformanceMonitor::new_default();
         let exporter = DataExporter::new_default();
@@ -842,6 +916,8 @@ impl ThingsMcpServer {
         Self {
             db,
             mutations,
+            unsafe_direct_db,
+            process_check: is_things3_running,
             cache: Arc::new(Mutex::new(cache)),
             performance_monitor: Arc::new(Mutex::new(performance_monitor)),
             exporter,
@@ -854,6 +930,22 @@ impl ThingsMcpServer {
     #[must_use]
     pub fn middleware_chain(&self) -> &MiddlewareChain {
         &self.middleware_chain
+    }
+
+    /// The mutation backend's static identifier — `"applescript"` (safe
+    /// default on macOS) or `"sqlx"` (direct DB writes; deprecated). Used by
+    /// tests and operators to confirm which path is active.
+    #[must_use]
+    pub fn backend_kind(&self) -> &'static str {
+        self.mutations.kind()
+    }
+
+    /// Override the Things 3 process check used by `restore_database`.
+    ///
+    /// Tests use this to bypass the live `pgrep -x Things3` call. Production
+    /// code should never need it — the default predicate is correct.
+    pub fn set_process_check_for_test(&mut self, check: fn() -> bool) {
+        self.process_check = check;
     }
 
     /// List available MCP tools
@@ -3175,10 +3267,31 @@ impl ThingsMcpServer {
     }
 
     async fn handle_restore_database(&self, args: Value) -> McpResult<CallToolResult> {
+        // Argument validation runs first so missing-parameter errors keep
+        // their existing semantics regardless of the safety gate below.
         let backup_path = args
             .get("backup_path")
             .and_then(|v| v.as_str())
             .ok_or_else(|| McpError::missing_parameter("backup_path"))?;
+
+        // restore_database overwrites the live Things 3 SQLite file directly —
+        // CulturedCode-unsupported and the highest-corruption scenario rust-things3
+        // exposes. Decision per #126: keep the tool but gate it on (1) explicit
+        // --unsafe-direct-db opt-in AND (2) Things 3 must not be running.
+        if !self.unsafe_direct_db {
+            return Err(McpError::validation_error(
+                "restore_database is gated. Re-launch with --unsafe-direct-db \
+                 (or THINGS_UNSAFE_DIRECT_DB=1). It overwrites the live Things 3 \
+                 database directly — see https://culturedcode.com/things/support/articles/5510170/",
+            ));
+        }
+        if (self.process_check)() {
+            return Err(McpError::validation_error(
+                "restore_database refuses to run while Things 3 is open: \
+                 overwriting the database file under a running app corrupts it. \
+                 Quit Things 3 (Cmd-Q) and retry.",
+            ));
+        }
 
         let backup_file = std::path::Path::new(backup_path);
         self.backup_manager
@@ -4548,5 +4661,79 @@ impl ThingsMcpServer {
             "id": id,
             "result": result
         })))
+    }
+}
+
+#[cfg(test)]
+mod backend_selection_tests {
+    use super::*;
+    use crate::mcp::test_harness::McpTestHarness;
+
+    /// Build a server backed by the test harness's in-memory DB, with the
+    /// given `unsafe_direct_db` flag. Mirrors `McpTestHarness::new_with_config`
+    /// but routes through `ThingsMcpServer::new` so the platform-aware default
+    /// backend selection runs.
+    fn build_server(unsafe_direct_db: bool) -> (ThingsMcpServer, tempfile::NamedTempFile) {
+        let temp_file = tempfile::NamedTempFile::new().unwrap();
+        let db_path = temp_file.path().to_path_buf();
+        let db_path_clone = db_path.clone();
+
+        let db = std::thread::spawn(move || {
+            tokio::runtime::Runtime::new().unwrap().block_on(async {
+                // Reuse the harness's schema-creation helper by going through
+                // `McpTestHarness` once to seed the file, then re-open it via
+                // the public `ThingsDatabase::new` path.
+                let _harness = McpTestHarness::new_with_config(MiddlewareConfig::default());
+                ThingsDatabase::new(&db_path_clone).await.unwrap()
+            })
+        })
+        .join()
+        .unwrap();
+
+        let config = ThingsConfig::new(&db_path, false);
+        let server = ThingsMcpServer::new(Arc::new(db), config, unsafe_direct_db);
+        (server, temp_file)
+    }
+
+    #[cfg(target_os = "macos")]
+    #[tokio::test]
+    async fn defaults_to_applescript_on_macos() {
+        let (server, _tmp) = build_server(false);
+        assert_eq!(server.backend_kind(), "applescript");
+    }
+
+    #[tokio::test]
+    async fn unsafe_flag_selects_sqlx() {
+        let (server, _tmp) = build_server(true);
+        assert_eq!(server.backend_kind(), "sqlx");
+    }
+
+    #[tokio::test]
+    async fn restore_database_refuses_without_flag() {
+        let (server, _tmp) = build_server(false);
+        let err = server
+            .handle_restore_database(serde_json::json!({"backup_path": "/tmp/x"}))
+            .await
+            .expect_err("must refuse when --unsafe-direct-db is not set");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("--unsafe-direct-db"),
+            "error should name the flag, got: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn restore_database_refuses_when_things3_running() {
+        let (mut server, _tmp) = build_server(true);
+        server.set_process_check_for_test(|| true);
+        let err = server
+            .handle_restore_database(serde_json::json!({"backup_path": "/tmp/x"}))
+            .await
+            .expect_err("must refuse while Things 3 is running");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Things 3"),
+            "error should mention Things 3, got: {msg}"
+        );
     }
 }

--- a/apps/things3-cli/src/mcp.rs
+++ b/apps/things3-cli/src/mcp.rs
@@ -4667,25 +4667,18 @@ impl ThingsMcpServer {
 #[cfg(test)]
 mod backend_selection_tests {
     use super::*;
-    use crate::mcp::test_harness::McpTestHarness;
 
-    /// Build a server backed by the test harness's in-memory DB, with the
-    /// given `unsafe_direct_db` flag. Mirrors `McpTestHarness::new_with_config`
-    /// but routes through `ThingsMcpServer::new` so the platform-aware default
-    /// backend selection runs.
+    /// Build a server with a fresh temp DB and the given `unsafe_direct_db` flag,
+    /// routing through `ThingsMcpServer::new` so platform-aware backend selection runs.
     fn build_server(unsafe_direct_db: bool) -> (ThingsMcpServer, tempfile::NamedTempFile) {
         let temp_file = tempfile::NamedTempFile::new().unwrap();
         let db_path = temp_file.path().to_path_buf();
         let db_path_clone = db_path.clone();
 
         let db = std::thread::spawn(move || {
-            tokio::runtime::Runtime::new().unwrap().block_on(async {
-                // Reuse the harness's schema-creation helper by going through
-                // `McpTestHarness` once to seed the file, then re-open it via
-                // the public `ThingsDatabase::new` path.
-                let _harness = McpTestHarness::new_with_config(MiddlewareConfig::default());
-                ThingsDatabase::new(&db_path_clone).await.unwrap()
-            })
+            tokio::runtime::Runtime::new()
+                .unwrap()
+                .block_on(async { ThingsDatabase::new(&db_path_clone).await.unwrap() })
         })
         .join()
         .unwrap();

--- a/apps/things3-cli/src/mcp/test_harness.rs
+++ b/apps/things3-cli/src/mcp/test_harness.rs
@@ -46,7 +46,7 @@ impl McpTestHarness {
         .unwrap();
 
         let config = ThingsConfig::new(&db_path, false);
-        let server = ThingsMcpServer::with_middleware_config(db, config, middleware_config);
+        let server = ThingsMcpServer::with_middleware_config(db, config, middleware_config, true);
 
         Self { server, temp_file }
     }

--- a/apps/things3-cli/tests/error_message_format_tests.rs
+++ b/apps/things3-cli/tests/error_message_format_tests.rs
@@ -14,7 +14,7 @@ async fn create_invalid_mcp_server() -> ThingsMcpServer {
         .unwrap();
 
     let config = ThingsConfig::for_testing().unwrap();
-    ThingsMcpServer::new(db.into(), config)
+    ThingsMcpServer::new(db.into(), config, true)
 }
 
 #[tokio::test]

--- a/apps/things3-cli/tests/integration_tests.rs
+++ b/apps/things3-cli/tests/integration_tests.rs
@@ -119,7 +119,7 @@ async fn test_mcp_server_integration() {
     let db = ThingsDatabase::new(&config.database_path).await.unwrap();
 
     // Test MCP server creation
-    let server = things3_cli::mcp::ThingsMcpServer::new(db.into(), config);
+    let server = things3_cli::mcp::ThingsMcpServer::new(db.into(), config, true);
 
     // Test tool listing
     let tools = server.list_tools().unwrap();

--- a/apps/things3-cli/tests/mcp_bulk_operations_tests.rs
+++ b/apps/things3-cli/tests/mcp_bulk_operations_tests.rs
@@ -18,7 +18,7 @@ impl McpTestHarness {
         create_test_database(db_path).await.unwrap();
         let db = ThingsDatabase::new(db_path).await.unwrap();
         let config = ThingsConfig::default();
-        let server = ThingsMcpServer::new(std::sync::Arc::new(db), config);
+        let server = ThingsMcpServer::new(std::sync::Arc::new(db), config, true);
 
         Self {
             server,

--- a/apps/things3-cli/tests/mcp_io_tests.rs
+++ b/apps/things3-cli/tests/mcp_io_tests.rs
@@ -159,7 +159,7 @@ async fn run_initialize_handshake_for(
     let (server_io, mut client_io) = MockIo::create_pair(4096);
 
     let server_handle =
-        tokio::spawn(async move { start_mcp_server_generic(db, config, server_io).await });
+        tokio::spawn(async move { start_mcp_server_generic(db, config, server_io, true).await });
 
     let initialize_request = json!({
         "jsonrpc": "2.0",
@@ -235,7 +235,7 @@ async fn test_initialize_response_structure() {
 
     let (server_io, mut client_io) = MockIo::create_pair(4096);
 
-    tokio::spawn(async move { start_mcp_server_generic(db, config, server_io).await });
+    tokio::spawn(async move { start_mcp_server_generic(db, config, server_io, true).await });
 
     let initialize_request = json!({
         "jsonrpc": "2.0",
@@ -269,7 +269,7 @@ async fn test_tools_list() {
 
     let (server_io, mut client_io) = MockIo::create_pair(4096);
 
-    tokio::spawn(async move { start_mcp_server_generic(db, config, server_io).await });
+    tokio::spawn(async move { start_mcp_server_generic(db, config, server_io, true).await });
 
     let tools_list_request = json!({
         "jsonrpc": "2.0",
@@ -306,7 +306,7 @@ async fn test_tools_call_get_today() {
 
     let (server_io, mut client_io) = MockIo::create_pair(4096);
 
-    tokio::spawn(async move { start_mcp_server_generic(db, config, server_io).await });
+    tokio::spawn(async move { start_mcp_server_generic(db, config, server_io, true).await });
 
     let tools_call_request = json!({
         "jsonrpc": "2.0",
@@ -338,7 +338,7 @@ async fn test_tools_call_get_inbox() {
 
     let (server_io, mut client_io) = MockIo::create_pair(4096);
 
-    tokio::spawn(async move { start_mcp_server_generic(db, config, server_io).await });
+    tokio::spawn(async move { start_mcp_server_generic(db, config, server_io, true).await });
 
     let tools_call_request = json!({
         "jsonrpc": "2.0",
@@ -376,7 +376,7 @@ async fn test_content_block_serialization() {
 
     let (server_io, mut client_io) = MockIo::create_pair(4096);
 
-    tokio::spawn(async move { start_mcp_server_generic(db, config, server_io).await });
+    tokio::spawn(async move { start_mcp_server_generic(db, config, server_io, true).await });
 
     let response = send_request_read_response(
         &mut client_io,
@@ -426,7 +426,7 @@ async fn test_tools_call_nonexistent_tool() {
     let (server_io, mut client_io) = MockIo::create_pair(4096);
 
     let server_handle =
-        tokio::spawn(async move { start_mcp_server_generic(db, config, server_io).await });
+        tokio::spawn(async move { start_mcp_server_generic(db, config, server_io, true).await });
 
     let tools_call_request = json!({
         "jsonrpc": "2.0",
@@ -475,7 +475,7 @@ async fn test_resources_list() {
 
     let (server_io, mut client_io) = MockIo::create_pair(4096);
 
-    tokio::spawn(async move { start_mcp_server_generic(db, config, server_io).await });
+    tokio::spawn(async move { start_mcp_server_generic(db, config, server_io, true).await });
 
     let resources_list_request = json!({
         "jsonrpc": "2.0",
@@ -504,7 +504,7 @@ async fn test_resources_read() {
     let (server_io, mut client_io) = MockIo::create_pair(4096);
 
     let server_handle =
-        tokio::spawn(async move { start_mcp_server_generic(db, config, server_io).await });
+        tokio::spawn(async move { start_mcp_server_generic(db, config, server_io, true).await });
 
     let resources_read_request = json!({
         "jsonrpc": "2.0",
@@ -547,7 +547,7 @@ async fn test_prompts_list() {
 
     let (server_io, mut client_io) = MockIo::create_pair(4096);
 
-    tokio::spawn(async move { start_mcp_server_generic(db, config, server_io).await });
+    tokio::spawn(async move { start_mcp_server_generic(db, config, server_io, true).await });
 
     let prompts_list_request = json!({
         "jsonrpc": "2.0",
@@ -570,7 +570,7 @@ async fn test_prompts_get() {
     let (server_io, mut client_io) = MockIo::create_pair(4096);
 
     let server_handle =
-        tokio::spawn(async move { start_mcp_server_generic(db, config, server_io).await });
+        tokio::spawn(async move { start_mcp_server_generic(db, config, server_io, true).await });
 
     let prompts_get_request = json!({
         "jsonrpc": "2.0",
@@ -615,7 +615,7 @@ async fn test_malformed_json() {
     let (server_io, mut client_io) = MockIo::create_pair(4096);
 
     let server_handle =
-        tokio::spawn(async move { start_mcp_server_generic(db, config, server_io).await });
+        tokio::spawn(async move { start_mcp_server_generic(db, config, server_io, true).await });
 
     // Send malformed JSON
     client_io.write_line("{invalid json}").await.unwrap();
@@ -637,7 +637,7 @@ async fn test_missing_method() {
 
     let (server_io, mut client_io) = MockIo::create_pair(4096);
 
-    tokio::spawn(async move { start_mcp_server_generic(db, config, server_io).await });
+    tokio::spawn(async move { start_mcp_server_generic(db, config, server_io, true).await });
 
     let request_without_method = json!({
         "jsonrpc": "2.0",
@@ -664,7 +664,7 @@ async fn test_unknown_method() {
 
     let (server_io, mut client_io) = MockIo::create_pair(4096);
 
-    tokio::spawn(async move { start_mcp_server_generic(db, config, server_io).await });
+    tokio::spawn(async move { start_mcp_server_generic(db, config, server_io, true).await });
 
     let unknown_method_request = json!({
         "jsonrpc": "2.0",
@@ -688,7 +688,7 @@ async fn test_empty_line_handling() {
 
     let (server_io, mut client_io) = MockIo::create_pair(4096);
 
-    tokio::spawn(async move { start_mcp_server_generic(db, config, server_io).await });
+    tokio::spawn(async move { start_mcp_server_generic(db, config, server_io, true).await });
 
     // Send empty lines (should be ignored)
     client_io.write_line("").await.unwrap();
@@ -721,7 +721,7 @@ async fn test_multiple_sequential_requests() {
 
     let (server_io, mut client_io) = MockIo::create_pair(8192);
 
-    tokio::spawn(async move { start_mcp_server_generic(db, config, server_io).await });
+    tokio::spawn(async move { start_mcp_server_generic(db, config, server_io, true).await });
 
     // Send multiple requests
     for i in 1..=5 {
@@ -747,7 +747,7 @@ async fn test_notification_no_response() {
 
     let (server_io, mut client_io) = MockIo::create_pair(4096);
 
-    tokio::spawn(async move { start_mcp_server_generic(db, config, server_io).await });
+    tokio::spawn(async move { start_mcp_server_generic(db, config, server_io, true).await });
 
     // Send notification (no id field)
     let notification = json!({
@@ -788,9 +788,9 @@ async fn test_start_mcp_server_with_config() {
 
     let (server_io, mut client_io) = MockIo::create_pair(4096);
 
-    tokio::spawn(
-        async move { start_mcp_server_with_config_generic(db, mcp_config, server_io).await },
-    );
+    tokio::spawn(async move {
+        start_mcp_server_with_config_generic(db, mcp_config, server_io, true).await
+    });
 
     // Test that server works with config
     let initialize_request = json!({
@@ -817,9 +817,9 @@ async fn test_start_mcp_server_with_config_tools() {
 
     let (server_io, mut client_io) = MockIo::create_pair(4096);
 
-    tokio::spawn(
-        async move { start_mcp_server_with_config_generic(db, mcp_config, server_io).await },
-    );
+    tokio::spawn(async move {
+        start_mcp_server_with_config_generic(db, mcp_config, server_io, true).await
+    });
 
     // Test tools/call with config
     let tools_call_request = json!({
@@ -847,7 +847,7 @@ async fn test_io_error_handling() {
     let (server_io, client_io) = MockIo::create_pair(4096);
 
     let server_handle =
-        tokio::spawn(async move { start_mcp_server_generic(db, config, server_io).await });
+        tokio::spawn(async move { start_mcp_server_generic(db, config, server_io, true).await });
 
     // Drop client immediately to trigger EOF
     drop(client_io);
@@ -869,7 +869,7 @@ async fn test_json_serialization_coverage() {
 
     let (server_io, mut client_io) = MockIo::create_pair(4096);
 
-    tokio::spawn(async move { start_mcp_server_generic(db, config, server_io).await });
+    tokio::spawn(async move { start_mcp_server_generic(db, config, server_io, true).await });
 
     // Test various request types to cover more code paths
     let requests = vec![
@@ -892,7 +892,7 @@ async fn test_mixed_requests_and_notifications() {
 
     let (server_io, mut client_io) = MockIo::create_pair(4096);
 
-    tokio::spawn(async move { start_mcp_server_generic(db, config, server_io).await });
+    tokio::spawn(async move { start_mcp_server_generic(db, config, server_io, true).await });
 
     // Send a mix of requests and notifications
     let notification = json!({
@@ -923,7 +923,7 @@ async fn test_all_available_tools() {
 
     let (server_io, mut client_io) = MockIo::create_pair(8192);
 
-    tokio::spawn(async move { start_mcp_server_generic(db, config, server_io).await });
+    tokio::spawn(async move { start_mcp_server_generic(db, config, server_io, true).await });
 
     // Get list of tools
     let tools_list_request = json!({
@@ -964,7 +964,7 @@ async fn test_large_response_handling() {
 
     let (server_io, mut client_io) = MockIo::create_pair(65536); // Large buffer
 
-    tokio::spawn(async move { start_mcp_server_generic(db, config, server_io).await });
+    tokio::spawn(async move { start_mcp_server_generic(db, config, server_io, true).await });
 
     // Request that might return large data
     let request = json!({
@@ -989,7 +989,7 @@ async fn test_sequential_initialize_calls() {
 
     let (server_io, mut client_io) = MockIo::create_pair(4096);
 
-    tokio::spawn(async move { start_mcp_server_generic(db, config, server_io).await });
+    tokio::spawn(async move { start_mcp_server_generic(db, config, server_io, true).await });
 
     // Call initialize multiple times (should handle gracefully)
     for i in 1..=3 {
@@ -1017,9 +1017,9 @@ async fn test_config_with_empty_lines() {
 
     let (server_io, mut client_io) = MockIo::create_pair(4096);
 
-    tokio::spawn(
-        async move { start_mcp_server_with_config_generic(db, mcp_config, server_io).await },
-    );
+    tokio::spawn(async move {
+        start_mcp_server_with_config_generic(db, mcp_config, server_io, true).await
+    });
 
     // Send empty lines (should be skipped)
     client_io.write_line("").await.unwrap();
@@ -1046,7 +1046,7 @@ async fn test_rapid_requests() {
 
     let (server_io, mut client_io) = MockIo::create_pair(32768); // Extra large buffer
 
-    tokio::spawn(async move { start_mcp_server_generic(db, config, server_io).await });
+    tokio::spawn(async move { start_mcp_server_generic(db, config, server_io, true).await });
 
     // Send many requests rapidly
     for i in 1..=20 {

--- a/apps/things3-cli/tests/mcp_tests/common.rs
+++ b/apps/things3-cli/tests/mcp_tests/common.rs
@@ -17,7 +17,7 @@ pub(crate) async fn create_test_mcp_server() -> ThingsMcpServer {
     create_test_schema(&db).await.unwrap();
 
     let config = ThingsConfig::for_testing().unwrap();
-    ThingsMcpServer::new(db.into(), config)
+    ThingsMcpServer::new(db.into(), config, true)
 }
 
 /// Create the test database schema

--- a/apps/things3-cli/tests/mcp_tests_legacy.rs
+++ b/apps/things3-cli/tests/mcp_tests_legacy.rs
@@ -26,7 +26,7 @@ async fn create_test_mcp_server() -> ThingsMcpServer {
     create_test_schema(&db).await.unwrap();
 
     let config = ThingsConfig::for_testing().unwrap();
-    ThingsMcpServer::new(db.into(), config)
+    ThingsMcpServer::new(db.into(), config, true)
 }
 
 /// Create the test database schema
@@ -824,7 +824,10 @@ async fn test_list_backups_tool_missing_backup_dir() {
 
 #[tokio::test]
 async fn test_restore_database_tool() {
-    let server = create_test_mcp_server().await;
+    let mut server = create_test_mcp_server().await;
+    // Bypass the "is Things 3 running" gate (#126); we want to exercise the
+    // BackupManager path, not the safety precondition.
+    server.set_process_check_for_test(|| false);
     let temp_file = tempfile::NamedTempFile::new().unwrap();
     let backup_path = temp_file.path().to_str().unwrap();
 
@@ -2640,7 +2643,7 @@ async fn test_mcp_server_with_custom_middleware() {
     let config = ThingsConfig::new(db_path, false);
     let middleware_config = MiddlewareConfig::default();
 
-    let server = ThingsMcpServer::with_middleware_config(db, config, middleware_config);
+    let server = ThingsMcpServer::with_middleware_config(db, config, middleware_config, true);
     assert!(!server.middleware_chain().is_empty());
 }
 

--- a/apps/things3-cli/tests/mcp_write_operations_tests.rs
+++ b/apps/things3-cli/tests/mcp_write_operations_tests.rs
@@ -17,7 +17,7 @@ impl McpTestHarness {
         create_test_database(db_path).await.unwrap();
         let db = ThingsDatabase::new(db_path).await.unwrap();
         let config = ThingsConfig::default();
-        let server = ThingsMcpServer::new(std::sync::Arc::new(db), config);
+        let server = ThingsMcpServer::new(std::sync::Arc::new(db), config, true);
 
         Self {
             server,

--- a/libs/things3-core/src/lib.rs
+++ b/libs/things3-core/src/lib.rs
@@ -127,6 +127,8 @@ pub use export::{DataExporter, ExportConfig, ExportData, ExportFormat};
 pub use mcp_cache_middleware::{MCPCacheConfig, MCPCacheEntry, MCPCacheMiddleware, MCPCacheStats};
 pub use mcp_config::McpServerConfig;
 pub use models::*;
+#[cfg(target_os = "macos")]
+pub use mutations::AppleScriptBackend;
 pub use mutations::{MutationBackend, SqlxBackend};
 // Explicitly re-export DeleteChildHandling for clarity
 pub use models::DeleteChildHandling;

--- a/libs/things3-core/src/mutations/applescript/mod.rs
+++ b/libs/things3-core/src/mutations/applescript/mod.rs
@@ -210,6 +210,10 @@ const MAX_BULK_BATCH_SIZE: usize = 1000;
 
 #[async_trait]
 impl MutationBackend for AppleScriptBackend {
+    fn kind(&self) -> &'static str {
+        "applescript"
+    }
+
     // ---- Tasks (Phase B — implemented) ----
 
     async fn create_task(&self, request: CreateTaskRequest) -> ThingsResult<ThingsId> {

--- a/libs/things3-core/src/mutations/mod.rs
+++ b/libs/things3-core/src/mutations/mod.rs
@@ -47,7 +47,9 @@ pub trait MutationBackend: Send + Sync {
     /// Static identifier for the backend implementation. Used by the MCP server
     /// to expose which backend is in use (`"sqlx"` direct-DB vs. `"applescript"`
     /// CulturedCode-supported) without an `Any` downcast.
-    fn kind(&self) -> &'static str;
+    fn kind(&self) -> &'static str {
+        "unknown"
+    }
 
     // ---- Tasks ----
 

--- a/libs/things3-core/src/mutations/mod.rs
+++ b/libs/things3-core/src/mutations/mod.rs
@@ -44,6 +44,11 @@ pub use applescript::AppleScriptBackend;
 /// async tasks via `Arc<dyn MutationBackend>`.
 #[async_trait]
 pub trait MutationBackend: Send + Sync {
+    /// Static identifier for the backend implementation. Used by the MCP server
+    /// to expose which backend is in use (`"sqlx"` direct-DB vs. `"applescript"`
+    /// CulturedCode-supported) without an `Any` downcast.
+    fn kind(&self) -> &'static str;
+
     // ---- Tasks ----
 
     async fn create_task(&self, request: CreateTaskRequest) -> ThingsResult<ThingsId>;

--- a/libs/things3-core/src/mutations/sqlx.rs
+++ b/libs/things3-core/src/mutations/sqlx.rs
@@ -33,6 +33,10 @@ impl SqlxBackend {
 
 #[async_trait]
 impl MutationBackend for SqlxBackend {
+    fn kind(&self) -> &'static str {
+        "sqlx"
+    }
+
     // ---- Tasks ----
 
     async fn create_task(&self, request: CreateTaskRequest) -> ThingsResult<ThingsId> {


### PR DESCRIPTION
## Summary

- **Flips the production default on macOS** from `SqlxBackend` (direct SQLite writes, CulturedCode-warned-against) to `AppleScriptBackend` (CulturedCode-supported osascript path). Linux/CI keeps `SqlxBackend` as the silent default — no Things 3 install to corrupt.
- **`--unsafe-direct-db` / `THINGS_UNSAFE_DIRECT_DB=1`** opts back into the deprecated direct-DB path with a loud multi-line startup warning (suppressed entirely in MCP mode for JSON-RPC purity — stderr must stay empty).
- **`restore_database` is now double-gated**: requires the flag AND Things 3 not running (`pgrep -x Things3`). Argument-parse errors still fire first, preserving existing client error semantics.
- Adds `MutationBackend::kind()` (`"sqlx"` / `"applescript"`) for introspection without `Any` downcast.
- Adds `select_default_backend()` platform-aware helper, `is_things3_running()`, and `process_check: fn() -> bool` field on `ThingsMcpServer` for test injection.
- 4 new `backend_selection_tests`: default backend, flag override, restore refuses without flag, restore refuses when Things 3 running.
- All existing test call sites pass `unsafe_direct_db = true` to keep `SqlxBackend` in tests (avoids live osascript calls against temp DBs).

## Test plan

- [ ] `cargo build --all-targets --all-features` — clean
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [ ] `cargo test --workspace --all-features` — all pass
- [ ] macOS smoke: `cargo run --bin things3 -- mcp` via MCP client — `create_task` routes through osascript (visible in Things 3 UI)
- [ ] `cargo run --bin things3 -- --unsafe-direct-db health` — deprecation banner prints to stderr
- [ ] `THINGS_UNSAFE_DIRECT_DB=1 cargo run --bin things3 -- health` — same banner via env var
- [ ] `restore_database` without flag → error mentions `--unsafe-direct-db`
- [ ] `restore_database` with flag, Things 3 running → error tells user to quit Things 3
- [ ] MCP mode with `--unsafe-direct-db` → no banner on stderr (JSON-RPC purity preserved)

Closes #125
Closes #126
Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)