### PR TITLE
fix(mcp): implement export_data output_path, CSV, Markdown, and RFC 4180 CSV fix (#164, #176)

### DIFF
--- a/apps/things3-cli/src/mcp.rs
+++ b/apps/things3-cli/src/mcp.rs
@@ -7,9 +7,9 @@ use std::sync::Arc;
 #[cfg(target_os = "macos")]
 use things3_core::AppleScriptBackend;
 use things3_core::{
-    models::ThingsId, BackupManager, DataExporter, DeleteChildHandling, McpServerConfig,
-    MutationBackend, PerformanceMonitor, SqlxBackend, ThingsCache, ThingsConfig, ThingsDatabase,
-    ThingsError,
+    models::ThingsId, BackupManager, DataExporter, DeleteChildHandling, ExportData, ExportFormat,
+    McpServerConfig, MutationBackend, PerformanceMonitor, SqlxBackend, ThingsCache, ThingsConfig,
+    ThingsDatabase, ThingsError,
 };
 use thiserror::Error;
 use tokio::sync::Mutex;
@@ -1676,7 +1676,7 @@ impl ThingsMcpServer {
             },
             Tool {
                 name: "export_data".to_string(),
-                description: "Export data in various formats".to_string(),
+                description: "Export data in various formats. When output_path is provided, writes to that file and returns a short confirmation; otherwise returns the data inline. Note: CSV format does not support data_type=all.".to_string(),
                 input_schema: serde_json::json!({
                     "type": "object",
                     "properties": {
@@ -1689,6 +1689,10 @@ impl ThingsMcpServer {
                             "type": "string",
                             "description": "Type of data to export",
                             "enum": ["tasks", "projects", "areas", "all"]
+                        },
+                        "output_path": {
+                            "type": "string",
+                            "description": "Optional absolute path to write the export file. Supports leading ~ for home directory. When provided, returns a confirmation object instead of inline data."
                         }
                     },
                     "required": ["format", "data_type"]
@@ -3153,75 +3157,129 @@ impl ThingsMcpServer {
             .get("data_type")
             .and_then(|v| v.as_str())
             .ok_or_else(|| McpError::missing_parameter("data_type"))?;
+        let output_path = args.get("output_path").and_then(|v| v.as_str());
+
+        if !matches!(data_type, "tasks" | "projects" | "areas" | "all") {
+            return Err(McpError::invalid_data_type(
+                data_type,
+                "tasks, projects, areas, all",
+            ));
+        }
+
+        if format == "csv" && data_type == "all" {
+            return Err(McpError::invalid_parameter(
+                "data_type",
+                "CSV format does not support data_type=all. Use tasks, projects, or areas individually.",
+            ));
+        }
 
         let db = &self.db;
-        let export_data =
-            match data_type {
-                "tasks" => {
-                    let inbox = db.get_inbox(None).await.map_err(|e| {
-                        McpError::database_operation_failed("get_inbox for export", e)
-                    })?;
-                    let today = db.get_today(None).await.map_err(|e| {
-                        McpError::database_operation_failed("get_today for export", e)
-                    })?;
-                    serde_json::json!({
-                        "inbox": inbox,
-                        "today": today
-                    })
-                }
-                "projects" => {
-                    let projects = db.get_projects(None).await.map_err(|e| {
-                        McpError::database_operation_failed("get_projects for export", e)
-                    })?;
-                    serde_json::json!({ "projects": projects })
-                }
-                "areas" => {
-                    let areas = db.get_areas().await.map_err(|e| {
-                        McpError::database_operation_failed("get_areas for export", e)
-                    })?;
-                    serde_json::json!({ "areas": areas })
-                }
-                "all" => {
-                    let inbox = db.get_inbox(None).await.map_err(|e| {
-                        McpError::database_operation_failed("get_inbox for export", e)
-                    })?;
-                    let today = db.get_today(None).await.map_err(|e| {
-                        McpError::database_operation_failed("get_today for export", e)
-                    })?;
-                    let projects = db.get_projects(None).await.map_err(|e| {
-                        McpError::database_operation_failed("get_projects for export", e)
-                    })?;
-                    let areas = db.get_areas().await.map_err(|e| {
-                        McpError::database_operation_failed("get_areas for export", e)
-                    })?;
-                    let _ = db;
-                    serde_json::json!({
-                        "inbox": inbox,
-                        "today": today,
-                        "projects": projects,
-                        "areas": areas
-                    })
-                }
-                _ => {
-                    return Err(McpError::invalid_data_type(
-                        data_type,
-                        "tasks, projects, areas, all",
-                    ))
-                }
-            };
+        let need_tasks = matches!(data_type, "tasks" | "all");
+        let need_projects = matches!(data_type, "projects" | "all");
+        let need_areas = matches!(data_type, "areas" | "all");
 
-        let result = match format {
-            "json" => serde_json::to_string_pretty(&export_data)
-                .map_err(|e| McpError::serialization_failed("export_data serialization", e))?,
-            "csv" => "CSV export not yet implemented".to_string(),
-            "markdown" => "Markdown export not yet implemented".to_string(),
+        let inbox = if need_tasks {
+            db.get_inbox(None)
+                .await
+                .map_err(|e| McpError::database_operation_failed("get_inbox for export", e))?
+        } else {
+            vec![]
+        };
+        let today = if need_tasks {
+            db.get_today(None)
+                .await
+                .map_err(|e| McpError::database_operation_failed("get_today for export", e))?
+        } else {
+            vec![]
+        };
+        let projects = if need_projects {
+            db.get_projects(None)
+                .await
+                .map_err(|e| McpError::database_operation_failed("get_projects for export", e))?
+        } else {
+            vec![]
+        };
+        let areas = if need_areas {
+            db.get_areas()
+                .await
+                .map_err(|e| McpError::database_operation_failed("get_areas for export", e))?
+        } else {
+            vec![]
+        };
+
+        let mut counts = serde_json::Map::new();
+        if need_tasks {
+            counts.insert("inbox".to_string(), inbox.len().into());
+            counts.insert("today".to_string(), today.len().into());
+        }
+        if need_projects {
+            counts.insert("projects".to_string(), projects.len().into());
+        }
+        if need_areas {
+            counts.insert("areas".to_string(), areas.len().into());
+        }
+
+        let formatted = match format {
+            "json" => {
+                let json_val = match data_type {
+                    "tasks" => serde_json::json!({ "inbox": &inbox, "today": &today }),
+                    "projects" => serde_json::json!({ "projects": &projects }),
+                    "areas" => serde_json::json!({ "areas": &areas }),
+                    _ => serde_json::json!({
+                        "inbox": &inbox,
+                        "today": &today,
+                        "projects": &projects,
+                        "areas": &areas
+                    }),
+                };
+                serde_json::to_string_pretty(&json_val)
+                    .map_err(|e| McpError::serialization_failed("export_data json", e))?
+            }
+            "csv" => {
+                let mut all_tasks = inbox;
+                all_tasks.extend(today);
+                let export_data = ExportData::new(all_tasks, projects, areas);
+                DataExporter::new_default()
+                    .export(&export_data, ExportFormat::Csv)
+                    .map_err(|e| McpError::invalid_parameter("format", e.to_string()))?
+            }
+            "markdown" => {
+                let mut all_tasks = inbox;
+                all_tasks.extend(today);
+                let export_data = ExportData::new(all_tasks, projects, areas);
+                DataExporter::new_default()
+                    .export(&export_data, ExportFormat::Markdown)
+                    .map_err(|e| McpError::invalid_parameter("format", e.to_string()))?
+            }
             _ => return Err(McpError::invalid_format(format, "json, csv, markdown")),
         };
 
-        Ok(CallToolResult {
-            content: vec![Content::Text { text: result }],
-            is_error: false,
-        })
+        if let Some(raw_path) = output_path {
+            let path = expand_tilde(raw_path)?;
+            let bytes = formatted.as_bytes();
+            std::fs::write(&path, bytes)
+                .map_err(|e| McpError::io_operation_failed("export_data write", e))?;
+            let confirmation = serde_json::json!({
+                "path": path.to_string_lossy().as_ref(),
+                "format": format,
+                "data_type": data_type,
+                "bytes_written": bytes.len(),
+                "counts": serde_json::Value::Object(counts)
+            });
+            Ok(CallToolResult {
+                content: vec![Content::Text {
+                    text: serde_json::to_string_pretty(&confirmation).map_err(|e| {
+                        McpError::serialization_failed("export_data confirmation", e)
+                    })?,
+                }],
+                is_error: false,
+            })
+        } else {
+            Ok(CallToolResult {
+                content: vec![Content::Text { text: formatted }],
+                is_error: false,
+            })
+        }
     }
 
     async fn handle_bulk_create_tasks(&self, args: Value) -> McpResult<CallToolResult> {
@@ -4732,6 +4790,25 @@ impl ThingsMcpServer {
             "id": id,
             "result": result
         })))
+    }
+}
+
+fn expand_tilde(path: &str) -> McpResult<std::path::PathBuf> {
+    if path == "~" || path.starts_with("~/") {
+        let home = std::env::var("HOME").map_err(|_| {
+            McpError::invalid_parameter(
+                "output_path",
+                "cannot expand ~: HOME environment variable is not set",
+            )
+        })?;
+        Ok(std::path::PathBuf::from(format!("{}{}", home, &path[1..])))
+    } else if path.starts_with('~') {
+        Err(McpError::invalid_parameter(
+            "output_path",
+            "~user expansion is not supported; use an absolute path or ~/...",
+        ))
+    } else {
+        Ok(std::path::PathBuf::from(path))
     }
 }
 

--- a/apps/things3-cli/src/mcp.rs
+++ b/apps/things3-cli/src/mcp.rs
@@ -3241,7 +3241,7 @@ impl ThingsMcpServer {
                 let export_data = ExportData::new(all_tasks, projects, areas);
                 DataExporter::new_default()
                     .export(&export_data, ExportFormat::Csv)
-                    .map_err(|e| McpError::invalid_parameter("format", e.to_string()))?
+                    .map_err(|e| McpError::configuration_error(e.to_string()))?
             }
             "markdown" => {
                 let mut all_tasks = inbox;
@@ -3249,7 +3249,7 @@ impl ThingsMcpServer {
                 let export_data = ExportData::new(all_tasks, projects, areas);
                 DataExporter::new_default()
                     .export(&export_data, ExportFormat::Markdown)
-                    .map_err(|e| McpError::invalid_parameter("format", e.to_string()))?
+                    .map_err(|e| McpError::configuration_error(e.to_string()))?
             }
             _ => return Err(McpError::invalid_format(format, "json, csv, markdown")),
         };

--- a/apps/things3-cli/tests/mcp_tests_legacy.rs
+++ b/apps/things3-cli/tests/mcp_tests_legacy.rs
@@ -612,8 +612,8 @@ async fn test_export_data_csv_tasks() {
     match &result.content[0] {
         Content::Text { text } => {
             assert!(
-                text.contains("Type,Title,Status"),
-                "expected task CSV header, got: {text}"
+                text.contains("Type,Title,Status,Notes,Start Date,Deadline,Created,Modified,Project,Area,Parent"),
+                "expected full task CSV header, got: {text}"
             );
             assert!(text.contains("Inbox Task"), "expected inbox task row");
         }

--- a/apps/things3-cli/tests/mcp_tests_legacy.rs
+++ b/apps/things3-cli/tests/mcp_tests_legacy.rs
@@ -597,6 +597,191 @@ async fn test_export_data_tool_invalid_format() {
 }
 
 #[tokio::test]
+async fn test_export_data_csv_tasks() {
+    let server = create_test_mcp_server().await;
+    let request = CallToolRequest {
+        name: "export_data".to_string(),
+        arguments: Some(json!({
+            "format": "csv",
+            "data_type": "tasks"
+        })),
+    };
+
+    let result = server.call_tool(request).await.unwrap();
+    assert!(!result.is_error);
+    match &result.content[0] {
+        Content::Text { text } => {
+            assert!(
+                text.contains("Type,Title,Status"),
+                "expected task CSV header, got: {text}"
+            );
+            assert!(text.contains("Inbox Task"), "expected inbox task row");
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_export_data_csv_projects() {
+    let server = create_test_mcp_server().await;
+    let request = CallToolRequest {
+        name: "export_data".to_string(),
+        arguments: Some(json!({
+            "format": "csv",
+            "data_type": "projects"
+        })),
+    };
+
+    let result = server.call_tool(request).await.unwrap();
+    assert!(!result.is_error);
+    match &result.content[0] {
+        Content::Text { text } => {
+            assert!(
+                text.contains("Title,Status,Notes"),
+                "expected project CSV header, got: {text}"
+            );
+            assert!(text.contains("Website Redesign"), "expected project row");
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_export_data_csv_areas() {
+    let server = create_test_mcp_server().await;
+    let request = CallToolRequest {
+        name: "export_data".to_string(),
+        arguments: Some(json!({
+            "format": "csv",
+            "data_type": "areas"
+        })),
+    };
+
+    let result = server.call_tool(request).await.unwrap();
+    assert!(!result.is_error);
+    match &result.content[0] {
+        Content::Text { text } => {
+            assert!(
+                text.contains("Title,Notes,Created,Modified"),
+                "expected area CSV header, got: {text}"
+            );
+            assert!(text.contains("Work"), "expected area row");
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_export_data_csv_all_rejected() {
+    let server = create_test_mcp_server().await;
+    let request = CallToolRequest {
+        name: "export_data".to_string(),
+        arguments: Some(json!({
+            "format": "csv",
+            "data_type": "all"
+        })),
+    };
+
+    let result = server.call_tool(request).await;
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        McpError::InvalidParameter {
+            parameter_name,
+            message,
+        } => {
+            assert_eq!(parameter_name, "data_type");
+            assert!(
+                message.contains("tasks")
+                    && message.contains("projects")
+                    && message.contains("areas"),
+                "error should name the valid alternatives, got: {message}"
+            );
+        }
+        e => panic!("Expected InvalidParameter error, got: {e:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_export_data_markdown_tasks() {
+    let server = create_test_mcp_server().await;
+    let request = CallToolRequest {
+        name: "export_data".to_string(),
+        arguments: Some(json!({
+            "format": "markdown",
+            "data_type": "tasks"
+        })),
+    };
+
+    let result = server.call_tool(request).await.unwrap();
+    assert!(!result.is_error);
+    match &result.content[0] {
+        Content::Text { text } => {
+            assert!(
+                text.starts_with("# Things 3 Export"),
+                "expected markdown heading, got: {text}"
+            );
+            assert!(text.contains("## Tasks"), "expected Tasks section");
+            assert!(text.contains("Inbox Task"), "expected inbox task");
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_export_data_markdown_all() {
+    let server = create_test_mcp_server().await;
+    let request = CallToolRequest {
+        name: "export_data".to_string(),
+        arguments: Some(json!({
+            "format": "markdown",
+            "data_type": "all"
+        })),
+    };
+
+    let result = server.call_tool(request).await.unwrap();
+    assert!(!result.is_error);
+    match &result.content[0] {
+        Content::Text { text } => {
+            assert!(text.contains("## Areas"), "expected Areas section");
+            assert!(text.contains("## Projects"), "expected Projects section");
+            assert!(text.contains("## Tasks"), "expected Tasks section");
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_export_data_output_path_writes_file() {
+    let server = create_test_mcp_server().await;
+    let tmp = NamedTempFile::new().unwrap();
+    let path = tmp.path().to_str().unwrap().to_string();
+
+    let request = CallToolRequest {
+        name: "export_data".to_string(),
+        arguments: Some(json!({
+            "format": "json",
+            "data_type": "tasks",
+            "output_path": path
+        })),
+    };
+
+    let result = server.call_tool(request).await.unwrap();
+    assert!(!result.is_error);
+
+    match &result.content[0] {
+        Content::Text { text } => {
+            let parsed: serde_json::Value = serde_json::from_str(text).unwrap();
+            assert_eq!(parsed["path"].as_str().unwrap(), path);
+            assert_eq!(parsed["format"].as_str().unwrap(), "json");
+            assert_eq!(parsed["data_type"].as_str().unwrap(), "tasks");
+            assert!(parsed["bytes_written"].as_u64().unwrap() > 0);
+            assert!(parsed["counts"]["inbox"].is_number());
+            assert!(parsed["counts"]["today"].is_number());
+
+            // Verify the file was actually written with valid JSON
+            let file_content = std::fs::read_to_string(&path).unwrap();
+            let file_json: serde_json::Value = serde_json::from_str(&file_content).unwrap();
+            assert!(file_json["inbox"].is_array());
+        }
+    }
+}
+
+#[tokio::test]
 async fn test_bulk_create_tasks_tool() {
     let server = create_test_mcp_server().await;
     let request = CallToolRequest {

--- a/apps/things3-cli/tests/mcp_tests_legacy.rs
+++ b/apps/things3-cli/tests/mcp_tests_legacy.rs
@@ -635,9 +635,15 @@ async fn test_export_data_csv_projects() {
     assert!(!result.is_error);
     match &result.content[0] {
         Content::Text { text } => {
+            // DataExporter emits a "\n\nProjects\n" section label before the header row.
+            // These assertions document the current format so any change is visible.
             assert!(
-                text.contains("Title,Status,Notes"),
-                "expected project CSV header, got: {text}"
+                text.contains("\n\nProjects\n"),
+                "expected Projects section label, got: {text}"
+            );
+            assert!(
+                text.contains("Title,Status,Notes,Start Date,Deadline,Created,Modified,Area"),
+                "expected full project CSV header, got: {text}"
             );
             assert!(text.contains("Website Redesign"), "expected project row");
         }
@@ -659,9 +665,14 @@ async fn test_export_data_csv_areas() {
     assert!(!result.is_error);
     match &result.content[0] {
         Content::Text { text } => {
+            // DataExporter emits a "\n\nAreas\n" section label before the header row.
+            assert!(
+                text.contains("\n\nAreas\n"),
+                "expected Areas section label, got: {text}"
+            );
             assert!(
                 text.contains("Title,Notes,Created,Modified"),
-                "expected area CSV header, got: {text}"
+                "expected full area CSV header, got: {text}"
             );
             assert!(text.contains("Work"), "expected area row");
         }
@@ -777,6 +788,41 @@ async fn test_export_data_output_path_writes_file() {
             let file_content = std::fs::read_to_string(&path).unwrap();
             let file_json: serde_json::Value = serde_json::from_str(&file_content).unwrap();
             assert!(file_json["inbox"].is_array());
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_export_data_output_path_csv() {
+    let server = create_test_mcp_server().await;
+    let tmp = NamedTempFile::new().unwrap();
+    let path = tmp.path().to_str().unwrap().to_string();
+
+    let request = CallToolRequest {
+        name: "export_data".to_string(),
+        arguments: Some(json!({
+            "format": "csv",
+            "data_type": "tasks",
+            "output_path": path
+        })),
+    };
+
+    let result = server.call_tool(request).await.unwrap();
+    assert!(!result.is_error);
+
+    match &result.content[0] {
+        Content::Text { text } => {
+            let parsed: serde_json::Value = serde_json::from_str(text).unwrap();
+            assert_eq!(parsed["format"].as_str().unwrap(), "csv");
+            assert_eq!(parsed["data_type"].as_str().unwrap(), "tasks");
+            assert!(parsed["bytes_written"].as_u64().unwrap() > 0);
+
+            // Verify the file content is CSV (not JSON)
+            let file_content = std::fs::read_to_string(&path).unwrap();
+            assert!(
+                file_content.contains("Type,Title,Status"),
+                "expected CSV header in file, got: {file_content}"
+            );
         }
     }
 }

--- a/apps/things3-cli/tests/mcp_tests_legacy.rs
+++ b/apps/things3-cli/tests/mcp_tests_legacy.rs
@@ -635,12 +635,6 @@ async fn test_export_data_csv_projects() {
     assert!(!result.is_error);
     match &result.content[0] {
         Content::Text { text } => {
-            // DataExporter emits a "\n\nProjects\n" section label before the header row.
-            // These assertions document the current format so any change is visible.
-            assert!(
-                text.contains("\n\nProjects\n"),
-                "expected Projects section label, got: {text}"
-            );
             assert!(
                 text.contains("Title,Status,Notes,Start Date,Deadline,Created,Modified,Area"),
                 "expected full project CSV header, got: {text}"
@@ -665,11 +659,6 @@ async fn test_export_data_csv_areas() {
     assert!(!result.is_error);
     match &result.content[0] {
         Content::Text { text } => {
-            // DataExporter emits a "\n\nAreas\n" section label before the header row.
-            assert!(
-                text.contains("\n\nAreas\n"),
-                "expected Areas section label, got: {text}"
-            );
             assert!(
                 text.contains("Title,Notes,Created,Modified"),
                 "expected full area CSV header, got: {text}"

--- a/libs/things3-core/src/export.rs
+++ b/libs/things3-core/src/export.rs
@@ -180,7 +180,6 @@ impl DataExporter {
 
         // Export projects
         if !data.projects.is_empty() {
-            csv.push_str("\n\nProjects\n");
             csv.push_str("Title,Status,Notes,Start Date,Deadline,Created,Modified,Area\n");
             for project in &data.projects {
                 writeln!(
@@ -205,7 +204,6 @@ impl DataExporter {
 
         // Export areas
         if !data.areas.is_empty() {
-            csv.push_str("\n\nAreas\n");
             csv.push_str("Title,Notes,Created,Modified\n");
             for area in &data.areas {
                 writeln!(
@@ -876,9 +874,9 @@ mod tests {
             "Type,Title,Status,Notes,Start Date,Deadline,Created,Modified,Project,Area,Parent"
         ));
         assert!(csv.contains("Research competitors"));
-        assert!(csv.contains("Projects"));
+        assert!(csv.contains("Title,Status,Notes,Start Date,Deadline,Created,Modified,Area"));
         assert!(csv.contains("Website Redesign"));
-        assert!(csv.contains("Areas"));
+        assert!(csv.contains("Title,Notes,Created,Modified"));
         assert!(csv.contains("Work"));
     }
 


### PR DESCRIPTION
## Summary

- **`output_path` parameter** — added to schema. When provided, writes the export to disk and returns a compact confirmation JSON (`path`, `format`, `data_type`, `bytes_written`, `counts`). Supports `~/` expansion. Inline return is unchanged when absent.
- **CSV format** — was a stub. Now delegates to `DataExporter::export_csv`. `data_type=all` rejected with a clear error naming the three valid alternatives.
- **Markdown format** — was a stub. Now delegates to `DataExporter::export_markdown`. All four `data_type` values including `all` are supported.
- **RFC 4180 fix (#176)** — `DataExporter::export_csv` previously emitted non-standard section labels (`"\n\nProjects\n"`, `"\n\nAreas\n"`) before each entity's column header. Removed both labels; output is now standard header + data rows.

JSON format and existing `data_type=all` JSON shape are unchanged (backward-compatible).

## Changes

- `apps/things3-cli/src/mcp.rs` — imports, schema, handler rewrite, `expand_tilde` helper
- `libs/things3-core/src/export.rs` — remove section labels; update `test_export_csv_with_data`
- `apps/things3-cli/tests/mcp_tests_legacy.rs` — 8 new tests; update CSV project/area assertions

## Test plan

- [x] `test_export_data_csv_tasks` — CSV header + inbox task row present
- [x] `test_export_data_csv_projects` — clean RFC 4180 header + project row (no section label)
- [x] `test_export_data_csv_areas` — clean RFC 4180 header + area row (no section label)
- [x] `test_export_data_csv_all_rejected` — `csv+all` returns `InvalidParameter` naming valid alternatives
- [x] `test_export_data_markdown_tasks` — starts with `# Things 3 Export`, has `## Tasks`
- [x] `test_export_data_markdown_all` — has Areas, Projects, Tasks sections
- [x] `test_export_data_output_path_writes_file` — writes file, returns confirmation with `path`/`bytes_written`/`counts`
- [x] `test_export_data_output_path_csv` — writes CSV to file, file content is valid CSV

```bash
cargo test -p things3-core --lib --features export-csv
cargo test -p things3-cli --test mcp_tests_legacy export_data --features mcp-server
cargo clippy -p things3-cli --features mcp-server -- -D warnings
```

Closes #164, #176

🤖 Generated with [Claude Code](https://claude.ai/claude-code)