### PR TITLE
docs: update docs to reflect AppleScriptBackend as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A high-performance Rust library and CLI for Things 3 integration with integrated
 - 🚀 **High Performance**: Built with Rust for maximum speed and reliability
 - 🔧 **CLI Tool**: Command-line interface for managing Things 3 data
 - 🤖 **MCP Integration**: Integrated MCP server for AI/LLM integration
-- 📊 **Comprehensive API**: Full access to Things 3 database with async SQLx
+- 📊 **Safe Integration**: Reads via async SQLx, mutations via AppleScript (per [CulturedCode guidelines](https://culturedcode.com/things/support/articles/5510170/))
 - 🏗️ **Moon Workspace**: Organized monorepo with Moon build system
 - 🧪 **Well Tested**: Comprehensive test suite and benchmarks
 - 📈 **Performance Monitoring**: Built-in metrics and system monitoring
@@ -232,7 +232,7 @@ The dashboard provides:
 
 ## 🤖 MCP Integration
 
-The MCP (Model Context Protocol) server provides 46 tools for AI/LLM integration:
+The MCP (Model Context Protocol) server provides 46 tools for AI/LLM integration. Common tools:
 
 ### Available MCP Tools
 
@@ -245,16 +245,22 @@ The MCP (Model Context Protocol) server provides 46 tools for AI/LLM integration
 | `search_tasks` | Search for tasks by title or notes |
 | `create_task` | Create a new task |
 | `update_task` | Update an existing task |
+| `complete_task` | Mark a task as completed |
+| `delete_task` | Soft delete a task |
 | `get_productivity_metrics` | Get productivity metrics |
 | `export_data` | Export data in various formats |
 | `bulk_create_tasks` | Create multiple tasks at once |
+| `bulk_complete` | Complete multiple tasks at once |
+| `bulk_move` | Move multiple tasks to a project or area |
 | `get_recent_tasks` | Get recently modified tasks |
 | `backup_database` | Create a database backup |
-| `restore_database` | Restore from a backup |
+| `restore_database` | Restore from a backup (**requires `--unsafe-direct-db`**) |
 | `list_backups` | List available backups |
 | `get_performance_stats` | Get performance statistics |
 | `get_system_metrics` | Get system resource metrics |
 | `get_cache_stats` | Get cache performance stats |
+
+See [`skills/things3/references/TOOLS.md`](skills/things3/references/TOOLS.md) for the full 46-tool catalog.
 
 ### Configuration
 
@@ -729,10 +735,11 @@ export THINGS_DB_PATH="/path/to/main.sqlite"
 
 ### Permission Issues
 
-Ensure Things 3 is closed when running the CLI:
-```bash
-killall Things3
-```
+**Things 3 must be running** when using mutation operations (create, update, complete, delete). The default `AppleScriptBackend` drives Things 3 via `osascript` — it requires the app to be open.
+
+On first run, macOS will prompt: *"rust-things3 wants to control Things3."* Grant access via System Settings → Privacy & Security → Automation.
+
+For read-only operations (inbox, today, search, etc.) Things 3 does not need to be running.
 
 ### Stale Binary After Upgrade
 

--- a/docs/API_STABILITY.md
+++ b/docs/API_STABILITY.md
@@ -49,7 +49,7 @@ impl ThingsDatabase {
     pub async fn get_logbook(&self, limit: Option<usize>) -> Result<Vec<Task>>;
     pub async fn get_trash(&self, limit: Option<usize>) -> Result<Vec<Task>>;
     
-    pub async fn get_projects(&self, area_uuid: Option<Uuid>, limit: Option<usize>) -> Result<Vec<Project>>;
+    pub async fn get_projects(&self, area_uuid: Option<ThingsId>, limit: Option<usize>) -> Result<Vec<Project>>;
     pub async fn get_areas(&self, limit: Option<usize>) -> Result<Vec<Area>>;
     pub async fn get_tags(&self) -> Result<Vec<Tag>>;
     
@@ -60,14 +60,14 @@ impl ThingsDatabase {
     pub async fn search_tags(&self, query: &str) -> Result<Vec<Tag>>;
     
     // Lookup methods
-    pub async fn get_task_by_uuid(&self, uuid: Uuid) -> Result<Option<Task>>;
-    pub async fn get_project_by_uuid(&self, uuid: Uuid) -> Result<Option<Project>>;
-    pub async fn get_area_by_uuid(&self, uuid: Uuid) -> Result<Option<Area>>;
+    pub async fn get_task_by_uuid(&self, id: &ThingsId) -> Result<Option<Task>>;
+    pub async fn get_project_by_uuid(&self, id: &ThingsId) -> Result<Option<Project>>;
+    pub async fn get_area_by_uuid(&self, id: &ThingsId) -> Result<Option<Area>>;
     pub async fn get_tag_by_title(&self, title: &str) -> Result<Option<Tag>>;
     
     // Relationship methods
-    pub async fn get_project_tasks(&self, project_uuid: Uuid) -> Result<Vec<Task>>;
-    pub async fn get_area_projects(&self, area_uuid: Uuid) -> Result<Vec<Project>>;
+    pub async fn get_project_tasks(&self, project_id: &ThingsId) -> Result<Vec<Task>>;
+    pub async fn get_area_projects(&self, area_id: &ThingsId) -> Result<Vec<Project>>;
     pub async fn get_tasks_by_tag(&self, tag_title: &str) -> Result<Vec<Task>>;
     
     // Statistics
@@ -85,7 +85,7 @@ impl ThingsDatabase {
 ```rust
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Task {
-    pub uuid: Uuid,
+    pub uuid: ThingsId,
     pub title: String,
     pub notes: Option<String>,
     pub status: TaskStatus,
@@ -96,15 +96,15 @@ pub struct Task {
     pub deadline: Option<NaiveDate>,
     pub stop_date: Option<NaiveDate>,
     pub completion_date: Option<NaiveDate>,
-    pub project_uuid: Option<Uuid>,
-    pub area_uuid: Option<Uuid>,
+    pub project_uuid: Option<ThingsId>,
+    pub area_uuid: Option<ThingsId>,
     pub tags: Vec<String>,
     pub checklist_items: Vec<ChecklistItem>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Project {
-    pub uuid: Uuid,
+    pub uuid: ThingsId,
     pub title: String,
     pub notes: Option<String>,
     pub status: TaskStatus,
@@ -114,14 +114,14 @@ pub struct Project {
     pub deadline: Option<NaiveDate>,
     pub stop_date: Option<NaiveDate>,
     pub completion_date: Option<NaiveDate>,
-    pub area_uuid: Option<Uuid>,
+    pub area_uuid: Option<ThingsId>,
     pub tags: Vec<String>,
     pub tasks: Vec<Task>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Area {
-    pub uuid: Uuid,
+    pub uuid: ThingsId,
     pub title: String,
     pub visible: bool,
     pub projects: Vec<Project>,
@@ -130,10 +130,10 @@ pub struct Area {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Tag {
-    pub uuid: Uuid,
+    pub uuid: ThingsId,
     pub title: String,
     pub shortcut: Option<String>,
-    pub parent_uuid: Option<Uuid>,
+    pub parent_uuid: Option<ThingsId>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -427,7 +427,7 @@ Potential changes being considered for 2.0:
 - More granular error types
 - Builder pattern for configuration
 - Trait-based database interface
-- Enhanced type safety with newtypes
+- ~~Enhanced type safety with newtypes~~ — **Done in 1.x**: `ThingsId` newtype replaces `Uuid` throughout
 
 See [POST_1.0_ROADMAP.md](POST_1.0_ROADMAP.md) for details.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -199,10 +199,9 @@ sequenceDiagram
     participant AI as AI Agent
     participant MCP as MCP Server
     participant Handler as Tool Handler
-    participant DB as ThingsDatabase
-    participant Validator as Validation Layer
-    participant SQLx as SQLx Pool
-    participant SQLite
+    participant AS as AppleScriptBackend
+    participant osascript
+    participant Things3 as Things 3 App
     
     Note over AI,Things3: Task Completion Flow (AppleScriptBackend default)
     AI->>MCP: complete_task(uuid)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -167,46 +167,30 @@ sequenceDiagram
 
 ### Database Write Flow (Create/Update Operations)
 
+Mutations use `AppleScriptBackend` by default on macOS — Things 3 must be running. Direct SQLite writes are available only with `--unsafe-direct-db` (deprecated).
+
 ```mermaid
 sequenceDiagram
     participant MCP as MCP Client
     participant Handler as Tool Handler
-    participant DB as ThingsDatabase
-    participant Validator as Validation Layer
-    participant SQLx as SQLx Pool
-    participant SQLite
+    participant Backend as MutationBackend
+    participant AS as AppleScriptBackend
+    participant osascript
+    participant Things3 as Things 3 App
     
     MCP->>Handler: create_task(request)
-    Handler->>DB: create_task(CreateTaskRequest)
-    DB->>DB: Generate UUID v4
-    
-    alt Project UUID provided
-        DB->>Validator: validate_project_exists()
-        Validator->>SQLx: SELECT 1 FROM TMTask WHERE uuid=? AND type=1
-        SQLx->>SQLite: Query
-        SQLite-->>SQLx: Result
-        SQLx-->>Validator: Exists/Not Found
-        Validator-->>DB: Validation result
-    end
-    
-    alt Area UUID provided
-        DB->>Validator: validate_area_exists()
-        Validator->>SQLx: SELECT 1 FROM TMArea WHERE uuid=?
-        SQLx->>SQLite: Query
-        SQLite-->>SQLx: Result
-        SQLx-->>Validator: Exists/Not Found
-        Validator-->>DB: Validation result
-    end
-    
-    DB->>DB: Convert dates to Things 3 format
-    DB->>DB: Serialize tags to BLOB
-    DB->>SQLx: INSERT INTO TMTask
-    SQLx->>SQLite: Execute INSERT
-    SQLite-->>SQLx: Success
-    SQLx-->>DB: Rows affected
-    DB-->>Handler: Created UUID
+    Handler->>Backend: create_task(CreateTaskRequest)
+    Backend->>AS: build_script(request)
+    AS->>osascript: execute AppleScript
+    osascript->>Things3: tell application "Things3"
+    Things3-->>osascript: created ThingsId
+    osascript-->>AS: output string
+    AS-->>Backend: ThingsId
+    Backend-->>Handler: ThingsId
     Handler-->>MCP: Success response
 ```
+
+> **`--unsafe-direct-db` path** (deprecated): bypasses AppleScript and writes directly to the SQLite file via SQLx. Risks data loss — see [CulturedCode's safety article](https://culturedcode.com/things/support/articles/5510170/).
 
 ### Task Lifecycle Flow (Complete/Delete Operations)
 
@@ -220,57 +204,27 @@ sequenceDiagram
     participant SQLx as SQLx Pool
     participant SQLite
     
-    Note over AI,SQLite: Task Completion Flow
+    Note over AI,Things3: Task Completion Flow (AppleScriptBackend default)
     AI->>MCP: complete_task(uuid)
     MCP->>Handler: handle_complete_task()
-    Handler->>DB: complete_task(uuid)
-    DB->>Validator: validate_task_exists()
-    Validator->>SQLite: SELECT 1 FROM TMTask WHERE uuid=?
-    SQLite-->>Validator: Task exists
-    Validator-->>DB: Validation OK
-    DB->>DB: Get current timestamp
-    DB->>SQLx: UPDATE TMTask SET status=1, stopDate=?, userModificationDate=?
-    SQLx->>SQLite: Execute UPDATE
-    SQLite-->>SQLx: Success
-    SQLx-->>DB: Rows affected
-    DB-->>Handler: Success
+    Handler->>AS: complete_task(id)
+    AS->>osascript: set status of to do id ? to completed
+    osascript->>Things3: AppleScript command
+    Things3-->>osascript: OK
+    osascript-->>AS: success
+    AS-->>Handler: Success
     Handler-->>MCP: Success response
     MCP-->>AI: Task completed
     
-    Note over AI,SQLite: Task Deletion Flow (with Children)
+    Note over AI,Things3: Task Deletion Flow
     AI->>MCP: delete_task(uuid, child_handling)
     MCP->>Handler: handle_delete_task()
-    Handler->>DB: delete_task(uuid, DeleteChildHandling)
-    DB->>Validator: validate_task_exists()
-    Validator-->>DB: Task exists
-    DB->>SQLx: SELECT uuid FROM TMTask WHERE heading=?
-    SQLx->>SQLite: Query children
-    SQLite-->>SQLx: Child rows
-    SQLx-->>DB: Children found
-    
-    alt child_handling = Error
-        DB-->>Handler: Error: Task has children
-        Handler-->>MCP: Error response
-    else child_handling = Cascade
-        loop For each child
-            DB->>SQLx: UPDATE TMTask SET trashed=1 WHERE uuid=?
-            SQLx->>SQLite: Mark child as trashed
-        end
-        DB->>SQLx: UPDATE TMTask SET trashed=1 WHERE uuid=?
-        SQLx->>SQLite: Mark parent as trashed
-        SQLite-->>DB: Success
-        DB-->>Handler: Success
-    else child_handling = Orphan
-        loop For each child
-            DB->>SQLx: UPDATE TMTask SET heading=NULL WHERE uuid=?
-            SQLx->>SQLite: Clear parent reference
-        end
-        DB->>SQLx: UPDATE TMTask SET trashed=1 WHERE uuid=?
-        SQLx->>SQLite: Mark parent as trashed
-        SQLite-->>DB: Success
-        DB-->>Handler: Success
-    end
-    
+    Handler->>AS: delete_task(id, DeleteChildHandling)
+    AS->>osascript: delete to do id ?
+    osascript->>Things3: AppleScript command
+    Things3-->>osascript: OK
+    osascript-->>AS: success
+    AS-->>Handler: Success
     Handler-->>MCP: Success/Error response
     MCP-->>AI: Task deleted or error
 ```
@@ -343,7 +297,7 @@ stateDiagram-v2
 - JSON-RPC protocol handling
 - Middleware system (logging, validation, auth, rate limiting)
 - I/O abstraction (stdin/stdout, testable)
-- Tool implementations (17 MCP tools)
+- Tool implementations (46 MCP tools)
 
 **Key Types**:
 - `Cli`: CLI argument parser
@@ -544,8 +498,8 @@ pub type Result<T> = std::result::Result<T, ThingsError>;
 ## Performance Considerations
 
 ### Database Access
-- **Connection Pooling**: SQLx pool (min: 1, max: 10)
-- **Read-Only**: Things 3 DB is never modified
+- **Connection Pooling**: SQLx pool (min: 1, max: 10), read-only mode
+- **Mutation Backend**: `AppleScriptBackend` (default, macOS) drives Things 3 via `osascript`; `SqlxBackend` available via `--unsafe-direct-db`
 - **Prepared Statements**: Cached for reuse
 - **Async Queries**: Non-blocking I/O
 
@@ -564,7 +518,8 @@ pub type Result<T> = std::result::Result<T, ThingsError>;
 ## Security Considerations
 
 ### Database Access
-- **Read-Only**: No write operations
+- **SQLx Read-Only**: SQLite connection opened in read-only mode; no direct writes
+- **AppleScript Mutations**: All writes go through `osascript` → Things 3 app by default
 - **Path Validation**: Prevent directory traversal
 - **Permission Checks**: Verify file access
 

--- a/docs/DATABASE_SCHEMA.md
+++ b/docs/DATABASE_SCHEMA.md
@@ -304,7 +304,7 @@ SQLite uses INTEGER for booleans:
 
 ## Write Operations
 
-> **Note**: `rust-things3` does not execute these SQL patterns directly by default. They document the internal format that `AppleScriptBackend` produces indirectly via Things 3. The `--unsafe-direct-db` flag enables direct SQLite writes (deprecated).
+> **Note**: `rust-things3` does not execute these SQL patterns directly by default. These SQL patterns document the internal format that `AppleScriptBackend` produces indirectly via Things 3. The `--unsafe-direct-db` flag enables direct SQLite writes (deprecated).
 
 ### Task Creation
 

--- a/docs/DATABASE_SCHEMA.md
+++ b/docs/DATABASE_SCHEMA.md
@@ -10,7 +10,9 @@
 
 ## Overview
 
-Things 3 uses SQLite as its database engine. The database is read-only for external tools to prevent corruption. This document describes the schema structure and how `rust-things3` interacts with it.
+Things 3 uses SQLite as its database engine. This document describes the schema structure and how `rust-things3` interacts with it.
+
+**Access model**: `rust-things3` opens the SQLite file in **read-only mode** for all queries. Mutations (create, update, complete, delete) go through `AppleScriptBackend` — driving Things 3 via `osascript` — rather than writing to the database file directly. Direct SQLite writes are available only via `--unsafe-direct-db` and are deprecated. See [CulturedCode's safety article](https://culturedcode.com/things/support/articles/5510170/).
 
 ### Database Files
 
@@ -301,6 +303,8 @@ SQLite uses INTEGER for booleans:
 **experimental**: Experimental features data
 
 ## Write Operations
+
+> **Note**: `rust-things3` does not execute these SQL patterns directly by default. They document the internal format that `AppleScriptBackend` produces indirectly via Things 3. The `--unsafe-direct-db` flag enables direct SQLite writes (deprecated).
 
 ### Task Creation
 

--- a/docs/MCP_INTEGRATION.md
+++ b/docs/MCP_INTEGRATION.md
@@ -747,6 +747,8 @@ Create a database backup.
 #### `restore_database`
 Restore from a backup.
 
+> ⚠️ **Requires `--unsafe-direct-db`**: This tool writes directly to the Things 3 SQLite file and is gated behind the `--unsafe-direct-db` flag (or `THINGS_UNSAFE_DIRECT_DB=1`). Without the flag the tool returns an error. See [CulturedCode's safety article](https://culturedcode.com/things/support/articles/5510170/).
+
 **Parameters**:
 - `backup_path` (required): Path to backup file
 

--- a/docs/MCP_INTEGRATION.md
+++ b/docs/MCP_INTEGRATION.md
@@ -749,6 +749,16 @@ Restore from a backup.
 
 > ⚠️ **Requires `--unsafe-direct-db`**: This tool writes directly to the Things 3 SQLite file and is gated behind the `--unsafe-direct-db` flag (or `THINGS_UNSAFE_DIRECT_DB=1`). Without the flag the tool returns an error. See [CulturedCode's safety article](https://culturedcode.com/things/support/articles/5510170/).
 
+**Error when flag is absent**:
+```json
+{
+  "error": {
+    "code": -32600,
+    "message": "restore_database requires --unsafe-direct-db (set THINGS_UNSAFE_DIRECT_DB=1 or pass --unsafe-direct-db)"
+  }
+}
+```
+
 **Parameters**:
 - `backup_path` (required): Path to backup file
 

--- a/docs/POST_1.0_ROADMAP.md
+++ b/docs/POST_1.0_ROADMAP.md
@@ -251,29 +251,20 @@ pub struct SqliteThingsDatabase { /* ... */ }
 ---
 
 **4. Improved Type Safety**
-```rust
-// Current (1.x)
-pub fn get_task(&self, uuid: &str) -> Result<Option<Task>>;
 
-// Proposed (2.0)
-pub fn get_task(&self, id: TaskId) -> Result<Task>;
+~~Proposed for 2.0~~ — **Done in 1.x**: `ThingsId` newtype (a 21–22-char base62 string matching Things 3's native ID format) replaced `Uuid` throughout the public API in v1.x. Separate `ProjectId`, `AreaId`, etc. newtypes could still be considered for 2.0.
 
-pub struct TaskId(Uuid);
-pub struct ProjectId(Uuid);
-```
-
-**Benefit**: Compile-time prevention of mixing IDs, clearer intent
+**Benefit**: Compile-time prevention of mixing IDs, correct round-trip with Things 3 IDs
 
 ---
 
 #### New Features (2.0)
 
-- [ ] **Write Support** (Experimental, opt-in)
-  - Create tasks (with safety guarantees)
-  - Update task properties
-  - Complete tasks
-  - Move tasks between projects/areas
-  - **Note**: Read-only remains default, write requires explicit opt-in
+- [x] **Write Support** — **Shipped in 1.x** via `AppleScriptBackend`
+  - Create, update, complete, delete tasks
+  - Full project/area/tag CRUD
+  - Bulk operations (complete, move, delete, update dates)
+  - AppleScript is the default; direct DB writes opt-in via `--unsafe-direct-db`
 
 - [ ] **Alternative Backends**
   - PostgreSQL support (for server deployments)

--- a/docs/POST_1.0_ROADMAP.md
+++ b/docs/POST_1.0_ROADMAP.md
@@ -254,6 +254,12 @@ pub struct SqliteThingsDatabase { /* ... */ }
 
 ~~Proposed for 2.0~~ — **Done in 1.x**: `ThingsId` newtype (a 21–22-char base62 string matching Things 3's native ID format) replaced `Uuid` throughout the public API in v1.x. Separate `ProjectId`, `AreaId`, etc. newtypes could still be considered for 2.0.
 
+```rust
+// ThingsId is the ID type throughout the public API
+let id: ThingsId = task.uuid.clone();
+let task = db.get_task_by_uuid(&id).await?;
+```
+
 **Benefit**: Compile-time prevention of mixing IDs, correct round-trip with Things 3 IDs
 
 ---

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -115,8 +115,7 @@ let areas = db.get_areas().await?;
 ### Bulk Operations
 
 ```rust
-use things3_core::{BulkCompleteRequest, BulkMoveRequest};
-use uuid::Uuid;
+use things3_core::{BulkCompleteRequest, BulkMoveRequest, ThingsId};
 
 // Complete multiple tasks
 let complete = BulkCompleteRequest {

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -119,14 +119,14 @@ use things3_core::{BulkCompleteRequest, BulkMoveRequest, ThingsId};
 
 // Complete multiple tasks
 let complete = BulkCompleteRequest {
-    task_uuids: vec![uuid1, uuid2, uuid3],
+    task_uuids: vec![id1, id2, id3],
 };
 let result = db.bulk_complete(complete).await?;
 
 // Move tasks to a project
 let move_req = BulkMoveRequest {
-    task_uuids: vec![uuid1, uuid2],
-    project_uuid: Some(project_uuid),
+    task_uuids: vec![id1, id2],
+    project_uuid: Some(project_id),
     area_uuid: None,
 };
 let result = db.bulk_move(move_req).await?;


### PR DESCRIPTION
## Summary

- **Critical fix**: README troubleshooting said "close Things 3" — this is now backwards; `AppleScriptBackend` *requires* Things 3 to be running. Replaced with correct guidance including the Automation permission prompt note.
- **`Uuid` → `ThingsId`**: Updated all method signatures and struct fields in `API_STABILITY.md` to reflect the PR #141 migration.
- **Write flow diagrams**: `ARCHITECTURE.md` write/lifecycle sequence diagrams now show the AppleScript → osascript → Things 3 path instead of the old direct-SQLx path.
- **`restore_database` gating**: Added `⚠️` warning in `MCP_INTEGRATION.md` that this tool requires `--unsafe-direct-db`.
- **Roadmap cleanup**: Marked "Write Support" and "Improved Type Safety / newtypes" as shipped in `POST_1.0_ROADMAP.md`.
- **Minor**: Tool count 17→46 in `ARCHITECTURE.md`; `DATABASE_SCHEMA.md` access-model clarification; `QUICKSTART.md` import fix.

## Test plan

- [ ] Review README troubleshooting section reads correctly for the AppleScript default
- [ ] Verify `ThingsId` usage in `API_STABILITY.md` matches actual public API
- [ ] Confirm `restore_database` warning matches runtime behaviour under `--unsafe-direct-db`

🤖 Generated with [Claude Code](https://claude.com/claude-code)