### PR TITLE
fix(core): align TMTag schema with real Things 3 + dynamic DB path discovery (#151, #152)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4434,6 +4434,7 @@ dependencies = [
  "serde_json",
  "syn 2.0.117",
  "tempfile",
+ "things3-core",
  "thiserror 1.0.69",
  "walkdir",
 ]

--- a/apps/things3-cli/src/bin/test_mcp_real_data.rs
+++ b/apps/things3-cli/src/bin/test_mcp_real_data.rs
@@ -48,7 +48,6 @@ struct Args {
     json_output: bool,
 }
 
-
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Args::parse();

--- a/apps/things3-cli/src/bin/test_mcp_real_data.rs
+++ b/apps/things3-cli/src/bin/test_mcp_real_data.rs
@@ -48,7 +48,6 @@ struct Args {
     json_output: bool,
 }
 
-const DEFAULT_THINGS_DB_PATH: &str = "/Users/garthdb/Library/Group Containers/JLMPQHK86H.com.culturedcode.ThingsMac/ThingsData-0Z0Z2/Things Database.thingsdatabase/main.sqlite";
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -66,7 +65,7 @@ async fn main() -> Result<()> {
     // Determine database path
     let db_path = args
         .database_path
-        .unwrap_or_else(|| PathBuf::from(DEFAULT_THINGS_DB_PATH));
+        .unwrap_or_else(things3_core::get_default_database_path);
 
     if !db_path.exists() {
         error!("Database not found at: {}", db_path.display());

--- a/apps/things3-cli/tests/mcp_tests/common.rs
+++ b/apps/things3-cli/tests/mcp_tests/common.rs
@@ -70,18 +70,17 @@ async fn create_test_schema(db: &ThingsDatabase) -> Result<(), Box<dyn std::erro
     .execute(pool)
     .await?;
 
-    // Create TMTag table
+    // Create TMTag table — schema mirrors real Things 3 (no creationDate/userModificationDate).
     sqlx::query(
         r"
         CREATE TABLE IF NOT EXISTS TMTag (
             uuid TEXT PRIMARY KEY,
-            title TEXT NOT NULL,
+            title TEXT,
             shortcut TEXT,
-            parent TEXT,
-            creationDate REAL NOT NULL,
-            userModificationDate REAL NOT NULL,
             usedDate REAL,
-            'index' INTEGER NOT NULL DEFAULT 0
+            parent TEXT,
+            'index' INTEGER,
+            experimental BLOB
         )
         ",
     )

--- a/libs/things3-core/src/config.rs
+++ b/libs/things3-core/src/config.rs
@@ -64,13 +64,13 @@ impl ThingsConfig {
         )))
     }
 
-    /// Get the default Things 3 database path
+    /// Get the default Things 3 database path.
+    ///
+    /// Delegates to [`crate::database::get_default_database_path`], which
+    /// auto-discovers the per-install `ThingsData-XXXXX` suffix.
     #[must_use]
     pub fn get_default_database_path() -> PathBuf {
-        let home = std::env::var("HOME").unwrap_or_else(|_| "~".to_string());
-        PathBuf::from(format!(
-            "{home}/Library/Group Containers/JLMPQHK86H.com.culturedcode.ThingsMac/ThingsData-0Z0Z2/Things Database.thingsdatabase/main.sqlite"
-        ))
+        crate::database::get_default_database_path()
     }
 
     /// Create configuration from environment variables
@@ -674,15 +674,16 @@ mod tests {
 
     #[test]
     fn test_get_default_database_path_format() {
-        // Test that the default path has the expected format
+        // Test that the default path has the expected format. The 4-char
+        // suffix on `ThingsData-XXXXX` varies per install, so we only assert
+        // structure — never the literal `ThingsData-0Z0Z2`.
         let default_path = ThingsConfig::get_default_database_path();
         let path_str = default_path.to_string_lossy();
 
-        // Should contain the expected macOS Things 3 path components
         assert!(path_str.contains("Library"));
         assert!(path_str.contains("Group Containers"));
         assert!(path_str.contains("JLMPQHK86H.com.culturedcode.ThingsMac"));
-        assert!(path_str.contains("ThingsData-0Z0Z2"));
+        assert!(path_str.contains("ThingsData-"));
         assert!(path_str.contains("Things Database.thingsdatabase"));
         assert!(path_str.contains("main.sqlite"));
     }
@@ -913,14 +914,13 @@ mod tests {
         let path = ThingsConfig::get_default_database_path();
         let path_str = path.to_string_lossy();
 
-        // Test the specific format of the path
         assert!(
             path_str.contains("JLMPQHK86H.com.culturedcode.ThingsMac"),
             "Should contain the correct container identifier"
         );
         assert!(
-            path_str.contains("ThingsData-0Z0Z2"),
-            "Should contain the correct data directory"
+            path_str.contains("ThingsData-"),
+            "Should contain a ThingsData-* data directory"
         );
         assert!(
             path_str.contains("Things Database.thingsdatabase"),

--- a/libs/things3-core/src/database/core.rs
+++ b/libs/things3-core/src/database/core.rs
@@ -84,6 +84,9 @@ pub fn serialize_tags_to_blob(tags: &[String]) -> ThingsResult<Vec<u8>> {
 
 /// Deserialize tags from Things 3 binary format
 pub fn deserialize_tags_from_blob(blob: &[u8]) -> ThingsResult<Vec<String>> {
+    if blob.is_empty() {
+        return Ok(Vec::new());
+    }
     serde_json::from_slice(blob)
         .map_err(|e| ThingsError::unknown(format!("Failed to deserialize tags: {e}")))
 }
@@ -2118,8 +2121,8 @@ impl ThingsDatabase {
         normalized: &str,
     ) -> ThingsResult<Option<crate::models::Tag>> {
         let row = sqlx::query(
-            "SELECT uuid, title, shortcut, parent, creationDate, userModificationDate, usedDate 
-             FROM TMTag 
+            "SELECT uuid, title, shortcut, parent, usedDate
+             FROM TMTag
              WHERE LOWER(title) = LOWER(?)",
         )
         .bind(normalized)
@@ -2133,18 +2136,6 @@ impl ThingsDatabase {
             let shortcut: Option<String> = row.get("shortcut");
             let parent_str: Option<String> = row.get("parent");
             let parent_uuid = parent_str.map(ThingsId::from_trusted);
-
-            let creation_ts: f64 = row.get("creationDate");
-            let created = {
-                let ts = safe_timestamp_convert(creation_ts);
-                DateTime::from_timestamp(ts, 0).unwrap_or_else(Utc::now)
-            };
-
-            let modification_ts: f64 = row.get("userModificationDate");
-            let modified = {
-                let ts = safe_timestamp_convert(modification_ts);
-                DateTime::from_timestamp(ts, 0).unwrap_or_else(Utc::now)
-            };
 
             let used_ts: Option<f64> = row.get("usedDate");
             let last_used = used_ts.and_then(|ts| {
@@ -2169,8 +2160,6 @@ impl ThingsDatabase {
                 title,
                 shortcut,
                 parent_uuid,
-                created,
-                modified,
                 usage_count: usage_count as u32,
                 last_used,
             }))
@@ -2233,9 +2222,9 @@ impl ThingsDatabase {
     #[instrument(skip(self))]
     pub async fn search_tags(&self, query: &str) -> ThingsResult<Vec<crate::models::Tag>> {
         let rows = sqlx::query(
-            "SELECT uuid, title, shortcut, parent, creationDate, userModificationDate, usedDate 
-             FROM TMTag 
-             WHERE title LIKE ? 
+            "SELECT uuid, title, shortcut, parent, usedDate
+             FROM TMTag
+             WHERE title LIKE ?
              ORDER BY title",
         )
         .bind(format!("%{}%", query))
@@ -2250,18 +2239,6 @@ impl ThingsDatabase {
             let shortcut: Option<String> = row.get("shortcut");
             let parent_str: Option<String> = row.get("parent");
             let parent_uuid = parent_str.map(ThingsId::from_trusted);
-
-            let creation_ts: f64 = row.get("creationDate");
-            let created = {
-                let ts = safe_timestamp_convert(creation_ts);
-                DateTime::from_timestamp(ts, 0).unwrap_or_else(Utc::now)
-            };
-
-            let modification_ts: f64 = row.get("userModificationDate");
-            let modified = {
-                let ts = safe_timestamp_convert(modification_ts);
-                DateTime::from_timestamp(ts, 0).unwrap_or_else(Utc::now)
-            };
 
             let used_ts: Option<f64> = row.get("usedDate");
             let last_used = used_ts.and_then(|ts| {
@@ -2286,8 +2263,6 @@ impl ThingsDatabase {
                 title,
                 shortcut,
                 parent_uuid,
-                created,
-                modified,
                 usage_count: usage_count as u32,
                 last_used,
             });
@@ -2304,8 +2279,8 @@ impl ThingsDatabase {
     #[instrument(skip(self))]
     pub async fn get_all_tags(&self) -> ThingsResult<Vec<crate::models::Tag>> {
         let rows = sqlx::query(
-            "SELECT uuid, title, shortcut, parent, creationDate, userModificationDate, usedDate 
-             FROM TMTag 
+            "SELECT uuid, title, shortcut, parent, usedDate
+             FROM TMTag
              ORDER BY title",
         )
         .fetch_all(&self.pool)
@@ -2319,18 +2294,6 @@ impl ThingsDatabase {
             let shortcut: Option<String> = row.get("shortcut");
             let parent_str: Option<String> = row.get("parent");
             let parent_uuid = parent_str.map(ThingsId::from_trusted);
-
-            let creation_ts: f64 = row.get("creationDate");
-            let created = {
-                let ts = safe_timestamp_convert(creation_ts);
-                DateTime::from_timestamp(ts, 0).unwrap_or_else(Utc::now)
-            };
-
-            let modification_ts: f64 = row.get("userModificationDate");
-            let modified = {
-                let ts = safe_timestamp_convert(modification_ts);
-                DateTime::from_timestamp(ts, 0).unwrap_or_else(Utc::now)
-            };
 
             let used_ts: Option<f64> = row.get("usedDate");
             let last_used = used_ts.and_then(|ts| {
@@ -2355,8 +2318,6 @@ impl ThingsDatabase {
                 title,
                 shortcut,
                 parent_uuid,
-                created,
-                modified,
                 usage_count: usage_count as u32,
                 last_used,
             });
@@ -2391,10 +2352,10 @@ impl ThingsDatabase {
     #[instrument(skip(self))]
     pub async fn get_recent_tags(&self, limit: usize) -> ThingsResult<Vec<crate::models::Tag>> {
         let rows = sqlx::query(
-            "SELECT uuid, title, shortcut, parent, creationDate, userModificationDate, usedDate 
-             FROM TMTag 
-             WHERE usedDate IS NOT NULL 
-             ORDER BY usedDate DESC 
+            "SELECT uuid, title, shortcut, parent, usedDate
+             FROM TMTag
+             WHERE usedDate IS NOT NULL
+             ORDER BY usedDate DESC
              LIMIT ?",
         )
         .bind(limit as i64)
@@ -2409,18 +2370,6 @@ impl ThingsDatabase {
             let shortcut: Option<String> = row.get("shortcut");
             let parent_str: Option<String> = row.get("parent");
             let parent_uuid = parent_str.map(ThingsId::from_trusted);
-
-            let creation_ts: f64 = row.get("creationDate");
-            let created = {
-                let ts = safe_timestamp_convert(creation_ts);
-                DateTime::from_timestamp(ts, 0).unwrap_or_else(Utc::now)
-            };
-
-            let modification_ts: f64 = row.get("userModificationDate");
-            let modified = {
-                let ts = safe_timestamp_convert(modification_ts);
-                DateTime::from_timestamp(ts, 0).unwrap_or_else(Utc::now)
-            };
 
             let used_ts: Option<f64> = row.get("usedDate");
             let last_used = used_ts.and_then(|ts| {
@@ -2445,8 +2394,6 @@ impl ThingsDatabase {
                 title,
                 shortcut,
                 parent_uuid,
-                created,
-                modified,
                 usage_count: usage_count as u32,
                 last_used,
             });
@@ -2497,18 +2444,15 @@ impl ThingsDatabase {
 
         // 5. No duplicates, safe to create
         let id = ThingsId::new_things_native();
-        let now = Utc::now().timestamp() as f64;
 
         sqlx::query(
-            "INSERT INTO TMTag (uuid, title, shortcut, parent, creationDate, userModificationDate, usedDate, `index`) \
-             VALUES (?, ?, ?, ?, ?, ?, NULL, 0)"
+            "INSERT INTO TMTag (uuid, title, shortcut, parent, usedDate, `index`) \
+             VALUES (?, ?, ?, ?, NULL, 0)"
         )
         .bind(id.as_str())
         .bind(&request.title)
         .bind(request.shortcut.as_ref())
         .bind(request.parent_uuid.map(|u| u.into_string()))
-        .bind(now)
-        .bind(now)
         .execute(&self.pool)
         .await
         .map_err(|e| ThingsError::unknown(format!("Failed to create tag: {e}")))?;
@@ -2531,18 +2475,15 @@ impl ThingsDatabase {
         request: crate::models::CreateTagRequest,
     ) -> ThingsResult<ThingsId> {
         let id = ThingsId::new_things_native();
-        let now = Utc::now().timestamp() as f64;
 
         sqlx::query(
-            "INSERT INTO TMTag (uuid, title, shortcut, parent, creationDate, userModificationDate, usedDate, `index`) \
-             VALUES (?, ?, ?, ?, ?, ?, NULL, 0)"
+            "INSERT INTO TMTag (uuid, title, shortcut, parent, usedDate, `index`) \
+             VALUES (?, ?, ?, ?, NULL, 0)"
         )
         .bind(id.as_str())
         .bind(&request.title)
         .bind(request.shortcut.as_ref())
         .bind(request.parent_uuid.map(|u| u.into_string()))
-        .bind(now)
-        .bind(now)
         .execute(&self.pool)
         .await
         .map_err(|e| ThingsError::unknown(format!("Failed to create tag: {e}")))?;
@@ -2593,8 +2534,6 @@ impl ThingsDatabase {
             }
         }
 
-        let now = Utc::now().timestamp() as f64;
-
         // Build dynamic UPDATE query
         let mut updates = Vec::new();
         let mut params: Vec<String> = Vec::new();
@@ -2615,9 +2554,6 @@ impl ThingsDatabase {
         if updates.is_empty() {
             return Ok(()); // Nothing to update
         }
-
-        updates.push("userModificationDate = ?");
-        params.push(now.to_string());
 
         let sql = format!("UPDATE TMTag SET {} WHERE uuid = ?", updates.join(", "));
         params.push(request.uuid.as_str().to_string());
@@ -2729,8 +2665,7 @@ impl ThingsDatabase {
 
         // Update usedDate on target if source was used more recently
         let now = Utc::now().timestamp() as f64;
-        sqlx::query("UPDATE TMTag SET userModificationDate = ?, usedDate = ? WHERE uuid = ?")
-            .bind(now)
+        sqlx::query("UPDATE TMTag SET usedDate = ? WHERE uuid = ?")
             .bind(now)
             .bind(target_id.as_str())
             .execute(&self.pool)
@@ -2835,8 +2770,7 @@ impl ThingsDatabase {
             .map_err(|e| ThingsError::unknown(format!("Failed to update task tags: {e}")))?;
 
             // 9. Update tag's usedDate
-            sqlx::query("UPDATE TMTag SET usedDate = ?, userModificationDate = ? WHERE uuid = ?")
-                .bind(now)
+            sqlx::query("UPDATE TMTag SET usedDate = ? WHERE uuid = ?")
                 .bind(now)
                 .bind(tag.uuid.as_str())
                 .execute(&self.pool)
@@ -3014,15 +2948,14 @@ impl ThingsDatabase {
         for title in &resolved_tags {
             let normalized = normalize_tag_title(title);
             if let Some(tag) = self.find_tag_by_normalized_title(&normalized).await? {
-                sqlx::query(
-                    "UPDATE TMTag SET usedDate = ?, userModificationDate = ? WHERE uuid = ?",
-                )
-                .bind(now)
-                .bind(now)
-                .bind(tag.uuid.as_str())
-                .execute(&self.pool)
-                .await
-                .map_err(|e| ThingsError::unknown(format!("Failed to update tag usedDate: {e}")))?;
+                sqlx::query("UPDATE TMTag SET usedDate = ? WHERE uuid = ?")
+                    .bind(now)
+                    .bind(tag.uuid.as_str())
+                    .execute(&self.pool)
+                    .await
+                    .map_err(|e| {
+                        ThingsError::unknown(format!("Failed to update tag usedDate: {e}"))
+                    })?;
             }
         }
 
@@ -3759,7 +3692,22 @@ impl DatabaseStats {
     }
 }
 
-/// Get the default Things 3 database path
+/// Things 3 group container directory under the user's `Library`.
+const THINGS_GROUP_CONTAINER: &str =
+    "Library/Group Containers/JLMPQHK86H.com.culturedcode.ThingsMac";
+
+/// Path inside a `ThingsData-XXXXX` directory that points at the SQLite file.
+const THINGS_DB_RELATIVE: &str = "Things Database.thingsdatabase/main.sqlite";
+
+/// Get the default Things 3 database path.
+///
+/// The 4-character suffix on `ThingsData-XXXXX` varies per install (App Store
+/// vs. direct purchase, possibly tied to iCloud account), so this function
+/// scans the group container for any `ThingsData-*` directory containing a
+/// real database file. If multiple candidates exist, the one whose
+/// `main.sqlite` was modified most recently wins. When no candidate is found
+/// the function falls back to the historical literal `ThingsData-0Z0Z2` path
+/// — callers downstream surface a clean "file not found" error in that case.
 ///
 /// # Examples
 ///
@@ -3773,9 +3721,44 @@ impl DatabaseStats {
 #[must_use]
 pub fn get_default_database_path() -> PathBuf {
     let home = std::env::var("HOME").unwrap_or_else(|_| "~".to_string());
-    PathBuf::from(format!(
-        "{home}/Library/Group Containers/JLMPQHK86H.com.culturedcode.ThingsMac/ThingsData-0Z0Z2/Things Database.thingsdatabase/main.sqlite"
-    ))
+    let group_container = PathBuf::from(&home).join(THINGS_GROUP_CONTAINER);
+
+    if let Some(found) = discover_things_database(&group_container) {
+        return found;
+    }
+
+    group_container
+        .join("ThingsData-0Z0Z2")
+        .join(THINGS_DB_RELATIVE)
+}
+
+/// Scan `group_container` for `ThingsData-*/Things Database.thingsdatabase/main.sqlite`
+/// and return the most-recently-modified candidate, if any.
+fn discover_things_database(group_container: &std::path::Path) -> Option<PathBuf> {
+    let entries = std::fs::read_dir(group_container).ok()?;
+
+    let mut best: Option<(PathBuf, std::time::SystemTime)> = None;
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name_str) = name.to_str() else { continue };
+        if !name_str.starts_with("ThingsData-") {
+            continue;
+        }
+
+        let candidate = entry.path().join(THINGS_DB_RELATIVE);
+        let Ok(meta) = std::fs::metadata(&candidate) else { continue };
+        if !meta.is_file() {
+            continue;
+        }
+        let mtime = meta.modified().unwrap_or(std::time::UNIX_EPOCH);
+
+        match &best {
+            Some((_, best_mtime)) if mtime <= *best_mtime => {}
+            _ => best = Some((candidate, mtime)),
+        }
+    }
+
+    best.map(|(path, _)| path)
 }
 
 #[cfg(test)]
@@ -4126,6 +4109,63 @@ mod tests {
         assert!(path_str.contains("Things Database.thingsdatabase"));
         assert!(path_str.contains("main.sqlite"));
         assert!(path_str.contains("Library/Group Containers"));
+    }
+
+    #[test]
+    fn test_discover_things_database_picks_non_default_suffix() {
+        let group_container = TempDir::new().unwrap();
+        let things_dir = group_container.path().join("ThingsData-01AEF");
+        let db_dir = things_dir.join("Things Database.thingsdatabase");
+        std::fs::create_dir_all(&db_dir).unwrap();
+        let db_path = db_dir.join("main.sqlite");
+        std::fs::write(&db_path, b"").unwrap();
+
+        let found = discover_things_database(group_container.path()).unwrap();
+        assert_eq!(found, db_path);
+    }
+
+    #[test]
+    fn test_discover_things_database_prefers_most_recent() {
+        let group_container = TempDir::new().unwrap();
+
+        let make = |suffix: &str| {
+            let dir = group_container
+                .path()
+                .join(format!("ThingsData-{suffix}"))
+                .join("Things Database.thingsdatabase");
+            std::fs::create_dir_all(&dir).unwrap();
+            let db = dir.join("main.sqlite");
+            std::fs::write(&db, b"").unwrap();
+            db
+        };
+
+        let _older = make("OLDER");
+        // 10ms is well above any reasonable filesystem mtime resolution, so
+        // the second file is guaranteed to have a strictly later mtime.
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        let newer = make("NEWER");
+
+        let found = discover_things_database(group_container.path()).unwrap();
+        assert_eq!(found, newer);
+    }
+
+    #[test]
+    fn test_discover_things_database_returns_none_when_empty() {
+        let group_container = TempDir::new().unwrap();
+        assert!(discover_things_database(group_container.path()).is_none());
+    }
+
+    #[test]
+    fn test_discover_things_database_skips_non_matching_dirs() {
+        let group_container = TempDir::new().unwrap();
+        std::fs::create_dir_all(group_container.path().join("SomethingElse")).unwrap();
+        std::fs::create_dir_all(
+            group_container
+                .path()
+                .join("ThingsData-EMPTY"), // no main.sqlite inside
+        )
+        .unwrap();
+        assert!(discover_things_database(group_container.path()).is_none());
     }
 
     #[tokio::test]

--- a/libs/things3-core/src/database/core.rs
+++ b/libs/things3-core/src/database/core.rs
@@ -2447,7 +2447,7 @@ impl ThingsDatabase {
 
         sqlx::query(
             "INSERT INTO TMTag (uuid, title, shortcut, parent, usedDate, `index`) \
-             VALUES (?, ?, ?, ?, NULL, 0)"
+             VALUES (?, ?, ?, ?, NULL, 0)",
         )
         .bind(id.as_str())
         .bind(&request.title)
@@ -2478,7 +2478,7 @@ impl ThingsDatabase {
 
         sqlx::query(
             "INSERT INTO TMTag (uuid, title, shortcut, parent, usedDate, `index`) \
-             VALUES (?, ?, ?, ?, NULL, 0)"
+             VALUES (?, ?, ?, ?, NULL, 0)",
         )
         .bind(id.as_str())
         .bind(&request.title)
@@ -3740,13 +3740,17 @@ fn discover_things_database(group_container: &std::path::Path) -> Option<PathBuf
     let mut best: Option<(PathBuf, std::time::SystemTime)> = None;
     for entry in entries.flatten() {
         let name = entry.file_name();
-        let Some(name_str) = name.to_str() else { continue };
+        let Some(name_str) = name.to_str() else {
+            continue;
+        };
         if !name_str.starts_with("ThingsData-") {
             continue;
         }
 
         let candidate = entry.path().join(THINGS_DB_RELATIVE);
-        let Ok(meta) = std::fs::metadata(&candidate) else { continue };
+        let Ok(meta) = std::fs::metadata(&candidate) else {
+            continue;
+        };
         if !meta.is_file() {
             continue;
         }
@@ -4160,9 +4164,7 @@ mod tests {
         let group_container = TempDir::new().unwrap();
         std::fs::create_dir_all(group_container.path().join("SomethingElse")).unwrap();
         std::fs::create_dir_all(
-            group_container
-                .path()
-                .join("ThingsData-EMPTY"), // no main.sqlite inside
+            group_container.path().join("ThingsData-EMPTY"), // no main.sqlite inside
         )
         .unwrap();
         assert!(discover_things_database(group_container.path()).is_none());

--- a/libs/things3-core/src/mcp_config.rs
+++ b/libs/things3-core/src/mcp_config.rs
@@ -694,13 +694,13 @@ impl McpServerConfig {
         )))
     }
 
-    /// Get the default Things 3 database path
+    /// Get the default Things 3 database path.
+    ///
+    /// Delegates to [`crate::database::get_default_database_path`], which
+    /// auto-discovers the per-install `ThingsData-XXXXX` suffix.
     #[must_use]
     pub fn get_default_database_path() -> PathBuf {
-        let home = std::env::var("HOME").unwrap_or_else(|_| "~".to_string());
-        PathBuf::from(format!(
-            "{home}/Library/Group Containers/JLMPQHK86H.com.culturedcode.ThingsMac/ThingsData-0Z0Z2/Things Database.thingsdatabase/main.sqlite"
-        ))
+        crate::database::get_default_database_path()
     }
 }
 

--- a/libs/things3-core/src/models.rs
+++ b/libs/things3-core/src/models.rs
@@ -484,10 +484,6 @@ pub struct Tag {
     pub shortcut: Option<String>,
     /// Parent tag UUID (for nested tags)
     pub parent_uuid: Option<ThingsId>,
-    /// Creation timestamp
-    pub created: DateTime<Utc>,
-    /// Last modification timestamp
-    pub modified: DateTime<Utc>,
     /// How many tasks use this tag
     pub usage_count: u32,
     /// Last time this tag was used
@@ -1098,8 +1094,6 @@ mod tests {
             title: "work".to_string(),
             shortcut: Some("w".to_string()),
             parent_uuid: Some(parent_uuid.clone()),
-            created: now,
-            modified: now,
             usage_count: 5,
             last_used: Some(now),
         };
@@ -1115,15 +1109,12 @@ mod tests {
     #[test]
     fn test_tag_serialization() {
         let uuid = ThingsId::new_v4();
-        let now = Utc::now();
 
         let tag = Tag {
             uuid: uuid.clone(),
             title: "test".to_string(),
             shortcut: None,
             parent_uuid: None,
-            created: now,
-            modified: now,
             usage_count: 0,
             last_used: None,
         };

--- a/libs/things3-core/src/mutations/applescript/mod.rs
+++ b/libs/things3-core/src/mutations/applescript/mod.rs
@@ -115,26 +115,20 @@ impl AppleScriptBackend {
         Ok(row.get("title"))
     }
 
-    /// Read a task's current tag-title list from the DB's `cachedTags` blob.
-    /// Returns an empty list if the task has no tags. Errors if the task
-    /// doesn't exist.
+    /// Read a task's current tag-title list by querying Things 3 via osascript.
+    /// Returns an empty list if the task has no tags.
     ///
-    /// CulturedCode-safe: read-only access.
+    /// We use osascript here (rather than reading `cachedTags` from SQLite)
+    /// because Things 3 writes `cachedTags` in a proprietary binary format
+    /// after any AppleScript mutation — not the JSON format we can parse.
     async fn read_task_tag_titles(&self, task_id: &ThingsId) -> ThingsResult<Vec<String>> {
-        let row = sqlx::query("SELECT cachedTags FROM TMTask WHERE uuid = ?")
-            .bind(task_id.as_str())
-            .fetch_optional(&self.db.pool)
-            .await
-            .map_err(|e| {
-                ThingsError::applescript(format!("failed to read tags for task {task_id}: {e}"))
-            })?;
-        let row =
-            row.ok_or_else(|| ThingsError::applescript(format!("task not found: {task_id}")))?;
-        let blob: Option<Vec<u8>> = row.get("cachedTags");
-        match blob {
-            None => Ok(Vec::new()),
-            Some(b) => crate::database::deserialize_tags_from_blob(&b),
+        let script = script::get_task_tag_names_script(task_id);
+        let output = runner::run_script(&script).await?;
+        let trimmed = output.trim();
+        if trimmed.is_empty() {
+            return Ok(Vec::new());
         }
+        Ok(trimmed.split(", ").map(str::to_string).collect())
     }
 
     /// List `(task_id, current_tag_titles)` for every non-trashed task whose

--- a/libs/things3-core/src/mutations/applescript/script.rs
+++ b/libs/things3-core/src/mutations/applescript/script.rs
@@ -627,9 +627,7 @@ pub(crate) fn set_task_tag_names_script(task_id: &ThingsId, joined: &str) -> Str
 /// Used by `read_task_tag_titles` to avoid parsing the proprietary binary
 /// blob that Things 3 writes to `cachedTags` after an AppleScript mutation.
 pub(crate) fn get_task_tag_names_script(task_id: &ThingsId) -> String {
-    wrap(&format!(
-        "\t\treturn tag names of to do id \"{task_id}\"\n"
-    ))
+    wrap(&format!("\t\treturn tag names of to do id \"{task_id}\"\n"))
 }
 
 /// Bulk variant of [`set_task_tag_names_script`] — one osascript invocation

--- a/libs/things3-core/src/mutations/applescript/script.rs
+++ b/libs/things3-core/src/mutations/applescript/script.rs
@@ -622,6 +622,17 @@ pub(crate) fn set_task_tag_names_script(task_id: &ThingsId, joined: &str) -> Str
     ))
 }
 
+/// Return the `tag names` string for a task. Things 3 stores tag names as a
+/// comma-separated text property; an untagged task returns an empty string.
+/// Used by `read_task_tag_titles` to avoid parsing the proprietary binary
+/// blob that Things 3 writes to `cachedTags` after an AppleScript mutation.
+#[allow(dead_code)] // Used by AppleScriptBackend
+pub(crate) fn get_task_tag_names_script(task_id: &ThingsId) -> String {
+    wrap(&format!(
+        "\t\treturn tag names of to do id \"{task_id}\"\n"
+    ))
+}
+
 /// Bulk variant of [`set_task_tag_names_script`] — one osascript invocation
 /// rewrites tag names for many tasks. Each item runs in its own try block
 /// via [`bulk_wrap`]. Used by `merge_tags` and `delete_tag(remove_from_tasks=true)`.

--- a/libs/things3-core/src/mutations/applescript/script.rs
+++ b/libs/things3-core/src/mutations/applescript/script.rs
@@ -626,7 +626,6 @@ pub(crate) fn set_task_tag_names_script(task_id: &ThingsId, joined: &str) -> Str
 /// comma-separated text property; an untagged task returns an empty string.
 /// Used by `read_task_tag_titles` to avoid parsing the proprietary binary
 /// blob that Things 3 writes to `cachedTags` after an AppleScript mutation.
-#[allow(dead_code)] // Used by AppleScriptBackend
 pub(crate) fn get_task_tag_names_script(task_id: &ThingsId) -> String {
     wrap(&format!(
         "\t\treturn tag names of to do id \"{task_id}\"\n"

--- a/libs/things3-core/src/test_utils.rs
+++ b/libs/things3-core/src/test_utils.rs
@@ -68,18 +68,17 @@ pub async fn create_test_database<P: AsRef<Path>>(db_path: P) -> crate::Result<(
     .await
     .map_err(|e| crate::ThingsError::Database(format!("Failed to create TMArea table: {e}")))?;
 
-    // Create TMTag table
+    // Create TMTag table — schema mirrors real Things 3 (no creationDate/userModificationDate).
     sqlx::query(
         "
         CREATE TABLE IF NOT EXISTS TMTag (
             uuid TEXT PRIMARY KEY,
-            title TEXT NOT NULL,
+            title TEXT,
             shortcut TEXT,
-            parent TEXT,
-            creationDate REAL NOT NULL,
-            userModificationDate REAL NOT NULL,
             usedDate REAL,
-            'index' INTEGER NOT NULL DEFAULT 0
+            parent TEXT,
+            'index' INTEGER,
+            experimental BLOB
         )
         ",
     )

--- a/libs/things3-core/tests/applescript_live.rs
+++ b/libs/things3-core/tests/applescript_live.rs
@@ -41,8 +41,15 @@ fn live_tests_enabled() -> bool {
 /// Connect to the user's real Things 3 SQLite database and wrap it in an
 /// `AppleScriptBackend`. Read-only DB access is CulturedCode-safe; the
 /// mutations route through osascript.
+///
+/// Honors `THINGS_DB_PATH` / `THINGS_DATABASE_PATH` so installs whose
+/// `ThingsData-*` group container suffix differs from the project default
+/// can still run this suite.
 async fn live_backend() -> Arc<AppleScriptBackend> {
-    let db_path = things3_core::get_default_database_path();
+    let db_path = std::env::var("THINGS_DB_PATH")
+        .or_else(|_| std::env::var("THINGS_DATABASE_PATH"))
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| things3_core::get_default_database_path());
     let db = Arc::new(
         ThingsDatabase::new(&db_path)
             .await

--- a/src/bin/test_mcp_real_data.rs
+++ b/src/bin/test_mcp_real_data.rs
@@ -42,7 +42,6 @@ struct Args {
     dry_run: bool,
 }
 
-const DEFAULT_THINGS_DB_PATH: &str = "/Users/garthdb/Library/Group Containers/JLMPQHK86H.com.culturedcode.ThingsMac/ThingsData-0Z0Z2/Things Database.thingsdatabase/main.sqlite";
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -60,7 +59,7 @@ async fn main() -> Result<()> {
     // Determine database path
     let db_path = args
         .database_path
-        .unwrap_or_else(|| PathBuf::from(DEFAULT_THINGS_DB_PATH));
+        .unwrap_or_else(things3_core::get_default_database_path);
 
     if !db_path.exists() {
         error!("Database not found at: {}", db_path.display());

--- a/tools/xtask/Cargo.toml
+++ b/tools/xtask/Cargo.toml
@@ -15,6 +15,9 @@ path = "src/main.rs"
 # CLI
 clap.workspace = true
 
+# Things 3 path discovery
+things3-core = { path = "../../libs/things3-core" }
+
 # Error handling
 anyhow.workspace = true
 thiserror.workspace = true

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -151,11 +151,8 @@ fn things_backup() {
 }
 
 fn things_db_location() {
-    let home = std::env::var("HOME").unwrap_or_else(|_| "~".to_string());
-    let db_path = format!(
-        "{home}/Library/Group Containers/JLMPQHK86H.com.culturedcode.ThingsMac/ThingsData-0Z0Z2/Things Database.thingsdatabase/main.sqlite"
-    );
-    println!("📁 Things database location: {db_path}");
+    let db_path = things3_core::get_default_database_path();
+    println!("📁 Things database location: {}", db_path.display());
 }
 
 fn analyze() {


### PR DESCRIPTION
## Summary

Two real-world bugs surfaced by running the live AppleScript integration tests against a real Things 3 install. Both stem from the same root cause: code paths that worked against the synthetic test fixture but broke against the production macOS Things 3 SQLite database.

- **Closes #151** — `find_tag_by_normalized_title` and the tag INSERT/UPDATE statements referenced `creationDate` and `userModificationDate` columns on `TMTag`. Those columns exist only in our synthetic schema; real Things 3 errored with `no such column: creationDate` on every tag-by-title lookup.
- **Closes #152** — `get_default_database_path()` hardcoded the group-container subdirectory `ThingsData-0Z0Z2`. That 4-char suffix is per-install, so the default was wrong on any machine with a different suffix (this machine uses `ThingsData-01AEF`).

### Changes

**TMTag schema (#151)**
- Drop `Tag.created` and `Tag.modified` from the public struct (real Things 3 doesn't store these).
- Rewrite all four `TMTag` SELECTs to: `uuid, title, shortcut, parent, usedDate`.
- Rewrite both `TMTag` INSERTs to omit the nonexistent columns.
- Remove `userModificationDate` from `UPDATE TMTag` in `update_tag`, `merge_tags`, `add_tag_to_task`, and `set_task_tags`.
- Realign the synthetic `TMTag` schema in `test_utils.rs` to match real Things 3 (drops `creationDate`/`userModificationDate`, adds `experimental BLOB`). Future divergence will now be caught immediately.

**DB path discovery (#152)**
- New `discover_things_database()` uses `std::fs::read_dir` to glob `ThingsData-*` dirs in the group container, filter for ones containing `Things Database.thingsdatabase/main.sqlite`, and return the most-recently-modified candidate. No new dependencies.
- Falls back to `ThingsData-0Z0Z2` only when discovery finds nothing — preserves current behavior for that install while fixing every other.
- Consolidate the three duplicate `get_default_database_path()` implementations into one canonical function in `database/core.rs`; `config.rs` and `mcp_config.rs` now delegate.
- Replace the literal in `tools/xtask/src/main.rs`, `apps/things3-cli/src/bin/test_mcp_real_data.rs`, and `src/bin/test_mcp_real_data.rs` with the canonical helper.
- 4 new unit tests cover discovery: non-default suffix, most-recent-mtime tiebreak, empty container, non-matching dirs.

**Empty `cachedTags` blob (encountered while testing #151 fix)**
- Freshly-created tasks may have `cachedTags = b""` (empty bytes, not NULL). `deserialize_tags_from_blob` now returns `Ok(Vec::new())` for empty input.
- `read_task_tag_titles` in `AppleScriptBackend` now queries Things 3 via `osascript get tag names of to do id "..."` instead of reading the SQLite blob — Things 3 writes `cachedTags` in a proprietary binary format after any AppleScript mutation, so the SQLite-read path is unreliable. Bypassing it removes a class of binary-plist parsing bugs entirely. New `get_task_tag_names_script` helper.

### Semver note

Removing `Tag.created` / `Tag.modified` is technically a breaking change at 1.4.0. Acceptable here because the previous fields were synthetic — real Things 3 never populated them — and the only consumer of this crate has confirmed.

## Test plan

- [x] `cargo test -p things3-core --lib` — 537 tests pass
- [x] `cargo test -p things3-core --features advanced-queries --lib` — 614 tests pass
- [x] `cargo check -p things3-core` — clean
- [x] `THINGS3_LIVE_TESTS=1 cargo test -p things3-core --test applescript_live -- --ignored --test-threads=1` — all 4 lifecycle round-trips pass against real Things 3:
  - `task_lifecycle_round_trip` ✓
  - `project_lifecycle_round_trip` ✓
  - `area_lifecycle_round_trip` ✓
  - `tag_lifecycle_round_trip` ✓
- [x] `unset THINGS_DB_PATH THINGS_DATABASE_PATH && cargo run --bin things3 -- health` discovers `ThingsData-01AEF` on this machine without env overrides

🤖 Generated with [Claude Code](https://claude.com/claude-code)