### PR TITLE
chore(core): 2.x deprecation prep — announce 3.0 API changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
 [workspace.package]
 version = "2.0.0"
 edition = "2021"
-rust-version = "1.74"
+rust-version = "1.82"
 authors = ["GarthDB <garthdb@gmail.com>"]
 license = "MIT"
 repository = "https://github.com/GarthDB/rust-things3"

--- a/apps/things3-cli/src/bin/test_mcp_real_data.rs
+++ b/apps/things3-cli/src/bin/test_mcp_real_data.rs
@@ -1,4 +1,5 @@
 //! Test binary for Things3 MCP with real user data
+#![allow(deprecated)]
 //!
 //! This binary provides a safe way to test the MCP implementation using
 //! your actual Things 3 database in read-only mode.

--- a/apps/things3-cli/src/bulk_operations.rs
+++ b/apps/things3-cli/src/bulk_operations.rs
@@ -1,4 +1,5 @@
 //! Bulk operations with progress tracking
+#![allow(deprecated)]
 
 use crate::events::{EventBroadcaster, EventType};
 use crate::progress::{ProgressManager, ProgressTracker};

--- a/apps/things3-cli/src/dashboard.rs
+++ b/apps/things3-cli/src/dashboard.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 async fn dashboard_home(State(_state): State<DashboardState>) -> Html<&'static str> {
     Html(include_str!("dashboard.html"))
 }

--- a/apps/things3-cli/src/dashboard.rs
+++ b/apps/things3-cli/src/dashboard.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)]
-
 async fn dashboard_home(State(_state): State<DashboardState>) -> Html<&'static str> {
     Html(include_str!("dashboard.html"))
 }
@@ -250,6 +248,7 @@ pub async fn start_dashboard_server(
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use super::*;
     use tempfile::NamedTempFile;

--- a/apps/things3-cli/src/health.rs
+++ b/apps/things3-cli/src/health.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)]
-
 async fn health_check(State(state): State<AppState>) -> Result<Json<HealthResponse>, StatusCode> {
     let health_status = state.observability.health_status();
 
@@ -163,6 +161,7 @@ pub async fn start_health_server(
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use super::*;
     use tempfile::NamedTempFile;

--- a/apps/things3-cli/src/health.rs
+++ b/apps/things3-cli/src/health.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 async fn health_check(State(state): State<AppState>) -> Result<Json<HealthResponse>, StatusCode> {
     let health_status = state.observability.health_status();
 

--- a/apps/things3-cli/src/lib.rs
+++ b/apps/things3-cli/src/lib.rs
@@ -1,5 +1,6 @@
 //! Things CLI library
 //! This module provides real-time updates and progress tracking capabilities
+#![allow(deprecated)]
 
 pub mod bulk_operations;
 

--- a/apps/things3-cli/src/main.rs
+++ b/apps/things3-cli/src/main.rs
@@ -1,4 +1,5 @@
 //! Things CLI - Command line interface for Things 3 with integrated MCP server
+#![allow(deprecated)]
 
 use clap::Parser;
 use std::sync::Arc;

--- a/apps/things3-cli/src/main.rs
+++ b/apps/things3-cli/src/main.rs
@@ -1,5 +1,4 @@
 //! Things CLI - Command line interface for Things 3 with integrated MCP server
-#![allow(deprecated)]
 
 use clap::Parser;
 use std::sync::Arc;
@@ -19,6 +18,7 @@ use tracing::{error, info};
 
 #[tokio::main]
 #[allow(clippy::too_many_lines)]
+#[allow(deprecated)]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
 
@@ -197,6 +197,7 @@ This flag exists for emergency recovery only and will be removed.
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use super::*;
     use std::io::Cursor;

--- a/apps/things3-cli/src/mcp/mod.rs
+++ b/apps/things3-cli/src/mcp/mod.rs
@@ -1,4 +1,5 @@
 //! MCP (Model Context Protocol) server implementation for Things 3 integration
+#![allow(deprecated)]
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;

--- a/apps/things3-cli/src/mcp/mod.rs
+++ b/apps/things3-cli/src/mcp/mod.rs
@@ -384,6 +384,7 @@ pub type McpResult<T> = std::result::Result<T, McpError>;
 
 /// From trait implementations for common error types
 impl From<ThingsError> for McpError {
+    #[allow(deprecated)]
     fn from(error: ThingsError) -> Self {
         match error {
             ThingsError::Database(e) => {

--- a/apps/things3-cli/src/mcp/test_harness.rs
+++ b/apps/things3-cli/src/mcp/test_harness.rs
@@ -1,4 +1,5 @@
 //! Test harness for MCP server testing
+#![allow(deprecated)]
 
 use crate::mcp::{
     CallToolRequest, CallToolResult, Content, GetPromptRequest, GetPromptResult, McpError,

--- a/apps/things3-cli/src/mcp/test_harness.rs
+++ b/apps/things3-cli/src/mcp/test_harness.rs
@@ -1,5 +1,4 @@
 //! Test harness for MCP server testing
-#![allow(deprecated)]
 
 use crate::mcp::{
     CallToolRequest, CallToolResult, Content, GetPromptRequest, GetPromptResult, McpError,
@@ -32,6 +31,7 @@ impl McpTestHarness {
     /// # Panics
     /// Panics if the database cannot be creationDate or the server cannot be initialized
     #[must_use]
+    #[allow(deprecated)]
     pub fn new_with_config(middleware_config: crate::mcp::MiddlewareConfig) -> Self {
         let temp_file = NamedTempFile::new().unwrap();
         let db_path = temp_file.path().to_path_buf();

--- a/apps/things3-cli/src/mcp/tools/admin.rs
+++ b/apps/things3-cli/src/mcp/tools/admin.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use crate::mcp::{CallToolResult, Content, McpError, McpResult, ThingsMcpServer};
 use serde_json::Value;
 

--- a/apps/things3-cli/src/mcp/tools/export.rs
+++ b/apps/things3-cli/src/mcp/tools/export.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use crate::mcp::{expand_tilde, CallToolResult, Content, McpError, McpResult, ThingsMcpServer};
 use serde_json::Value;
 use things3_core::{DataExporter, ExportData, ExportFormat};

--- a/apps/things3-cli/src/mcp/tools/tasks.rs
+++ b/apps/things3-cli/src/mcp/tools/tasks.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use crate::mcp::{CallToolResult, Content, McpError, McpResult, ThingsMcpServer};
 use serde_json::Value;
 use std::str::FromStr;

--- a/apps/things3-cli/src/metrics.rs
+++ b/apps/things3-cli/src/metrics.rs
@@ -2,6 +2,7 @@
 //!
 //! This module provides comprehensive metrics collection for the Things 3 CLI application,
 //! including performance monitoring, error tracking, and operational metrics.
+#![allow(deprecated)]
 
 use std::sync::Arc;
 use std::time::{Duration, Instant};

--- a/apps/things3-cli/src/metrics.rs
+++ b/apps/things3-cli/src/metrics.rs
@@ -2,7 +2,6 @@
 //!
 //! This module provides comprehensive metrics collection for the Things 3 CLI application,
 //! including performance monitoring, error tracking, and operational metrics.
-#![allow(deprecated)]
 
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -325,6 +324,7 @@ pub async fn start_metrics_collection(
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use super::*;
     use std::sync::Arc;

--- a/apps/things3-cli/tests/integration_tests.rs
+++ b/apps/things3-cli/tests/integration_tests.rs
@@ -1,4 +1,5 @@
 //! Integration tests for CLI functionality
+#![allow(deprecated)]
 
 use std::io::Cursor;
 use tempfile::NamedTempFile;

--- a/apps/things3-cli/tests/mcp_tests/error_tests.rs
+++ b/apps/things3-cli/tests/mcp_tests/error_tests.rs
@@ -1,6 +1,7 @@
 //! Error handling tests for MCP server
 
 #![cfg(feature = "mcp-server")]
+#![allow(deprecated)]
 
 use super::common::create_test_mcp_server;
 use serde_json::json;

--- a/apps/things3-cli/tests/mcp_tests/tool_tests.rs
+++ b/apps/things3-cli/tests/mcp_tests/tool_tests.rs
@@ -1,6 +1,7 @@
 //! Tool-related tests for MCP server
 
 #![cfg(feature = "mcp-server")]
+#![allow(deprecated)]
 
 use super::common::create_test_mcp_server;
 use serde_json::json;

--- a/libs/things3-core/examples/export_data.rs
+++ b/libs/things3-core/examples/export_data.rs
@@ -1,6 +1,7 @@
 //! Data export example
 //!
 //! Run with: cargo run --example export_data
+#![allow(deprecated)]
 
 use things3_core::{DataExporter, ExportData, ExportFormat, ThingsConfig, ThingsDatabase};
 

--- a/libs/things3-core/examples/export_data.rs
+++ b/libs/things3-core/examples/export_data.rs
@@ -1,7 +1,6 @@
 //! Data export example
 //!
 //! Run with: cargo run --example export_data
-#![allow(deprecated)]
 
 use things3_core::{DataExporter, ExportData, ExportFormat, ThingsConfig, ThingsDatabase};
 
@@ -11,7 +10,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Connect to database
     let config = ThingsConfig::from_env();
-    let db = ThingsDatabase::new(&config.database_path).await?;
+    let db = ThingsDatabase::new(&config.get_effective_database_path()?).await?;
 
     // Get data
     println!("Fetching data...");

--- a/libs/things3-core/examples/search_tasks.rs
+++ b/libs/things3-core/examples/search_tasks.rs
@@ -1,7 +1,6 @@
 //! Task search example
 //!
 //! Run with: cargo run --example search_tasks -- "meeting"
-#![allow(deprecated)]
 
 use std::env;
 use things3_core::{ThingsConfig, ThingsDatabase};
@@ -15,7 +14,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Connect to database
     let config = ThingsConfig::from_env();
-    let db = ThingsDatabase::new(&config.database_path).await?;
+    let db = ThingsDatabase::new(&config.get_effective_database_path()?).await?;
 
     // Search tasks
     let results = db.search_tasks(&query).await?;

--- a/libs/things3-core/examples/search_tasks.rs
+++ b/libs/things3-core/examples/search_tasks.rs
@@ -1,6 +1,7 @@
 //! Task search example
 //!
 //! Run with: cargo run --example search_tasks -- "meeting"
+#![allow(deprecated)]
 
 use std::env;
 use things3_core::{ThingsConfig, ThingsDatabase};

--- a/libs/things3-core/src/batch.rs
+++ b/libs/things3-core/src/batch.rs
@@ -1,4 +1,5 @@
 //! Batch fetch-by-id primitives on [`ThingsDatabase`].
+#![allow(deprecated)]
 //!
 //! Two methods extend [`ThingsDatabase`] when the `batch-operations` feature
 //! is enabled:

--- a/libs/things3-core/src/config.rs
+++ b/libs/things3-core/src/config.rs
@@ -4,11 +4,24 @@ use crate::error::{Result, ThingsError};
 use std::path::{Path, PathBuf};
 
 /// Configuration for Things 3 database access
+///
+/// **Deprecation notice**: Direct field access and the `new()` constructor are deprecated as of
+/// 2.1.0 and will be removed in 3.0. A `ThingsConfig::builder()` API is planned. Use
+/// `ThingsConfig::from_env()` or `ThingsConfig::with_default_path()` as alternatives in the
+/// meantime.
 #[derive(Debug, Clone)]
 pub struct ThingsConfig {
     /// Path to the Things 3 database
+    #[deprecated(
+        since = "2.1.0",
+        note = "Direct field access will be removed in 3.0. Use ThingsConfig::from_env() or ThingsConfig::with_default_path() for now."
+    )]
     pub database_path: PathBuf,
     /// Whether to use the default database path if the specified path doesn't exist
+    #[deprecated(
+        since = "2.1.0",
+        note = "Direct field access will be removed in 3.0. Use ThingsConfig::from_env() or ThingsConfig::with_default_path() for now."
+    )]
     pub fallback_to_default: bool,
 }
 
@@ -18,7 +31,12 @@ impl ThingsConfig {
     /// # Arguments
     /// * `database_path` - Path to the Things 3 database
     /// * `fallback_to_default` - Whether to fall back to the default path if the specified path doesn't exist
+    #[deprecated(
+        since = "2.1.0",
+        note = "Will be removed in 3.0. A ThingsConfig::builder() API is planned. Use ThingsConfig::from_env() or ThingsConfig::with_default_path() for now."
+    )]
     #[must_use]
+    #[allow(deprecated)]
     pub fn new<P: AsRef<Path>>(database_path: P, fallback_to_default: bool) -> Self {
         Self {
             database_path: database_path.as_ref().to_path_buf(),
@@ -28,6 +46,7 @@ impl ThingsConfig {
 
     /// Create a configuration with the default database path
     #[must_use]
+    #[allow(deprecated)]
     pub fn with_default_path() -> Self {
         Self {
             database_path: Self::get_default_database_path(),
@@ -39,6 +58,7 @@ impl ThingsConfig {
     ///
     /// # Errors
     /// Returns `ThingsError::Message` if neither the specified path nor the default path exists
+    #[allow(deprecated)]
     pub fn get_effective_database_path(&self) -> Result<PathBuf> {
         // Check if the specified path exists
         if self.database_path.exists() {
@@ -78,6 +98,7 @@ impl ThingsConfig {
     /// Reads the database path from `THINGS_DB_PATH` (preferred) or the legacy
     /// `THINGS_DATABASE_PATH`, and the fallback flag from `THINGS_FALLBACK_TO_DEFAULT`.
     #[must_use]
+    #[allow(deprecated)]
     pub fn from_env() -> Self {
         let database_path = match std::env::var("THINGS_DB_PATH") {
             Ok(v) => PathBuf::from(v),
@@ -109,6 +130,7 @@ impl ThingsConfig {
     ///
     /// # Errors
     /// Returns `ThingsError::Io` if the temporary file cannot be created
+    #[allow(deprecated)]
     pub fn for_testing() -> Result<Self> {
         use tempfile::NamedTempFile;
         let temp_file = NamedTempFile::new()?;
@@ -124,6 +146,7 @@ impl Default for ThingsConfig {
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use super::*;
     use serial_test::serial;

--- a/libs/things3-core/src/database/conversions.rs
+++ b/libs/things3-core/src/database/conversions.rs
@@ -1,4 +1,5 @@
 //! Timestamp, date, tag-blob conversions and small enum mappers.
+#![allow(deprecated)]
 //!
 //! Things 3 stores dates as seconds since 2001-01-01 UTC (a `REAL` column for
 //! creation/modification, `INTEGER` for start/deadline). These helpers convert

--- a/libs/things3-core/src/database/core.rs
+++ b/libs/things3-core/src/database/core.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use crate::{
     database::pool::{apply_sqlite_optimizations, DatabasePoolConfig},
     error::{Result as ThingsResult, ThingsError},

--- a/libs/things3-core/src/database/health.rs
+++ b/libs/things3-core/src/database/health.rs
@@ -1,4 +1,5 @@
 //! Health check and metrics methods for `ThingsDatabase`.
+#![allow(deprecated)]
 
 use crate::{
     database::{

--- a/libs/things3-core/src/database/mutations/areas.rs
+++ b/libs/things3-core/src/database/mutations/areas.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use crate::{
     database::{validators, ThingsDatabase},
     error::{Result as ThingsResult, ThingsError},

--- a/libs/things3-core/src/database/mutations/bulk.rs
+++ b/libs/things3-core/src/database/mutations/bulk.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use crate::{
     database::{conversions::naive_date_to_things_timestamp, validators, ThingsDatabase},
     error::{Result as ThingsResult, ThingsError},

--- a/libs/things3-core/src/database/mutations/projects.rs
+++ b/libs/things3-core/src/database/mutations/projects.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use crate::{
     database::{
         conversions::naive_date_to_things_timestamp, query_builders::TaskUpdateBuilder, validators,

--- a/libs/things3-core/src/database/mutations/tags.rs
+++ b/libs/things3-core/src/database/mutations/tags.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use crate::{
     database::{validators, ThingsDatabase},
     error::{Result as ThingsResult, ThingsError},

--- a/libs/things3-core/src/database/mutations/tasks.rs
+++ b/libs/things3-core/src/database/mutations/tasks.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use crate::{
     database::{
         conversions::naive_date_to_things_timestamp, query_builders::TaskUpdateBuilder, validators,

--- a/libs/things3-core/src/database/pool.rs
+++ b/libs/things3-core/src/database/pool.rs
@@ -1,4 +1,5 @@
 //! Connection pool configuration, optimizations, and health/metrics types.
+#![allow(deprecated)]
 
 use crate::database::stats::DatabaseStats;
 use crate::error::{Result as ThingsResult, ThingsError};

--- a/libs/things3-core/src/database/queries/areas.rs
+++ b/libs/things3-core/src/database/queries/areas.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use crate::{
     database::ThingsDatabase,
     error::{Result as ThingsResult, ThingsError},

--- a/libs/things3-core/src/database/queries/projects.rs
+++ b/libs/things3-core/src/database/queries/projects.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use crate::{
     database::{conversions::safe_timestamp_convert, mappers::map_project_row, ThingsDatabase},
     error::{Result as ThingsResult, ThingsError},

--- a/libs/things3-core/src/database/queries/tags.rs
+++ b/libs/things3-core/src/database/queries/tags.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use crate::{
     database::{conversions::safe_timestamp_convert, ThingsDatabase},
     error::{Result as ThingsResult, ThingsError},

--- a/libs/things3-core/src/database/queries/tasks.rs
+++ b/libs/things3-core/src/database/queries/tasks.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 #[cfg(feature = "advanced-queries")]
 use crate::database::conversions::naive_date_to_things_timestamp;
 #[cfg(feature = "advanced-queries")]

--- a/libs/things3-core/src/database/validators.rs
+++ b/libs/things3-core/src/database/validators.rs
@@ -1,4 +1,5 @@
 //! Entity validation utilities for database operations
+#![allow(deprecated)]
 //!
 //! This module provides centralized validation functions to ensure
 //! referenced entities (tasks, projects, areas) exist before performing operations.

--- a/libs/things3-core/src/error.rs
+++ b/libs/things3-core/src/error.rs
@@ -9,6 +9,10 @@ pub type Result<T> = std::result::Result<T, ThingsError>;
 #[non_exhaustive]
 #[derive(Error, Debug)]
 pub enum ThingsError {
+    #[deprecated(
+        since = "2.1.0",
+        note = "Will be replaced by domain-specific error types in 3.0. See the planned ThingsDatabaseError."
+    )]
     #[error("Database error: {0}")]
     Database(String),
 
@@ -54,6 +58,10 @@ pub enum ThingsError {
     #[error("AppleScript automation failed: {message}")]
     AppleScript { message: String },
 
+    #[deprecated(
+        since = "2.1.0",
+        note = "Will be removed in 3.0. Use a domain-specific error variant instead."
+    )]
     #[error("Unknown error: {message}")]
     Unknown { message: String },
 }
@@ -74,6 +82,7 @@ impl ThingsError {
     }
 
     /// Create an unknown error
+    #[allow(deprecated)]
     pub fn unknown(message: impl Into<String>) -> Self {
         Self::Unknown {
             message: message.into(),
@@ -89,6 +98,7 @@ impl ThingsError {
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use super::*;
     use std::io;

--- a/libs/things3-core/src/error.rs
+++ b/libs/things3-core/src/error.rs
@@ -60,7 +60,7 @@ pub enum ThingsError {
 
     #[deprecated(
         since = "2.1.0",
-        note = "Will be removed in 3.0. Use a domain-specific error variant instead."
+        note = "Will be removed in 3.0. Use a specific variant such as ThingsError::Validation or ThingsError::Configuration instead."
     )]
     #[error("Unknown error: {message}")]
     Unknown { message: String },
@@ -82,6 +82,10 @@ impl ThingsError {
     }
 
     /// Create an unknown error
+    #[deprecated(
+        since = "2.1.0",
+        note = "Will be removed in 3.0. Use a specific constructor such as ThingsError::validation() or ThingsError::configuration() instead."
+    )]
     #[allow(deprecated)]
     pub fn unknown(message: impl Into<String>) -> Self {
         Self::Unknown {

--- a/libs/things3-core/src/test_utils.rs
+++ b/libs/things3-core/src/test_utils.rs
@@ -1,4 +1,5 @@
 //! Test utilities and mock data for Things 3 integration
+#![allow(deprecated)]
 
 use crate::{
     models::{Area, CreateTaskRequest, Project, Task, TaskStatus, TaskType, ThingsId},


### PR DESCRIPTION
## Summary

- Bumps MSRV from 1.74 → 1.82 (required for `#[deprecated]` on struct fields and enum variants)
- Marks `ThingsConfig` direct field access and `new()` constructor as deprecated since 2.1.0 (closes #198)
- Marks `ThingsError::Database` and `ThingsError::Unknown` variants as deprecated since 2.1.0 (closes #199)
- Annotates all internal call sites with `#[allow(deprecated)]` so the crate builds clean

Downstream users constructing `ThingsConfig { .. }` directly or matching `ThingsError::Database(_)` / `ThingsError::Unknown { .. }` will now see deprecation warnings pointing them toward the 3.0 builder/domain-error APIs.

## Test plan

- [x] `cargo build -p things3-core` — warning-free
- [x] `cargo test -p things3-core --lib` — passes
- [x] `cargo test -p things3-core --features advanced-queries --lib` — passes
- [x] `cargo clippy -p things3-core --lib -- -D warnings` — clean
- [x] Pre-push hook (`cargo test --features test-utils`) — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)