### PR TITLE
docs(skills): document AppleScript backend + add things3-inbox-triage skill

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -8,6 +8,7 @@ Reusable skill files for driving Things 3 from AI agents via the rust-things3 MC
 |-------|-------------|
 | [`things3`](things3/SKILL.md) | Foundational skill — MCP setup and full tool catalog. Use this first; other skills depend on it for setup. |
 | [`things3-daily-review`](things3-daily-review/SKILL.md) | Read-only daily review workflow. Pulls today's tasks, inbox, and recent work; produces a structured Markdown summary grouped by area and project with overdue items flagged. |
+| [`things3-inbox-triage`](things3-inbox-triage/SKILL.md) | GTD-style inbox triage. Walks each inbox item, classifies it (do-now / schedule / delegate / archive / delete), and applies the user's choice via MCP write tools. Confirms before destructive ops. |
 
 ## Install instructions
 
@@ -16,15 +17,16 @@ Skills are loaded from a local directory that your AI host watches. The steps be
 ### Claude Code
 
 ```bash
-# Copy both skills to your Claude Code skills directory
+# Copy all skills to your Claude Code skills directory
 cp -r skills/things3 ~/.claude/skills/things3
 cp -r skills/things3-daily-review ~/.claude/skills/things3-daily-review
+cp -r skills/things3-inbox-triage ~/.claude/skills/things3-inbox-triage
 ```
 
 Then add `trigger` keys so the skills are available as slash commands:
 
 ```bash
-for skill in things3 things3-daily-review; do
+for skill in things3 things3-daily-review things3-inbox-triage; do
   python3 -c "
 import pathlib, re
 p = pathlib.Path('~/.claude/skills/$skill/SKILL.md').expanduser()
@@ -33,7 +35,7 @@ p.write_text(re.sub(r'(?m)^---$(?=\n\n)', 'trigger: /$skill\n---', p.read_text()
 done
 ```
 
-Use with `/things3` and `/things3-daily-review` in Claude Code.
+Use with `/things3`, `/things3-daily-review`, and `/things3-inbox-triage` in Claude Code.
 
 ### Claude Desktop, Cursor, Zed
 
@@ -42,6 +44,7 @@ Check your host's documentation for the skills directory path, then copy the ski
 ```bash
 cp -r skills/things3 /path/to/host/skills/things3
 cp -r skills/things3-daily-review /path/to/host/skills/things3-daily-review
+cp -r skills/things3-inbox-triage /path/to/host/skills/things3-inbox-triage
 ```
 
 ## Spec compliance
@@ -52,6 +55,7 @@ Skills are validated with [`skills-ref`](https://pypi.org/project/skills-ref/) (
 pip install skills-ref
 agentskills validate skills/things3
 agentskills validate skills/things3-daily-review
+agentskills validate skills/things3-inbox-triage
 ```
 
 CI runs this automatically on every PR that touches `skills/`.

--- a/skills/things3-daily-review/SKILL.md
+++ b/skills/things3-daily-review/SKILL.md
@@ -134,5 +134,5 @@ Flag overdue items in both the **Today** and **Recent** sections wherever they a
 
 ## Notes
 
-- This skill is read-only — it makes no mutations. For processing inbox items, see the companion `things3-inbox-triage` skill (coming soon).
+- This skill is read-only — it makes no mutations. For processing inbox items, see the companion [`things3-inbox-triage`](../things3-inbox-triage/SKILL.md) skill.
 - Things 3 must be running on macOS for the MCP server to reach its database.

--- a/skills/things3-inbox-triage/SKILL.md
+++ b/skills/things3-inbox-triage/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: things3-inbox-triage
+description: GTD-style inbox triage for Things 3 — walks every item in the inbox, classifies it (do-now, schedule, delegate, archive, delete), and applies the user's choice via MCP write tools. Requires explicit confirmation before any destructive op. Use when the user wants to "triage", "process", or "clear" their Things 3 inbox.
+---
+
+# /things3-inbox-triage
+
+A GTD-style inbox triage workflow over the [rust-things3](https://github.com/GarthDB/rust-things3) MCP server. Walks each inbox item with the user, applies their disposition, and confirms before deletion. Companion to `things3-daily-review` — the daily-review skill is read-only; this one writes.
+
+## Claude Code slash command
+
+To use `/things3-inbox-triage` as a Claude Code slash command, copy the skill to your local skills directory and patch in a `trigger` key. The canonical file omits it because `skills-ref validate` rejects unknown frontmatter fields.
+
+```bash
+cp -r skills/things3-inbox-triage ~/.claude/skills/things3-inbox-triage
+python3 -c "
+import pathlib, re
+p = pathlib.Path('~/.claude/skills/things3-inbox-triage/SKILL.md').expanduser()
+p.write_text(re.sub(r'(?m)^---\$(?=\n\n)', 'trigger: /things3-inbox-triage\n---', p.read_text(), count=1))
+"
+```
+
+## Prerequisites
+
+The `things3` foundational skill must be installed and the MCP server configured before running this workflow — see [`../things3/SKILL.md`](../things3/SKILL.md) for setup instructions.
+
+**Backend note.** Writes route through AppleScript by default on macOS (see [`../things3/SKILL.md` → Mutation backend](../things3/SKILL.md#mutation-backend)). The first write of the session may trigger a one-time macOS Automation permission prompt; grant it and continue.
+
+## When to use this skill
+
+- Clearing a piled-up Things 3 inbox during a weekly review
+- Processing items captured throughout the day before end-of-day shutdown
+- Any time the user says "triage my inbox", "process my inbox", or "get to inbox zero"
+
+## Recipe
+
+### Step 1 — Pull the inbox
+
+```json
+{
+  "name": "get_inbox",
+  "arguments": { "limit": 50 }
+}
+```
+
+If the response is empty, report "Inbox is clear" and stop. Otherwise, present a one-line count: "N items to triage."
+
+### Step 2 — Walk each item, classify, apply
+
+For **each** inbox item, in the order returned:
+
+1. **Show the item.** Display `title`, `notes` (if present), and any existing `tags` so the user can decide without switching to Things 3.
+2. **Ask for a disposition** — exactly one of:
+   - **do-now** — do or schedule for today
+   - **schedule** — defer to a future date
+   - **delegate** — hand off (typically tagged `@waiting`)
+   - **archive** — already done, mark complete
+   - **delete** — capture mistake; remove from inbox
+3. **Apply the choice** by calling the matching tool below. Confirm to the user with a one-line acknowledgement (e.g. "✓ scheduled for 2026-05-10") and move to the next item.
+
+| Disposition | MCP call | Notes |
+|---|---|---|
+| **do-now** | `update_task` with `start_date` = today (or move to a project) | Optional: also `add_tag_to_task` with `today` if the user uses that convention |
+| **schedule** | `update_task` with `start_date` = future date and/or `deadline` | Ask for the date if the user did not supply one |
+| **delegate** | `add_tag_to_task` with `tag_title: "@waiting"` (adjust to user's convention); optionally `update_task` to append a `notes` line "delegated to NAME" | The task stays in the inbox (or is moved to a "Waiting" project if the user has one) |
+| **archive** | `complete_task` | Use when the item was already finished |
+| **delete** | **Confirm first** with the user (show title + ask "delete this?"), then `delete_task` | `delete_task` is a soft-delete (moves to Trash); not reversible from this skill |
+
+**Confirmation rule for `delete_task`.** Always re-show the item title and ask for explicit "yes" before calling `delete_task`. Do not batch-confirm a list. This is the only step in this skill that requires a hard stop.
+
+### Step 3 — Bulk shortcuts (optional)
+
+If the user wants to fast-path a group of similar items, prefer the bulk tools over a loop:
+
+- `bulk_complete` — archive several items at once
+- `bulk_move` — relocate several items into a project or area
+- `bulk_update_dates` — schedule several items for the same date
+- `bulk_delete` — **only after** the user confirms the full list
+
+Bulk calls run a single AppleScript and report per-item success/failure in the response. Re-run `get_inbox` after a bulk op to confirm what landed.
+
+### Step 4 — Confirm completion
+
+After the last item:
+
+```json
+{
+  "name": "get_inbox",
+  "arguments": { "limit": 50 }
+}
+```
+
+Report the final state:
+- "Inbox cleared." if empty.
+- "N item(s) remaining" with the titles, if the user stopped early.
+
+## Output format
+
+Each item-pass produces a compact log line, suitable for streaming back to the user:
+
+```
+[1/12] "Email Q3 vendor list" — schedule → 2026-05-10
+[2/12] "Pick up dry cleaning" — do-now (today)
+[3/12] "Old TODO from December" — delete (confirmed)
+```
+
+Tally at the end:
+
+```
+Triage summary
+  do-now:    2
+  schedule:  5
+  delegate:  1
+  archive:   3
+  delete:    1
+  remaining: 0
+```
+
+## Notes
+
+- Delete is a soft-delete — items move to the Things 3 Trash. The MCP server has no tool to permanently purge or restore from Trash; users do that in the Things 3 UI.
+- For the read-only complement (today's plan, recent work, overdue), see the companion `things3-daily-review` skill.
+- This skill is a recipe, not a guarantee — if any tool call fails (e.g. macOS Automation permission revoked), surface the error to the user and stop the loop rather than skipping items silently.

--- a/skills/things3/SKILL.md
+++ b/skills/things3/SKILL.md
@@ -28,6 +28,36 @@ The `things3` CLI must be installed and the MCP server must be configured in you
 
 **Things 3 must be running** on macOS for the MCP server to reach its database.
 
+## Mutation backend
+
+On macOS, all 24 write tools route through **AppleScript** by default — CulturedCode's documented scripting API. Reads continue to use direct SQLite. This is the safe-by-default configuration: the data-corruption risk that motivated CulturedCode's [warning against direct database writes](https://culturedcode.com/things/support/articles/5510170/) does not apply to AppleScript-mediated mutations.
+
+### One-time Automation permission
+
+The first write triggers a macOS prompt asking your terminal/host to control Things 3. Grant it once. If denied or later revoked, you will see:
+
+> macOS Automation permission denied. Grant access in System Settings → Privacy & Security → Automation, then retry.
+
+Re-enable in **System Settings → Privacy & Security → Automation**, then retry the call.
+
+### `--unsafe-direct-db` opt-in (discouraged)
+
+The deprecated direct-SQLite backend (`SqlxBackend`) can be re-enabled with `--unsafe-direct-db` or `THINGS_UNSAFE_DIRECT_DB=1`. CulturedCode warns that direct writes "can corrupt your data and break syncs." Use only when:
+
+- Running on non-macOS (Linux/CI), where AppleScript is unavailable.
+- You explicitly need `restore_database` (see below).
+
+This flag will be removed in a future release.
+
+### `restore_database` is gated
+
+`restore_database` overwrites the live SQLite file and is the highest-corruption operation the server exposes. It refuses to run unless **both** conditions hold:
+
+1. The server was launched with `--unsafe-direct-db` (or `THINGS_UNSAFE_DIRECT_DB=1`).
+2. Things 3 is **not** running. Quit Things 3 (Cmd-Q) before invoking.
+
+Without (1) you get a structured validation error pointing to the CulturedCode article. Without (2) you get a "refuses to run while Things 3 is open" error.
+
 ## When to use this skill
 
 - Reading inbox, today, or project task lists
@@ -161,7 +191,7 @@ The server also exposes four prompt templates: `task_review`, `project_planning`
 
 ## Notes
 
-- **Things 3 must be open** on macOS. The server reads directly from the SQLite database at `~/Library/Group Containers/JLMPQHK86H.com.culturedcode.ThingsMac/ThingsData-*/Containers/com.culturedcode.ThingsMac/Data/Library/Application Support/Cultured Code/Things 3/Things Database.thingsdatabase/main.sqlite`.
-- Override the path with `THINGS_DB_PATH` env var.
+- **Things 3 must be open** on macOS. The server reads directly from the SQLite database at `~/Library/Group Containers/JLMPQHK86H.com.culturedcode.ThingsMac/ThingsData-*/Containers/com.culturedcode.ThingsMac/Data/Library/Application Support/Cultured Code/Things 3/Things Database.thingsdatabase/main.sqlite`. Writes go through AppleScript — see [Mutation backend](#mutation-backend).
+- Override the read database path with `THINGS_DB_PATH` env var.
 - `delete_task` / `delete_project` are soft-deletes (move to Trash). There is no MCP tool to permanently purge or restore from Trash.
 - For full parameter schemas and advanced configuration, see [`docs/MCP_INTEGRATION.md`](../../docs/MCP_INTEGRATION.md).

--- a/skills/things3/references/TOOLS.md
+++ b/skills/things3/references/TOOLS.md
@@ -61,6 +61,8 @@ All fields optional. `limit` max 500, default 50.
 
 ---
 
+> **Mutation backend.** All write tools below (Task / Project / Area / Bulk / Tag CRUD / Tag assignment) route through **AppleScript** by default on macOS — CulturedCode-supported, no data-corruption risk. First call may trigger a macOS Automation permission prompt. To re-enable the deprecated direct-SQLite backend (e.g. on Linux/CI), launch with `--unsafe-direct-db` or `THINGS_UNSAFE_DIRECT_DB=1`. See [SKILL.md → Mutation backend](../SKILL.md#mutation-backend) for full details.
+
 ## Task mutations
 
 ### `create_task`
@@ -195,7 +197,10 @@ Soft-delete a project.
 
 ---
 
-## Bulk operations (all transactional — all-or-nothing)
+## Bulk operations
+
+Each bulk call processes its items in a single AppleScript invocation with per-item try/catch. The result reports `success: true` only when every item succeeded; partial failures surface via the response message and `processed_count`. (Pre-AppleScript, these were SQL transactions — all-or-nothing — but the database is no longer written to directly.)
+
 
 ### `bulk_move`
 Move multiple tasks to a project or area.
@@ -352,9 +357,17 @@ Full data export. No parameters.
 Create a database backup. No parameters.
 
 ### `restore_database`
-Restore from backup. No parameters in the current MCP API — the backup path cannot be specified via this tool. If you have multiple backups (see `list_backups`), you will need to restore the desired file to the default backup location before calling this tool, or restore manually outside the MCP server.
+Restore from a specific backup file. Overwrites the live Things 3 SQLite file directly.
+```json
+{ "backup_path": "/path/to/backup.sqlite" }
+```
+`backup_path` required.
 
-> **Known gap**: `list_backups` accepts a `backup_dir` and implies multiple backups may exist, but `restore_database` provides no way to select among them. Tracked in #126.
+> **Gated.** This tool refuses to run unless **both** are true:
+> 1. The server was launched with `--unsafe-direct-db` (or `THINGS_UNSAFE_DIRECT_DB=1`). Without this flag the call returns a validation error referencing the [CulturedCode warning](https://culturedcode.com/things/support/articles/5510170/).
+> 2. Things 3 is not running. Quit Things 3 (Cmd-Q) first.
+>
+> See [SKILL.md → Mutation backend](../SKILL.md#mutation-backend) for the rationale.
 
 ### `list_backups`
 ```json


### PR DESCRIPTION
## Summary

- **#127** — Updates `skills/things3/SKILL.md` with a new "Mutation backend" section (AppleScript-default on macOS, one-time Automation permission UX, `--unsafe-direct-db` opt-in with CulturedCode warning quoted, `restore_database` gating). Also updates `references/TOOLS.md`: backend banner above all mutation sections; rewrote `restore_database` entry (correct `backup_path` param + both gates); softened bulk-ops "transactional" claim (AppleScript is per-item try/catch, not a SQL transaction).
- **#113** — Adds `skills/things3-inbox-triage/SKILL.md`: GTD-style five-disposition triage (do-now / schedule / delegate / archive / delete) with mandatory user confirmation before `delete_task`. References `things3` foundational skill for setup; does not duplicate install instructions.
- Housekeeping: replaces the "(coming soon)" footer link in `things3-daily-review`, adds the new skill to the table and all install paths in `skills/README.md`.

Closes #127. Closes #113.

## Test plan

- [x] `agentskills validate skills/things3` passes (CI runs this automatically)
- [x] `agentskills validate skills/things3-daily-review` passes
- [x] `agentskills validate skills/things3-inbox-triage` passes
- [x] Read through `things3/SKILL.md` → Mutation backend as a new user: data-corruption risk addressed, permission prompt explained, `--unsafe-direct-db` use cases clear
- [x] Read `things3-inbox-triage/SKILL.md`: five dispositions map to MCP tools, delete requires explicit confirm, references (doesn't duplicate) foundational setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)