### PR TITLE
fix(mcp): recover from handler errors instead of dropping the connection (#148)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CI: skills frontmatter validation** (#114) — new `.github/workflows/skills.yml` runs `agentskills validate` (PyPI `skills-ref==0.1.1`) on every `skills/*/` directory for PRs that touch `skills/**`. Fails the job if any skill is spec-invalid.
 
 ### Fixed
+- **MCP tool errors no longer drop the connection** (#148) — when a `tools/call`, `resources/read`, or `prompts/get` handler returned an error (e.g. AppleScriptBackend rejecting a malformed task ID with `-1728`), the request loop's `?` propagation terminated the loop, surfacing to the client as `MCP error -32000: Connection closed`. Tool/resource/prompt errors now flow through the existing `*_with_fallback` variants and come back as structured `isError: true` envelopes inside the JSON-RPC `result`; any remaining handler-level error is converted to a JSON-RPC error response (-32600) instead of killing the loop. The server stays up; subsequent requests are answered.
 - **MCP `Prompt.arguments` shape** (#119) — `Prompt.arguments` was a `serde_json::Value` holding a JSON Schema object, which is spec-invalid; the MCP 2025-11-25 spec requires `Vec<PromptArgument>`. Adds a `PromptArgument` struct (`name`, optional `description`, `required: bool`), rewrites the four `create_*_prompt()` helpers, and enables full `ListPromptsResult` schema validation in `test_prompts_list` (previously skipped because of this bug). Spec-strict clients like Claude Code 2.1+ now render prompt arguments correctly.
 
 ## [1.3.0] - 2026-04-27

--- a/apps/things3-cli/src/mcp.rs
+++ b/apps/things3-cli/src/mcp.rs
@@ -579,23 +579,23 @@ pub struct ThingsMcpServer {
 /// the result. Only protocol-level failures (missing method, malformed params)
 /// reach this helper.
 fn build_jsonrpc_error_response(
-    request: &serde_json::Value,
+    id: Option<serde_json::Value>,
     err: &things3_core::ThingsError,
 ) -> Option<serde_json::Value> {
     use serde_json::json;
 
-    // Notifications don't get responses, even on error.
-    let id = request.get("id")?.clone();
+    // Notifications (no `id`) must not receive a response per JSON-RPC 2.0.
+    let id = id?;
 
-    // -32600 (Invalid Request) covers the protocol-shape errors that can
-    // currently bubble up: missing `method`, missing tool/resource/prompt
-    // name, etc. Wider catch-all than -32603 because in practice these are
-    // all "your request was malformed" rather than "the server is broken".
+    // -32601 (Method Not Found) is the most precise fit for the protocol-level
+    // failures that reach here: unknown method names, missing dispatch targets.
+    // Use -32603 (Internal Error) only if we ever distinguish structural/parse
+    // errors, which are caught earlier and already map to -32700 / -32600.
     Some(json!({
         "jsonrpc": "2.0",
         "id": id,
         "error": {
-            "code": -32600,
+            "code": -32601,
             "message": err.to_string()
         }
     }))
@@ -656,12 +656,15 @@ pub async fn start_mcp_server_generic<I: McpIo>(
         // Handle the request. If the handler errors we MUST NOT propagate with
         // `?` — that terminates the loop and drops the MCP connection (#148).
         // Convert handler errors into JSON-RPC error responses instead.
+        // Extract `id` before consuming `request` so we can use it in the error
+        // path without cloning the entire request value on every hot-path call.
+        let request_id = request.get("id").cloned();
         let server_clone = Arc::clone(&server);
         let response_opt = {
             let server = server_clone.lock().await;
-            match server.handle_jsonrpc_request(request.clone()).await {
+            match server.handle_jsonrpc_request(request).await {
                 Ok(opt) => opt,
-                Err(e) => build_jsonrpc_error_response(&request, &e),
+                Err(e) => build_jsonrpc_error_response(request_id, &e),
             }
         };
 
@@ -744,12 +747,13 @@ pub async fn start_mcp_server_with_config_generic<I: McpIo>(
         // Handle the request. See note in `start_mcp_server_generic` — handler
         // errors are converted to JSON-RPC error responses instead of being
         // propagated with `?`, which would terminate the loop (#148).
+        let request_id = request.get("id").cloned();
         let server_clone = Arc::clone(&server);
         let response_opt = {
             let server = server_clone.lock().await;
-            match server.handle_jsonrpc_request(request.clone()).await {
+            match server.handle_jsonrpc_request(request).await {
                 Ok(opt) => opt,
-                Err(e) => build_jsonrpc_error_response(&request, &e),
+                Err(e) => build_jsonrpc_error_response(request_id, &e),
             }
         };
 

--- a/apps/things3-cli/src/mcp.rs
+++ b/apps/things3-cli/src/mcp.rs
@@ -563,6 +563,44 @@ pub struct ThingsMcpServer {
     middleware_chain: MiddlewareChain,
 }
 
+/// Build a JSON-RPC error response from a `ThingsError` produced inside the
+/// request loop.
+///
+/// This is the connection-survival path: if `handle_jsonrpc_request` returns
+/// `Err`, we convert it to a structured JSON-RPC error response instead of
+/// propagating with `?` (which would terminate the server loop and drop the
+/// connection — see issue #148).
+///
+/// Returns `None` when the request is a JSON-RPC notification (no `id` field):
+/// the spec forbids responses to notifications, so we silently drop the error.
+///
+/// Tool/resource/prompt errors are NOT routed here — those go through the
+/// `*_with_fallback` variants and surface as `isError: true` envelopes inside
+/// the result. Only protocol-level failures (missing method, malformed params)
+/// reach this helper.
+fn build_jsonrpc_error_response(
+    request: &serde_json::Value,
+    err: &things3_core::ThingsError,
+) -> Option<serde_json::Value> {
+    use serde_json::json;
+
+    // Notifications don't get responses, even on error.
+    let id = request.get("id")?.clone();
+
+    // -32600 (Invalid Request) covers the protocol-shape errors that can
+    // currently bubble up: missing `method`, missing tool/resource/prompt
+    // name, etc. Wider catch-all than -32603 because in practice these are
+    // all "your request was malformed" rather than "the server is broken".
+    Some(json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": {
+            "code": -32600,
+            "message": err.to_string()
+        }
+    }))
+}
+
 #[allow(dead_code)]
 /// Start the MCP server
 ///
@@ -615,12 +653,17 @@ pub async fn start_mcp_server_generic<I: McpIo>(
             things3_core::ThingsError::unknown(format!("Failed to parse JSON-RPC request: {}", e))
         })?;
 
-        // Handle the request
+        // Handle the request. If the handler errors we MUST NOT propagate with
+        // `?` — that terminates the loop and drops the MCP connection (#148).
+        // Convert handler errors into JSON-RPC error responses instead.
         let server_clone = Arc::clone(&server);
         let response_opt = {
             let server = server_clone.lock().await;
-            server.handle_jsonrpc_request(request).await
-        }?;
+            match server.handle_jsonrpc_request(request.clone()).await {
+                Ok(opt) => opt,
+                Err(e) => build_jsonrpc_error_response(&request, &e),
+            }
+        };
 
         // Only write response if this is a request (not a notification)
         if let Some(response) = response_opt {
@@ -698,12 +741,17 @@ pub async fn start_mcp_server_with_config_generic<I: McpIo>(
             things3_core::ThingsError::unknown(format!("Failed to parse JSON-RPC request: {}", e))
         })?;
 
-        // Handle the request
+        // Handle the request. See note in `start_mcp_server_generic` — handler
+        // errors are converted to JSON-RPC error responses instead of being
+        // propagated with `?`, which would terminate the loop (#148).
         let server_clone = Arc::clone(&server);
         let response_opt = {
             let server = server_clone.lock().await;
-            server.handle_jsonrpc_request(request).await
-        }?;
+            match server.handle_jsonrpc_request(request.clone()).await {
+                Ok(opt) => opt,
+                Err(e) => build_jsonrpc_error_response(&request, &e),
+            }
+        };
 
         // Only write response if this is a request (not a notification)
         if let Some(response) = response_opt {
@@ -4587,9 +4635,12 @@ impl ThingsMcpServer {
                     arguments: Some(arguments),
                 };
 
-                let call_result = self.call_tool(call_request).await.map_err(|e| {
-                    things3_core::ThingsError::unknown(format!("Failed to call tool: {}", e))
-                })?;
+                // Use the fallback variant so tool-level failures (e.g. an
+                // AppleScript backend error) come back as a structured
+                // `{"isError": true, "content": [...]}` envelope inside the
+                // JSON-RPC `result`, rather than propagating up as an `Err`
+                // and dropping the MCP connection (#148).
+                let call_result = self.call_tool_with_fallback(call_request).await;
 
                 json!(call_result)
             }
@@ -4609,9 +4660,8 @@ impl ThingsMcpServer {
                     .to_string();
 
                 let read_request = ReadResourceRequest { uri };
-                let read_result = self.read_resource(read_request).await.map_err(|e| {
-                    things3_core::ThingsError::unknown(format!("Failed to read resource: {}", e))
-                })?;
+                // Same envelope pattern as `tools/call` above (#148).
+                let read_result = self.read_resource_with_fallback(read_request).await;
 
                 json!(read_result)
             }
@@ -4638,9 +4688,8 @@ impl ThingsMcpServer {
                     arguments,
                 };
 
-                let get_result = self.get_prompt(get_request).await.map_err(|e| {
-                    things3_core::ThingsError::unknown(format!("Failed to get prompt: {}", e))
-                })?;
+                // Same envelope pattern as `tools/call` above (#148).
+                let get_result = self.get_prompt_with_fallback(get_request).await;
 
                 json!(get_result)
             }

--- a/apps/things3-cli/tests/mcp_io_tests.rs
+++ b/apps/things3-cli/tests/mcp_io_tests.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, OnceLock};
 use tempfile::NamedTempFile;
 use things3_cli::mcp::io_wrapper::{McpIo, MockIo};
-use things3_cli::mcp::start_mcp_server_generic;
+use things3_cli::mcp::{start_mcp_server_generic, start_mcp_server_with_config_generic};
 use things3_core::{ThingsConfig, ThingsDatabase};
 use tokio::time::{timeout, Duration};
 
@@ -561,6 +561,142 @@ async fn test_resources_read_unknown_uri_returns_envelope_not_disconnect() {
     .await;
     assert_eq!(follow_up["id"], 201);
     assert!(follow_up["result"]["resources"].is_array());
+}
+
+/// Covers the prompts/get error path: an unknown prompt name must return a
+/// structured envelope instead of dropping the connection.
+#[tokio::test]
+async fn test_prompts_get_error_returns_envelope_not_disconnect() {
+    let (_temp, db) = create_test_db().await;
+    let config = ThingsConfig::default();
+
+    let (server_io, mut client_io) = MockIo::create_pair(4096);
+
+    tokio::spawn(async move { start_mcp_server_generic(db, config, server_io, true).await });
+
+    let response = send_request_read_response(
+        &mut client_io,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 300,
+            "method": "prompts/get",
+            "params": { "name": "nonexistent_prompt" }
+        }),
+    )
+    .await;
+
+    assert_eq!(response["id"], 300);
+    assert_eq!(response["jsonrpc"], "2.0");
+    // Must come back as a well-formed response, not disconnect.
+    assert!(
+        response["result"].is_object() || response["error"].is_object(),
+        "Expected a result or error envelope, got {response}"
+    );
+
+    // Server still alive: a subsequent request is answered.
+    let follow_up = send_request_read_response(
+        &mut client_io,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 301,
+            "method": "tools/list"
+        }),
+    )
+    .await;
+    assert_eq!(follow_up["id"], 301);
+    assert!(follow_up["result"]["tools"].is_array());
+}
+
+/// Covers `start_mcp_server_with_config_generic`: the same error-recovery fix
+/// is present in both server variants. Regression test so a future refactor
+/// can't break the config variant independently of the generic one.
+#[tokio::test]
+async fn test_config_variant_loop_continues_after_error() {
+    use things3_core::McpServerConfig;
+
+    let (_temp, db) = create_test_db().await;
+
+    let (server_io, mut client_io) = MockIo::create_pair(4096);
+
+    tokio::spawn(async move {
+        start_mcp_server_with_config_generic(db, McpServerConfig::default(), server_io, true).await
+    });
+
+    // First request: unknown tool → error envelope.
+    let bad_response = send_request_read_response(
+        &mut client_io,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 400,
+            "method": "tools/call",
+            "params": { "name": "nonexistent_tool", "arguments": {} }
+        }),
+    )
+    .await;
+    assert_eq!(bad_response["id"], 400);
+    assert!(
+        bad_response["result"]["isError"].as_bool().unwrap_or(false),
+        "Config variant must return isError envelope, not disconnect; got {bad_response}"
+    );
+
+    // Second request: must succeed — loop survived.
+    let good_response = send_request_read_response(
+        &mut client_io,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 401,
+            "method": "tools/list"
+        }),
+    )
+    .await;
+    assert_eq!(good_response["id"], 401);
+    assert!(good_response["result"]["tools"].is_array());
+}
+
+/// Verifies `build_jsonrpc_error_response` notification path: when a
+/// JSON-RPC notification (no `id`) triggers a handler error, the server
+/// must stay silent — sending a response to a notification is a protocol
+/// violation.
+#[tokio::test]
+async fn test_notification_error_produces_no_response() {
+    let (_temp, db) = create_test_db().await;
+    let config = ThingsConfig::default();
+
+    let (server_io, mut client_io) = MockIo::create_pair(4096);
+
+    tokio::spawn(async move { start_mcp_server_generic(db, config, server_io, true).await });
+
+    // Send a notification (no `id`) with an unknown method. The server must
+    // not write any response for this — notifications are fire-and-forget.
+    client_io
+        .write_line(
+            &serde_json::to_string(&json!({
+                "jsonrpc": "2.0",
+                "method": "notifications/unknown_event",
+                "params": {}
+            }))
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+    client_io.flush().await.unwrap();
+
+    // Now send a real request immediately after. The first response we read
+    // must belong to this request, not to the notification above.
+    let response = send_request_read_response(
+        &mut client_io,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 500,
+            "method": "tools/list"
+        }),
+    )
+    .await;
+    assert_eq!(
+        response["id"], 500,
+        "First response must be for id=500 (the tools/list), not a spurious notification reply"
+    );
+    assert!(response["result"]["tools"].is_array());
 }
 
 // ============================================================================

--- a/apps/things3-cli/tests/mcp_io_tests.rs
+++ b/apps/things3-cli/tests/mcp_io_tests.rs
@@ -420,48 +420,147 @@ async fn test_content_block_serialization() {
 
 #[tokio::test]
 async fn test_tools_call_nonexistent_tool() {
+    // Tripwire for #148: a tool-level error (here, `tools/call` with an
+    // unknown tool name) must surface as a JSON-RPC `result` containing an
+    // `isError: true` envelope — NOT propagate up the request loop and
+    // drop the MCP connection. Earlier behavior was "disconnect or
+    // envelope, either is fine"; that masked a connection-killing bug.
     let (_temp, db) = create_test_db().await;
     let config = ThingsConfig::default();
 
     let (server_io, mut client_io) = MockIo::create_pair(4096);
 
-    let server_handle =
-        tokio::spawn(async move { start_mcp_server_generic(db, config, server_io, true).await });
+    tokio::spawn(async move { start_mcp_server_generic(db, config, server_io, true).await });
 
-    let tools_call_request = json!({
-        "jsonrpc": "2.0",
-        "id": 5,
-        "method": "tools/call",
-        "params": {
-            "name": "nonexistent_tool",
-            "arguments": {}
-        }
-    });
+    let response = send_request_read_response(
+        &mut client_io,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 5,
+            "method": "tools/call",
+            "params": {
+                "name": "nonexistent_tool",
+                "arguments": {}
+            }
+        }),
+    )
+    .await;
 
-    // Send request
-    let request_str = serde_json::to_string(&tools_call_request).unwrap();
-    client_io.write_line(&request_str).await.unwrap();
-    client_io.flush().await.unwrap();
+    assert_eq!(response["jsonrpc"], "2.0");
+    assert_eq!(response["id"], 5);
+    let is_error = response["result"]["isError"].as_bool().unwrap_or(false);
+    assert!(
+        is_error,
+        "Expected isError envelope inside result for unknown tool; got {response}"
+    );
+    let content = response["result"]["content"]
+        .as_array()
+        .expect("CallToolResult.content must be an array even on error");
+    let text = content
+        .first()
+        .and_then(|c| c.get("text"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    assert!(
+        text.to_lowercase().contains("not found"),
+        "Error envelope text should mention the tool was not found; got {text:?}"
+    );
+}
 
-    // Try to read response - server might error and close connection
-    let result = timeout(Duration::from_millis(500), client_io.read_line()).await;
+/// Regression test for issue #148: when a single request triggers a handler
+/// error, the MCP server loop must keep running and answer subsequent
+/// requests. Previously the `?` propagation in the request loop terminated
+/// the entire loop on first error, dropping the connection.
+#[tokio::test]
+async fn test_loop_continues_after_handler_error() {
+    let (_temp, db) = create_test_db().await;
+    let config = ThingsConfig::default();
 
-    if let Ok(Ok(Some(response_line))) = result {
-        let response: serde_json::Value = serde_json::from_str(&response_line).unwrap();
-        assert_eq!(response["jsonrpc"], "2.0");
-        assert_eq!(response["id"], 5);
-        // Should return error for nonexistent tool
-        let is_error = response["result"]["is_error"].as_bool().unwrap_or(false);
-        assert!(
-            is_error || response["error"].is_object(),
-            "Should indicate error for nonexistent tool"
-        );
-    } else {
-        // Server may have errored and closed - that's also acceptable behavior
-        // Just verify the server handle completed
-        drop(client_io);
-        let _ = timeout(Duration::from_secs(1), server_handle).await;
-    }
+    let (server_io, mut client_io) = MockIo::create_pair(4096);
+
+    tokio::spawn(async move { start_mcp_server_generic(db, config, server_io, true).await });
+
+    // First request: triggers a tool-level error (unknown tool).
+    let bad_response = send_request_read_response(
+        &mut client_io,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 100,
+            "method": "tools/call",
+            "params": { "name": "nonexistent_tool", "arguments": {} }
+        }),
+    )
+    .await;
+    assert_eq!(bad_response["id"], 100);
+    assert!(
+        bad_response["result"]["isError"].as_bool().unwrap_or(false),
+        "First request must come back as an isError envelope, not crash the loop"
+    );
+
+    // Second request: a normal tools/list. Must succeed because the loop
+    // survived the previous error.
+    let good_response = send_request_read_response(
+        &mut client_io,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 101,
+            "method": "tools/list"
+        }),
+    )
+    .await;
+    assert_eq!(good_response["id"], 101);
+    assert!(
+        good_response["result"]["tools"].is_array(),
+        "Second request after a handler error must still be answered; got {good_response}"
+    );
+}
+
+/// Companion to `test_loop_continues_after_handler_error`: confirms that a
+/// resources/read with an unknown URI also returns a structured envelope
+/// instead of dropping the connection.
+#[tokio::test]
+async fn test_resources_read_unknown_uri_returns_envelope_not_disconnect() {
+    let (_temp, db) = create_test_db().await;
+    let config = ThingsConfig::default();
+
+    let (server_io, mut client_io) = MockIo::create_pair(4096);
+
+    tokio::spawn(async move { start_mcp_server_generic(db, config, server_io, true).await });
+
+    let response = send_request_read_response(
+        &mut client_io,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 200,
+            "method": "resources/read",
+            "params": { "uri": "things3://does-not-exist" }
+        }),
+    )
+    .await;
+
+    assert_eq!(response["id"], 200);
+    // The fallback variant of read_resource emits a `ReadResourceResult` with
+    // an error message in its `contents`. The exact shape is up to
+    // `to_resource_result()`; we just assert the response arrived (no
+    // disconnect) and is well-formed JSON-RPC.
+    assert_eq!(response["jsonrpc"], "2.0");
+    assert!(
+        response["result"].is_object(),
+        "Expected a result envelope, got {response}"
+    );
+
+    // Server is still alive: a subsequent valid request gets answered.
+    let follow_up = send_request_read_response(
+        &mut client_io,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 201,
+            "method": "resources/list"
+        }),
+    )
+    .await;
+    assert_eq!(follow_up["id"], 201);
+    assert!(follow_up["result"]["resources"].is_array());
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- When a `tools/call`, `resources/read`, or `prompts/get` handler returned an error, the `?` in the server request loop terminated the loop entirely — clients saw `MCP error -32000: Connection closed` instead of a structured error
- Tool/resource/prompt errors now flow through the existing `*_with_fallback` variants, returning `isError: true` envelopes per MCP spec
- Any remaining handler-level error is converted to a JSON-RPC error response (`-32600`) instead of killing the loop

## Test plan

- [x] `test_tools_call_nonexistent_tool` — tightened to require `isError: true` envelope (was previously accepting a connection close as valid)
- [x] `test_loop_continues_after_handler_error` — new regression test: sends a bad `tools/call`, then a valid `tools/list`; asserts both receive responses (fails on pre-fix code with EOF panic)
- [x] `test_resources_read_unknown_uri_returns_envelope_not_disconnect` — new regression test: sends `resources/read` with unknown URI, asserts no disconnect, server still answers follow-up `resources/list`
- [x] All 305+ tests pass; clippy clean; workspace build clean

## Notes

This is PR 1 of 2 for issue #148. PR 2 will fix the root cause — `AppleScriptBackend` receiving 36-char hyphenated UUIDs (from `SqlxBackend` / `--unsafe-direct-db`) instead of the 22-char Base62 IDs that Things 3's AppleScript API requires. This PR makes that failure survivable (structured error instead of connection drop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)