### PR TITLE
fix(applescript): reject hyphenated UUIDs at boundary, generate native IDs (#148)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`#[serde(transparent)]`). `FromStr` validates strictly at MCP/API boundaries; internal DB reads
   use `ThingsId::from_trusted` to avoid re-parsing values the DB already owns. Implements
   `Display`, `Hash`, `Eq`, `Ord`, `From<Uuid>`.
+- **`ThingsId::new_things_native()`** (#148) — generates a fresh 22-char Base62 ID derived from
+  a v4 UUID's 16 random bytes. Use this for any new entity that may be referenced via
+  AppleScript; Things 3's AppleScript dictionary only accepts this format in `to do id "..."`
+  references and rejects hyphenated UUIDs with the opaque `-1728` ("Can't get to do id ...").
+  All `ThingsDatabase::create_*` paths now use this constructor.
+
+### Fixed
+
+- **`AppleScriptBackend` rejects hyphenated UUIDs at the boundary** (#148) — every mutation
+  method that takes a `ThingsId` (directly or via request struct) now validates the format
+  *before* invoking `osascript`. Hyphenated UUIDs (which Things 3's AppleScript dictionary
+  cannot resolve) return a clear `Validation` error pointing at the recreate-the-entity
+  remediation, instead of forwarding the bad ID and surfacing the opaque AppleScript error
+  `-1728`. New entities created via `ThingsDatabase::create_task` / `create_project` /
+  `create_area` / `create_tag_*` now use 22-char Base62 IDs, so this affects only legacy rows
+  written by `SqlxBackend` on Linux/CI or with `--unsafe-direct-db`.
+
+### Known issue
+
+- **Legacy hyphenated-UUID entities cannot be mutated via AppleScript** (#148). Tasks,
+  projects, areas, and tags created by earlier versions on Linux/CI (or with
+  `--unsafe-direct-db`) may have hyphenated UUIDs persisted in `Things Database.thingsdatabase`.
+  These rows are unreachable from Things 3's AppleScript dictionary; they must be recreated in
+  Things 3 (which assigns a fresh native ID) or mutated via direct SQLite writes
+  (`THINGS_UNSAFE_DIRECT_DB=1`).
 
 ## [1.4.0] - 2026-04-28
 

--- a/apps/things3-cli/tests/mcp_tag_tests.rs
+++ b/apps/things3-cli/tests/mcp_tag_tests.rs
@@ -2,7 +2,6 @@
 
 use serde_json::json;
 use things3_cli::mcp::CallToolRequest;
-use uuid::Uuid;
 
 mod mcp_tests;
 use mcp_tests::common::create_test_mcp_server;
@@ -594,7 +593,9 @@ async fn test_tag_lifecycle_integration() {
     };
     let create_response: serde_json::Value = serde_json::from_str(create_text).unwrap();
     assert_eq!(create_response["status"], "created");
-    let tag_uuid = Uuid::parse_str(create_response["uuid"].as_str().unwrap()).unwrap();
+    // Created entities now use 22-char Things-native Base62 IDs (#148), not
+    // hyphenated UUIDs — keep the returned string verbatim for downstream calls.
+    let tag_uuid = create_response["uuid"].as_str().unwrap().to_string();
 
     // 2. Update the tag
     let update_request = CallToolRequest {

--- a/libs/things3-core/src/database/core.rs
+++ b/libs/things3-core/src/database/core.rs
@@ -1323,7 +1323,7 @@ impl ThingsDatabase {
         crate::database::validate_date_range(request.start_date, request.deadline)?;
 
         // Generate ID for new task
-        let id = ThingsId::new_v4();
+        let id = ThingsId::new_things_native();
 
         // Validate referenced entities
         if let Some(project_uuid) = &request.project_uuid {
@@ -1401,7 +1401,7 @@ impl ThingsDatabase {
         crate::database::validate_date_range(request.start_date, request.deadline)?;
 
         // Generate ID for new project
-        let id = ThingsId::new_v4();
+        let id = ThingsId::new_things_native();
 
         // Validate area if provided
         if let Some(area_uuid) = &request.area_uuid {
@@ -2008,7 +2008,7 @@ impl ThingsDatabase {
         request: crate::models::CreateAreaRequest,
     ) -> ThingsResult<ThingsId> {
         // Generate ID for new area
-        let id = ThingsId::new_v4();
+        let id = ThingsId::new_things_native();
 
         // Get current timestamp for creation/modification dates
         let now = Utc::now().timestamp() as f64;
@@ -2496,7 +2496,7 @@ impl ThingsDatabase {
         }
 
         // 5. No duplicates, safe to create
-        let id = ThingsId::new_v4();
+        let id = ThingsId::new_things_native();
         let now = Utc::now().timestamp() as f64;
 
         sqlx::query(
@@ -2530,7 +2530,7 @@ impl ThingsDatabase {
         &self,
         request: crate::models::CreateTagRequest,
     ) -> ThingsResult<ThingsId> {
-        let id = ThingsId::new_v4();
+        let id = ThingsId::new_things_native();
         let now = Utc::now().timestamp() as f64;
 
         sqlx::query(

--- a/libs/things3-core/src/models.rs
+++ b/libs/things3-core/src/models.rs
@@ -53,7 +53,7 @@ impl ThingsId {
     /// entities.
     #[must_use]
     #[cfg_attr(
-        not(test),
+        not(any(test, feature = "test-utils")),
         deprecated(
             since = "1.5.0",
             note = "Use `new_things_native()` for entities that may be referenced via AppleScript"

--- a/libs/things3-core/src/models.rs
+++ b/libs/things3-core/src/models.rs
@@ -56,6 +56,19 @@ impl ThingsId {
         Self(Uuid::new_v4().to_string())
     }
 
+    /// Generate a fresh Things-native 22-char Base62 ID. Use this for any
+    /// new entity that may be referenced via AppleScript — Things 3's
+    /// AppleScript dictionary only accepts this format in `to do id "..."`
+    /// references, so a hyphenated UUID would fail with `-1728` (#148).
+    ///
+    /// Internally derived from a v4 UUID's 16 random bytes, base62-encoded
+    /// (a 16-byte / 128-bit value fits in 22 base62 characters).
+    #[must_use]
+    pub fn new_things_native() -> Self {
+        let bytes = *Uuid::new_v4().as_bytes();
+        Self(base62_encode_22(&bytes))
+    }
+
     /// Borrow the underlying string (for SQL parameter binding, AppleScript
     /// interpolation, logging, etc.).
     #[must_use]
@@ -81,6 +94,42 @@ impl ThingsId {
         let len = s.len();
         (len == 21 || len == 22) && s.chars().all(|c| c.is_ascii_alphanumeric())
     }
+
+    /// Borrow the underlying string if it's already in Things native format
+    /// (21–22-char Base62), or return a `Validation` error pointing the
+    /// caller at the recreate-the-entity remediation.
+    ///
+    /// AppleScript-driving call sites use this to fail fast with a useful
+    /// message instead of letting a hyphenated UUID reach `osascript`
+    /// (which returns the opaque error `-1728` "Can't get to do id ...").
+    pub(crate) fn as_things_native(&self) -> Result<&str, ThingsError> {
+        if Self::is_things_native(&self.0) {
+            Ok(&self.0)
+        } else {
+            Err(ThingsError::validation(format!(
+                "ID {:?} is not in Things native format (21–22-char Base62) \
+                 and cannot be referenced via AppleScript. This entity was \
+                 likely created on Linux/CI or with --unsafe-direct-db. \
+                 Recreate it in Things 3, or set THINGS_UNSAFE_DIRECT_DB=1 \
+                 to mutate via direct SQLite writes.",
+                self.0
+            )))
+        }
+    }
+}
+
+/// Encode 16 bytes into a fixed 22-char Base62 string (alphabet:
+/// `0-9A-Za-z`). 16 bytes = 128 bits; 22 base62 chars hold ~131 bits, so
+/// the encoding is fixed-length with leading-zero padding.
+fn base62_encode_22(bytes: &[u8; 16]) -> String {
+    const ALPHABET: &[u8; 62] = b"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    let mut n = u128::from_be_bytes(*bytes);
+    let mut out = [b'0'; 22];
+    for slot in out.iter_mut().rev() {
+        *slot = ALPHABET[(n % 62) as usize];
+        n /= 62;
+    }
+    String::from_utf8(out.to_vec()).expect("alphabet is ASCII")
 }
 
 impl fmt::Display for ThingsId {
@@ -134,6 +183,69 @@ mod things_id_tests {
         let s = id.as_str();
         assert_eq!(s.len(), 36);
         assert!(Uuid::parse_str(s).is_ok());
+    }
+
+    #[test]
+    fn new_things_native_produces_22_char_base62() {
+        let id = ThingsId::new_things_native();
+        let s = id.as_str();
+        assert_eq!(s.len(), 22);
+        assert!(s.chars().all(|c| c.is_ascii_alphanumeric()));
+        assert!(ThingsId::is_things_native(s));
+    }
+
+    #[test]
+    fn new_things_native_round_trips_through_from_str() {
+        let original = ThingsId::new_things_native();
+        let parsed: ThingsId = original.as_str().parse().unwrap();
+        assert_eq!(original, parsed);
+    }
+
+    #[test]
+    fn new_things_native_yields_unique_ids() {
+        use std::collections::HashSet;
+        let ids: HashSet<_> = (0..1000).map(|_| ThingsId::new_things_native()).collect();
+        assert_eq!(ids.len(), 1000);
+    }
+
+    #[test]
+    fn as_things_native_accepts_native_id() {
+        let id: ThingsId = "R4t2G8Q63aGZq4epMHNeCr".parse().unwrap();
+        assert_eq!(id.as_things_native().unwrap(), "R4t2G8Q63aGZq4epMHNeCr");
+    }
+
+    #[test]
+    fn as_things_native_accepts_21_char_native_id() {
+        let id: ThingsId = "19KLMeA2ULbixtvNbXsDK".parse().unwrap();
+        assert_eq!(id.as_things_native().unwrap(), "19KLMeA2ULbixtvNbXsDK");
+    }
+
+    #[test]
+    fn as_things_native_rejects_hyphenated_uuid() {
+        let id: ThingsId = "9d3f1e44-5c2a-4b8e-9c1f-7e2d8a4b3c5e".parse().unwrap();
+        let err = id.as_things_native().unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("not in Things native format"),
+            "missing format hint, got: {msg}"
+        );
+        assert!(msg.contains("Recreate"), "missing remediation, got: {msg}");
+    }
+
+    #[test]
+    fn base62_encode_22_pads_zero_input() {
+        // All-zero input → 22 leading-zero alphabet chars (i.e. all '0').
+        let s = base62_encode_22(&[0u8; 16]);
+        assert_eq!(s, "0".repeat(22));
+    }
+
+    #[test]
+    fn base62_encode_22_handles_max_input() {
+        // All-0xFF input is the largest u128, which maps to "7n42DGM5Tflk9n8mt7Fhc7"
+        // (21 non-zero chars). Just verify length + alphabet, not the exact value.
+        let s = base62_encode_22(&[0xFFu8; 16]);
+        assert_eq!(s.len(), 22);
+        assert!(s.chars().all(|c| c.is_ascii_alphanumeric()));
     }
 
     #[test]

--- a/libs/things3-core/src/models.rs
+++ b/libs/things3-core/src/models.rs
@@ -52,6 +52,13 @@ impl ThingsId {
     /// Generate a fresh hyphenated UUID, suitable for `SqlxBackend`-created
     /// entities.
     #[must_use]
+    #[cfg_attr(
+        not(test),
+        deprecated(
+            since = "1.5.0",
+            note = "Use `new_things_native()` for entities that may be referenced via AppleScript"
+        )
+    )]
     pub fn new_v4() -> Self {
         Self(Uuid::new_v4().to_string())
     }
@@ -123,6 +130,9 @@ impl ThingsId {
 /// `0-9A-Za-z`). 16 bytes = 128 bits; 22 base62 chars hold ~131 bits, so
 /// the encoding is fixed-length with leading-zero padding.
 fn base62_encode_22(bytes: &[u8; 16]) -> String {
+    // Alphabet is 0-9A-Za-z (digits, uppercase, lowercase). Arbitrary but
+    // stable — Things 3's native-ID check only requires length 21-22 and
+    // ASCII alphanumeric, not a specific ordering.
     const ALPHABET: &[u8; 62] = b"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
     let mut n = u128::from_be_bytes(*bytes);
     let mut out = [b'0'; 22];

--- a/libs/things3-core/src/models.rs
+++ b/libs/things3-core/src/models.rs
@@ -102,6 +102,7 @@ impl ThingsId {
     /// AppleScript-driving call sites use this to fail fast with a useful
     /// message instead of letting a hyphenated UUID reach `osascript`
     /// (which returns the opaque error `-1728` "Can't get to do id ...").
+    #[cfg(target_os = "macos")]
     pub(crate) fn as_things_native(&self) -> Result<&str, ThingsError> {
         if Self::is_things_native(&self.0) {
             Ok(&self.0)
@@ -208,18 +209,21 @@ mod things_id_tests {
         assert_eq!(ids.len(), 1000);
     }
 
+    #[cfg(target_os = "macos")]
     #[test]
     fn as_things_native_accepts_native_id() {
         let id: ThingsId = "R4t2G8Q63aGZq4epMHNeCr".parse().unwrap();
         assert_eq!(id.as_things_native().unwrap(), "R4t2G8Q63aGZq4epMHNeCr");
     }
 
+    #[cfg(target_os = "macos")]
     #[test]
     fn as_things_native_accepts_21_char_native_id() {
         let id: ThingsId = "19KLMeA2ULbixtvNbXsDK".parse().unwrap();
         assert_eq!(id.as_things_native().unwrap(), "19KLMeA2ULbixtvNbXsDK");
     }
 
+    #[cfg(target_os = "macos")]
     #[test]
     fn as_things_native_rejects_hyphenated_uuid() {
         let id: ThingsId = "9d3f1e44-5c2a-4b8e-9c1f-7e2d8a4b3c5e".parse().unwrap();

--- a/libs/things3-core/src/models.rs
+++ b/libs/things3-core/src/models.rs
@@ -52,13 +52,6 @@ impl ThingsId {
     /// Generate a fresh hyphenated UUID, suitable for `SqlxBackend`-created
     /// entities.
     #[must_use]
-    #[cfg_attr(
-        not(any(test, feature = "test-utils")),
-        deprecated(
-            since = "1.5.0",
-            note = "Use `new_things_native()` for entities that may be referenced via AppleScript"
-        )
-    )]
     pub fn new_v4() -> Self {
         Self(Uuid::new_v4().to_string())
     }

--- a/libs/things3-core/src/mutations/applescript/mod.rs
+++ b/libs/things3-core/src/mutations/applescript/mod.rs
@@ -223,18 +223,27 @@ impl MutationBackend for AppleScriptBackend {
     }
 
     async fn update_task(&self, request: UpdateTaskRequest) -> ThingsResult<()> {
+        request.uuid.as_things_native()?;
+        if let Some(p) = &request.project_uuid {
+            p.as_things_native()?;
+        }
+        if let Some(a) = &request.area_uuid {
+            a.as_things_native()?;
+        }
         let script = script::update_task_script(&request);
         runner::run_script(&script).await?;
         Ok(())
     }
 
     async fn complete_task(&self, id: &ThingsId) -> ThingsResult<()> {
+        id.as_things_native()?;
         let script = script::complete_task_script(id);
         runner::run_script(&script).await?;
         Ok(())
     }
 
     async fn uncomplete_task(&self, id: &ThingsId) -> ThingsResult<()> {
+        id.as_things_native()?;
         let script = script::uncomplete_task_script(id);
         runner::run_script(&script).await?;
         Ok(())
@@ -245,6 +254,7 @@ impl MutationBackend for AppleScriptBackend {
         id: &ThingsId,
         child_handling: DeleteChildHandling,
     ) -> ThingsResult<()> {
+        id.as_things_native()?;
         let children = self.list_subtask_uuids(id).await?;
 
         if !children.is_empty() {
@@ -311,6 +321,9 @@ impl MutationBackend for AppleScriptBackend {
                 request.task_uuids.len(),
             )));
         }
+        for id in &request.task_uuids {
+            id.as_things_native()?;
+        }
         let total = request.task_uuids.len();
         let script = script::bulk_delete_script(&request);
         let stdout = runner::run_script(&script).await?;
@@ -332,6 +345,15 @@ impl MutationBackend for AppleScriptBackend {
                 "bulk_move requires either project_uuid or area_uuid",
             ));
         }
+        for id in &request.task_uuids {
+            id.as_things_native()?;
+        }
+        if let Some(p) = &request.project_uuid {
+            p.as_things_native()?;
+        }
+        if let Some(a) = &request.area_uuid {
+            a.as_things_native()?;
+        }
         let total = request.task_uuids.len();
         let script = script::bulk_move_script(&request);
         let stdout = runner::run_script(&script).await?;
@@ -350,6 +372,9 @@ impl MutationBackend for AppleScriptBackend {
                 "Batch size {} exceeds maximum of {MAX_BULK_BATCH_SIZE}",
                 request.task_uuids.len(),
             )));
+        }
+        for id in &request.task_uuids {
+            id.as_things_native()?;
         }
         let total = request.task_uuids.len();
         let script = script::bulk_update_dates_script(&request);
@@ -370,6 +395,9 @@ impl MutationBackend for AppleScriptBackend {
                 request.task_uuids.len(),
             )));
         }
+        for id in &request.task_uuids {
+            id.as_things_native()?;
+        }
         let total = request.task_uuids.len();
         let script = script::bulk_complete_script(&request);
         let stdout = runner::run_script(&script).await?;
@@ -385,6 +413,10 @@ impl MutationBackend for AppleScriptBackend {
     }
 
     async fn update_project(&self, request: UpdateProjectRequest) -> ThingsResult<()> {
+        request.uuid.as_things_native()?;
+        if let Some(a) = &request.area_uuid {
+            a.as_things_native()?;
+        }
         let script = script::update_project_script(&request);
         runner::run_script(&script).await?;
         Ok(())
@@ -395,6 +427,7 @@ impl MutationBackend for AppleScriptBackend {
         id: &ThingsId,
         child_handling: ProjectChildHandling,
     ) -> ThingsResult<()> {
+        id.as_things_native()?;
         let children = self.list_project_task_uuids(id).await?;
 
         if children.is_empty() {
@@ -430,6 +463,7 @@ impl MutationBackend for AppleScriptBackend {
         id: &ThingsId,
         child_handling: ProjectChildHandling,
     ) -> ThingsResult<()> {
+        id.as_things_native()?;
         let children = self.list_project_task_uuids(id).await?;
 
         if children.is_empty() {
@@ -468,12 +502,14 @@ impl MutationBackend for AppleScriptBackend {
     }
 
     async fn update_area(&self, request: UpdateAreaRequest) -> ThingsResult<()> {
+        request.uuid.as_things_native()?;
         let script = script::update_area_script(&request);
         runner::run_script(&script).await?;
         Ok(())
     }
 
     async fn delete_area(&self, id: &ThingsId) -> ThingsResult<()> {
+        id.as_things_native()?;
         let script = script::delete_area_script(id);
         runner::run_script(&script).await?;
         Ok(())
@@ -513,6 +549,10 @@ impl MutationBackend for AppleScriptBackend {
     }
 
     async fn update_tag(&self, request: UpdateTagRequest) -> ThingsResult<()> {
+        request.uuid.as_things_native()?;
+        if let Some(p) = &request.parent_uuid {
+            p.as_things_native()?;
+        }
         if request.shortcut.is_some() || request.parent_uuid.is_some() {
             tracing::debug!(
                 tag = %request.uuid,
@@ -527,6 +567,7 @@ impl MutationBackend for AppleScriptBackend {
     }
 
     async fn delete_tag(&self, id: &ThingsId, remove_from_tasks: bool) -> ThingsResult<()> {
+        id.as_things_native()?;
         if !remove_from_tasks {
             let script = script::delete_tag_script(id);
             runner::run_script(&script).await?;
@@ -579,6 +620,9 @@ impl MutationBackend for AppleScriptBackend {
 
     async fn merge_tags(&self, source_id: &ThingsId, target_id: &ThingsId) -> ThingsResult<()> {
         use crate::database::tag_utils::normalize_tag_title;
+
+        source_id.as_things_native()?;
+        target_id.as_things_native()?;
 
         if source_id == target_id {
             return Err(ThingsError::validation(
@@ -655,6 +699,8 @@ impl MutationBackend for AppleScriptBackend {
     ) -> ThingsResult<TagAssignmentResult> {
         use crate::database::tag_utils::normalize_tag_title;
 
+        task_id.as_things_native()?;
+
         let normalized = normalize_tag_title(tag_title);
 
         let (resolved_title, resolved_uuid) =
@@ -695,6 +741,8 @@ impl MutationBackend for AppleScriptBackend {
     async fn remove_tag_from_task(&self, task_id: &ThingsId, tag_title: &str) -> ThingsResult<()> {
         use crate::database::tag_utils::normalize_tag_title;
 
+        task_id.as_things_native()?;
+
         let normalized = normalize_tag_title(tag_title);
         let current = self.read_task_tag_titles(task_id).await?;
         let original_len = current.len();
@@ -717,6 +765,8 @@ impl MutationBackend for AppleScriptBackend {
         tag_titles: Vec<String>,
     ) -> ThingsResult<Vec<TagMatch>> {
         use crate::database::tag_utils::normalize_tag_title;
+
+        task_id.as_things_native()?;
 
         // Intentionally asymmetric with add_tag_to_task: similar-tag suggestions
         // accumulate for the caller but never block the write — every title is
@@ -864,7 +914,7 @@ mod tests {
         .expect("seed tag");
         let backend = AppleScriptBackend::new(Arc::new(db));
 
-        let task_id = ThingsId::new_v4();
+        let task_id = ThingsId::new_things_native();
         let result = backend
             .add_tag_to_task(&task_id, "importnt")
             .await
@@ -888,7 +938,7 @@ mod tests {
             .await
             .expect("test db");
 
-        let task_id = ThingsId::new_v4();
+        let task_id = ThingsId::new_things_native();
         let blob =
             crate::database::serialize_tags_to_blob(&["Work".to_string(), "Personal".to_string()])
                 .expect("serialize");
@@ -934,7 +984,7 @@ mod tests {
             .await
             .expect("test db");
 
-        let task_id = ThingsId::new_v4();
+        let task_id = ThingsId::new_things_native();
         let blob =
             crate::database::serialize_tags_to_blob(&["to_do".to_string()]).expect("serialize");
         let now = 1_700_000_000.0_f64;
@@ -971,7 +1021,7 @@ mod tests {
                 .expect("in-memory db"),
         );
         let backend = AppleScriptBackend::new(db);
-        let id = ThingsId::new_v4();
+        let id = ThingsId::new_things_native();
         let err = backend
             .merge_tags(&id, &id)
             .await
@@ -997,7 +1047,7 @@ mod tests {
 
         let err = backend
             .bulk_delete(BulkDeleteRequest {
-                task_uuids: (0..1001).map(|_| ThingsId::new_v4()).collect(),
+                task_uuids: (0..1001).map(|_| ThingsId::new_things_native()).collect(),
             })
             .await
             .expect_err("oversize");
@@ -1005,13 +1055,115 @@ mod tests {
 
         let err = backend
             .bulk_move(BulkMoveRequest {
-                task_uuids: vec![ThingsId::new_v4()],
+                task_uuids: vec![ThingsId::new_things_native()],
                 project_uuid: None,
                 area_uuid: None,
             })
             .await
             .expect_err("missing destination");
         assert!(matches!(err, ThingsError::Validation { .. }));
+    }
+
+    // ============================================================================
+    // ID format guard (#148) — every mutation method that takes a `ThingsId`
+    // must reject hyphenated UUIDs *before* invoking osascript, so the user
+    // sees an actionable Validation error instead of AppleScript's opaque
+    // `-1728`. The guard fires synchronously before any `runner::run_script`
+    // call, which is what makes these tests deterministic in CI without a
+    // live Things 3 install.
+    // ============================================================================
+
+    fn hyphenated_uuid() -> ThingsId {
+        "9d3f1e44-5c2a-4b8e-9c1f-7e2d8a4b3c5e".parse().unwrap()
+    }
+
+    async fn guard_test_backend() -> AppleScriptBackend {
+        let db = Arc::new(
+            ThingsDatabase::from_connection_string("sqlite::memory:")
+                .await
+                .expect("in-memory db"),
+        );
+        AppleScriptBackend::new(db)
+    }
+
+    fn assert_native_format_validation(err: ThingsError) {
+        match &err {
+            ThingsError::Validation { .. } => {
+                assert!(
+                    err.to_string().contains("not in Things native format"),
+                    "wrong validation error: {err}"
+                );
+            }
+            other => panic!("expected Validation, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn complete_task_rejects_hyphenated_uuid() {
+        let backend = guard_test_backend().await;
+        let err = backend
+            .complete_task(&hyphenated_uuid())
+            .await
+            .expect_err("guard should fire");
+        assert_native_format_validation(err);
+    }
+
+    #[tokio::test]
+    async fn update_task_rejects_hyphenated_uuid_in_request() {
+        let backend = guard_test_backend().await;
+        let req = UpdateTaskRequest {
+            uuid: hyphenated_uuid(),
+            title: Some("x".into()),
+            notes: None,
+            start_date: None,
+            deadline: None,
+            status: None,
+            project_uuid: None,
+            area_uuid: None,
+            tags: None,
+        };
+        let err = backend
+            .update_task(req)
+            .await
+            .expect_err("guard should fire on request.uuid");
+        assert_native_format_validation(err);
+    }
+
+    #[tokio::test]
+    async fn update_task_rejects_hyphenated_secondary_id() {
+        // request.uuid is native, but a secondary optional ID is hyphenated —
+        // the guard must catch it too.
+        let backend = guard_test_backend().await;
+        let req = UpdateTaskRequest {
+            uuid: ThingsId::new_things_native(),
+            title: Some("x".into()),
+            notes: None,
+            start_date: None,
+            deadline: None,
+            status: None,
+            project_uuid: Some(hyphenated_uuid()),
+            area_uuid: None,
+            tags: None,
+        };
+        let err = backend
+            .update_task(req)
+            .await
+            .expect_err("guard should fire on request.project_uuid");
+        assert_native_format_validation(err);
+    }
+
+    #[tokio::test]
+    async fn bulk_delete_rejects_hyphenated_uuid_in_vec() {
+        let backend = guard_test_backend().await;
+        let req = BulkDeleteRequest {
+            // Mix of valid + invalid; guard must fail-fast on the bad one.
+            task_uuids: vec![ThingsId::new_things_native(), hyphenated_uuid()],
+        };
+        let err = backend
+            .bulk_delete(req)
+            .await
+            .expect_err("guard should fire on the bad ID");
+        assert_native_format_validation(err);
     }
 
     // Live lifecycle tests live in `libs/things3-core/tests/applescript_live.rs`

--- a/libs/things3-core/tests/write_operations_tests.rs
+++ b/libs/things3-core/tests/write_operations_tests.rs
@@ -108,8 +108,15 @@ async fn test_create_task_returns_valid_uuid() {
 
     let uuid = db.create_task(request).await.unwrap();
 
-    // Verify UUID is valid by checking it's a hyphenated UUID format
-    assert!(uuid.as_str().contains('-'), "Should be UUID v4 format");
+    // Created tasks now use Things-native 22-char Base62 IDs (#148) so the
+    // mutation can be referenced via AppleScript. The hyphenated UUID format
+    // would be rejected with `-1728` by Things 3's AppleScript dictionary.
+    let s = uuid.as_str();
+    assert_eq!(s.len(), 22, "expected 22-char Base62 native ID, got {s:?}");
+    assert!(
+        s.chars().all(|c| c.is_ascii_alphanumeric()),
+        "expected Base62 alphanumeric, got {s:?}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Adds `ThingsId::new_things_native()` — generates a 22-char Base62 ID (same format Things 3 uses internally) by re-encoding 16 random UUID bytes; no new `rand` dependency
- Switches all 5 `ThingsDatabase::create_*` production call sites from `new_v4()` to `new_things_native()` so entities created on macOS always get AppleScript-compatible IDs
- Adds `ThingsId::as_things_native()?` boundary guard at the entry of all 19 `AppleScriptBackend` mutation methods — rejects hyphenated UUIDs with a clear `Validation` error ("Recreate it in Things 3...") instead of forwarding them to `osascript` where Things 3 returns the opaque error `-1728`

This is PR 2 of 2 for issue #148. PR 1 (#149) made MCP tool errors recoverable so AppleScript failures no longer drop the transport connection. This PR fixes the root cause.

## Root cause

`AppleScriptBackend` (default mutation backend on macOS since #146) interpolates `ThingsId` directly into AppleScript: `to do id "{id}"`. Things 3's AppleScript dictionary only accepts 21–22-char Base62 IDs. When given a 36-char hyphenated UUID (generated by the now-deprecated `SqlxBackend` via `new_v4()`), Things 3 returns error `-1728` ("Can't get to do id ..."). There is no recoverable mapping from a hyphenated UUID to a native short ID.

Real Things 3 user databases contain only native Base62 IDs. Hyphenated UUIDs only appear when `SqlxBackend` creates entities via `--unsafe-direct-db` / `THINGS_UNSAFE_DIRECT_DB=1`.

## Test plan

- [x] 8 new `ThingsId` unit tests: `new_things_native` format/uniqueness/round-trip, `as_things_native` accepts native / rejects hyphenated
- [x] 4 new `AppleScriptBackend` guard regression tests: `complete_task`, `update_task` (request struct), `update_task` secondary ID, `bulk_delete` (Vec)
- [x] Guard fires before `runner::run_script` — deterministic in CI without live Things 3
- [x] Updated `test_create_task_returns_valid_uuid` to assert 22-char Base62 (was 36-char hyphenated)
- [x] Fixed `test_tag_lifecycle_integration` UUID parsing (now raw string, not `Uuid::parse_str`)
- [x] All 591+ workspace tests pass; `cargo clippy --workspace --all-targets -- -D warnings` clean

## Manual verification (macOS with Things 3)

1. Create a task via MCP — returned `uuid` is 22 chars, all alphanumeric
2. Update that task — succeeds
3. With `THINGS_UNSAFE_DIRECT_DB=1`, create a task (returns hyphenated UUID), then unset env and update — returns `isError: true` with "not in Things native format" / "Recreate it in Things 3" message; server stays up

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)