### PR TITLE
feat(core): granular error types — ThingsDatabaseError, ThingsExportError, ThingsQueryError (3.0)

### DIFF
--- a/apps/things3-cli/src/mcp/mod.rs
+++ b/apps/things3-cli/src/mcp/mod.rs
@@ -404,9 +404,6 @@ impl From<ThingsError> for McpError {
                 ThingsDatabaseError::AreaNotFound { uuid } => {
                     McpError::validation_error(format!("Area not found: {uuid}"))
                 }
-                ThingsDatabaseError::InvalidCursor(message) => {
-                    McpError::validation_error(format!("Invalid cursor: {message}"))
-                }
                 ThingsDatabaseError::AppleScript { message } => {
                     McpError::internal_error(format!("AppleScript automation failed: {message}"))
                 }
@@ -427,6 +424,9 @@ impl From<ThingsError> for McpError {
                 }
                 ThingsQueryError::DateConversion(e) => {
                     McpError::validation_error(format!("Date conversion failed: {e}"))
+                }
+                ThingsQueryError::InvalidCursor(message) => {
+                    McpError::validation_error(format!("Invalid cursor: {message}"))
                 }
                 e => McpError::internal_error(format!("unhandled query error: {e:?}")),
             },

--- a/apps/things3-cli/src/mcp/mod.rs
+++ b/apps/things3-cli/src/mcp/mod.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use things3_core::AppleScriptBackend;
 use things3_core::{
     BackupManager, DataExporter, McpServerConfig, MutationBackend, PerformanceMonitor, SqlxBackend,
-    ThingsCache, ThingsConfig, ThingsDatabase, ThingsError,
+    ThingsCache, ThingsConfig, ThingsDatabase, ThingsDatabaseError, ThingsError, ThingsQueryError,
 };
 use thiserror::Error;
 use tokio::sync::Mutex;
@@ -387,43 +387,55 @@ impl From<ThingsError> for McpError {
     #[allow(deprecated)]
     fn from(error: ThingsError) -> Self {
         match error {
-            ThingsError::Database(e) => {
-                McpError::database_operation_failed("database operation", ThingsError::Database(e))
+            ThingsError::Database(db_err) => match db_err {
+                ThingsDatabaseError::Database(e) => McpError::database_operation_failed(
+                    "database operation",
+                    ThingsError::Database(ThingsDatabaseError::Database(e)),
+                ),
+                ThingsDatabaseError::DatabaseNotFound { path } => {
+                    McpError::configuration_error(format!("Database not found at: {path}"))
+                }
+                ThingsDatabaseError::TaskNotFound { uuid } => {
+                    McpError::validation_error(format!("Task not found: {uuid}"))
+                }
+                ThingsDatabaseError::ProjectNotFound { uuid } => {
+                    McpError::validation_error(format!("Project not found: {uuid}"))
+                }
+                ThingsDatabaseError::AreaNotFound { uuid } => {
+                    McpError::validation_error(format!("Area not found: {uuid}"))
+                }
+                ThingsDatabaseError::InvalidCursor(message) => {
+                    McpError::validation_error(format!("Invalid cursor: {message}"))
+                }
+                ThingsDatabaseError::AppleScript { message } => {
+                    McpError::internal_error(format!("AppleScript automation failed: {message}"))
+                }
+                ThingsDatabaseError::Configuration { message } => {
+                    McpError::configuration_error(message)
+                }
+                e => McpError::internal_error(format!("unhandled database error: {e:?}")),
+            },
+            ThingsError::Query(q_err) => match q_err {
+                ThingsQueryError::InvalidUuid { uuid } => {
+                    McpError::validation_error(format!("Invalid UUID format: {uuid}"))
+                }
+                ThingsQueryError::InvalidDate { date } => {
+                    McpError::validation_error(format!("Invalid date format: {date}"))
+                }
+                ThingsQueryError::DateValidation(e) => {
+                    McpError::validation_error(format!("Date validation failed: {e}"))
+                }
+                ThingsQueryError::DateConversion(e) => {
+                    McpError::validation_error(format!("Date conversion failed: {e}"))
+                }
+                e => McpError::internal_error(format!("unhandled query error: {e:?}")),
+            },
+            ThingsError::Export(ex_err) => {
+                McpError::internal_error(format!("Export error: {ex_err}"))
             }
             ThingsError::Serialization(e) => McpError::serialization_failed("serialization", e),
             ThingsError::Io(e) => McpError::io_operation_failed("io operation", e),
-            ThingsError::DatabaseNotFound { path } => {
-                McpError::configuration_error(format!("Database not found at: {path}"))
-            }
-            ThingsError::InvalidUuid { uuid } => {
-                McpError::validation_error(format!("Invalid UUID format: {uuid}"))
-            }
-            ThingsError::InvalidDate { date } => {
-                McpError::validation_error(format!("Invalid date format: {date}"))
-            }
-            ThingsError::TaskNotFound { uuid } => {
-                McpError::validation_error(format!("Task not found: {uuid}"))
-            }
-            ThingsError::ProjectNotFound { uuid } => {
-                McpError::validation_error(format!("Project not found: {uuid}"))
-            }
-            ThingsError::AreaNotFound { uuid } => {
-                McpError::validation_error(format!("Area not found: {uuid}"))
-            }
             ThingsError::Validation { message } => McpError::validation_error(message),
-            ThingsError::InvalidCursor(message) => {
-                McpError::validation_error(format!("Invalid cursor: {message}"))
-            }
-            ThingsError::Configuration { message } => McpError::configuration_error(message),
-            ThingsError::DateValidation(e) => {
-                McpError::validation_error(format!("Date validation failed: {e}"))
-            }
-            ThingsError::DateConversion(e) => {
-                McpError::validation_error(format!("Date conversion failed: {e}"))
-            }
-            ThingsError::AppleScript { message } => {
-                McpError::internal_error(format!("AppleScript automation failed: {message}"))
-            }
             ThingsError::Unknown { message } => McpError::internal_error(message),
             e => McpError::internal_error(format!("unhandled Things error: {e:?}")),
         }

--- a/apps/things3-cli/tests/mcp_tests/error_tests.rs
+++ b/apps/things3-cli/tests/mcp_tests/error_tests.rs
@@ -151,7 +151,8 @@ async fn test_from_traits() {
 #[tokio::test]
 async fn test_from_traits_comprehensive() {
     // Test all ThingsError variants
-    let db_error = things3_core::ThingsError::Database("TypeNotFound: test_column".to_string());
+    let db_error: things3_core::ThingsError =
+        things3_core::ThingsDatabaseError::Database("TypeNotFound: test_column".to_string()).into();
     let mcp_error: McpError = db_error.into();
     assert!(
         matches!(mcp_error, McpError::DatabaseOperationFailed { operation, .. } if operation == "database operation")
@@ -174,49 +175,59 @@ async fn test_from_traits_comprehensive() {
         matches!(mcp_error, McpError::IoOperationFailed { operation, .. } if operation == "io operation")
     );
 
-    let db_not_found = things3_core::ThingsError::DatabaseNotFound {
-        path: "/test/path".to_string(),
-    };
+    let db_not_found: things3_core::ThingsError =
+        things3_core::ThingsDatabaseError::DatabaseNotFound {
+            path: "/test/path".to_string(),
+        }
+        .into();
     let mcp_error: McpError = db_not_found.into();
     assert!(
         matches!(mcp_error, McpError::ConfigurationError { message } if message.contains("Database not found at: /test/path"))
     );
 
-    let invalid_uuid = things3_core::ThingsError::InvalidUuid {
+    let invalid_uuid: things3_core::ThingsError = things3_core::ThingsQueryError::InvalidUuid {
         uuid: "invalid-uuid".to_string(),
-    };
+    }
+    .into();
     let mcp_error: McpError = invalid_uuid.into();
     assert!(
         matches!(mcp_error, McpError::ValidationError { message } if message.contains("Invalid UUID format: invalid-uuid"))
     );
 
-    let invalid_date = things3_core::ThingsError::InvalidDate {
+    let invalid_date: things3_core::ThingsError = things3_core::ThingsQueryError::InvalidDate {
         date: "invalid-date".to_string(),
-    };
+    }
+    .into();
     let mcp_error: McpError = invalid_date.into();
     assert!(
         matches!(mcp_error, McpError::ValidationError { message } if message.contains("Invalid date format: invalid-date"))
     );
 
-    let task_not_found = things3_core::ThingsError::TaskNotFound {
-        uuid: "task-uuid".to_string(),
-    };
+    let task_not_found: things3_core::ThingsError =
+        things3_core::ThingsDatabaseError::TaskNotFound {
+            uuid: "task-uuid".to_string(),
+        }
+        .into();
     let mcp_error: McpError = task_not_found.into();
     assert!(
         matches!(mcp_error, McpError::ValidationError { message } if message.contains("Task not found: task-uuid"))
     );
 
-    let project_not_found = things3_core::ThingsError::ProjectNotFound {
-        uuid: "project-uuid".to_string(),
-    };
+    let project_not_found: things3_core::ThingsError =
+        things3_core::ThingsDatabaseError::ProjectNotFound {
+            uuid: "project-uuid".to_string(),
+        }
+        .into();
     let mcp_error: McpError = project_not_found.into();
     assert!(
         matches!(mcp_error, McpError::ValidationError { message } if message.contains("Project not found: project-uuid"))
     );
 
-    let area_not_found = things3_core::ThingsError::AreaNotFound {
-        uuid: "area-uuid".to_string(),
-    };
+    let area_not_found: things3_core::ThingsError =
+        things3_core::ThingsDatabaseError::AreaNotFound {
+            uuid: "area-uuid".to_string(),
+        }
+        .into();
     let mcp_error: McpError = area_not_found.into();
     assert!(
         matches!(mcp_error, McpError::ValidationError { message } if message.contains("Area not found: area-uuid"))
@@ -230,9 +241,11 @@ async fn test_from_traits_comprehensive() {
         matches!(mcp_error, McpError::ValidationError { message } if message == "test validation")
     );
 
-    let config_error = things3_core::ThingsError::Configuration {
-        message: "test config".to_string(),
-    };
+    let config_error: things3_core::ThingsError =
+        things3_core::ThingsDatabaseError::Configuration {
+            message: "test config".to_string(),
+        }
+        .into();
     let mcp_error: McpError = config_error.into();
     assert!(
         matches!(mcp_error, McpError::ConfigurationError { message } if message == "test config")

--- a/libs/things3-core/src/config.rs
+++ b/libs/things3-core/src/config.rs
@@ -149,6 +149,7 @@ impl Default for ThingsConfig {
 #[allow(deprecated)]
 mod tests {
     use super::*;
+    use crate::error::ThingsDatabaseError;
     use serial_test::serial;
     use tempfile::NamedTempFile;
 
@@ -533,7 +534,7 @@ mod tests {
             assert!(result.is_err());
             let error = result.unwrap_err();
             match error {
-                ThingsError::Configuration { message } => {
+                ThingsError::Database(ThingsDatabaseError::Configuration { message }) => {
                     assert!(message.contains("Database not found at"));
                     assert!(message.contains("fallback is enabled but default path also not found"));
                 }
@@ -552,7 +553,7 @@ mod tests {
         assert!(result.is_err());
         let error = result.unwrap_err();
         match error {
-            ThingsError::Configuration { message } => {
+            ThingsError::Database(ThingsDatabaseError::Configuration { message }) => {
                 assert!(message.contains("Database not found at"));
                 assert!(message.contains("fallback is disabled"));
             }
@@ -765,7 +766,10 @@ mod tests {
         let result = config.get_effective_database_path();
         assert!(result.is_err());
         let error = result.unwrap_err();
-        assert!(matches!(error, ThingsError::Configuration { .. }));
+        assert!(matches!(
+            error,
+            ThingsError::Database(ThingsDatabaseError::Configuration { .. })
+        ));
     }
 
     #[test]
@@ -794,7 +798,10 @@ mod tests {
             "Expected error when both configured and default paths don't exist"
         );
         let error = result.unwrap_err();
-        assert!(matches!(error, ThingsError::Configuration { .. }));
+        assert!(matches!(
+            error,
+            ThingsError::Database(ThingsDatabaseError::Configuration { .. })
+        ));
 
         // Check the error message contains the expected text
         let error_message = format!("{error}");

--- a/libs/things3-core/src/config_hot_reload.rs
+++ b/libs/things3-core/src/config_hot_reload.rs
@@ -413,6 +413,7 @@ impl ConfigHotReloaderWithHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::ThingsDatabaseError;
     use std::time::Duration;
     use tempfile::NamedTempFile;
 
@@ -536,7 +537,10 @@ mod tests {
         let result = ConfigHotReloader::new(config, config_path, Duration::from_secs(1));
         assert!(result.is_err());
         let error = result.unwrap_err();
-        assert!(matches!(error, ThingsError::Configuration { .. }));
+        assert!(matches!(
+            error,
+            ThingsError::Database(ThingsDatabaseError::Configuration { .. })
+        ));
     }
 
     #[tokio::test]

--- a/libs/things3-core/src/config_loader.rs
+++ b/libs/things3-core/src/config_loader.rs
@@ -268,6 +268,7 @@ pub fn load_config_from_env() -> Result<McpServerConfig> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::ThingsDatabaseError;
     use serial_test::serial;
     use std::sync::Mutex;
     use tempfile::TempDir;
@@ -539,7 +540,10 @@ mod tests {
         let result = loader.load();
         assert!(result.is_err());
         let error = result.unwrap_err();
-        assert!(matches!(error, ThingsError::Configuration { .. }));
+        assert!(matches!(
+            error,
+            ThingsError::Database(ThingsDatabaseError::Configuration { .. })
+        ));
     }
 
     #[test]

--- a/libs/things3-core/src/cursor.rs
+++ b/libs/things3-core/src/cursor.rs
@@ -27,7 +27,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::error::{Result, ThingsDatabaseError, ThingsError};
+use crate::error::{Result, ThingsError, ThingsQueryError};
 
 /// Opaque pagination token. Constructed by
 /// [`crate::query::TaskQueryBuilder::execute_paged`] and round-tripped
@@ -58,11 +58,11 @@ impl Cursor {
 
     /// Decode the cursor back into its payload.
     pub(crate) fn decode(&self) -> Result<CursorPayload> {
-        let bytes = URL_SAFE_NO_PAD.decode(self.0.as_bytes()).map_err(|e| {
-            ThingsDatabaseError::InvalidCursor(format!("base64 decode failed: {e}"))
-        })?;
+        let bytes = URL_SAFE_NO_PAD
+            .decode(self.0.as_bytes())
+            .map_err(|e| ThingsQueryError::InvalidCursor(format!("base64 decode failed: {e}")))?;
         serde_json::from_slice(&bytes)
-            .map_err(|e| ThingsDatabaseError::InvalidCursor(format!("payload parse failed: {e}")))
+            .map_err(|e| ThingsQueryError::InvalidCursor(format!("payload parse failed: {e}")))
     }
 }
 
@@ -141,7 +141,7 @@ mod tests {
     fn test_cursor_rejects_invalid_base64() {
         let err = Cursor::from_str("!!!not base64!!!").unwrap_err();
         match err {
-            ThingsError::Database(ThingsDatabaseError::InvalidCursor(msg)) => {
+            ThingsError::Query(ThingsQueryError::InvalidCursor(msg)) => {
                 assert!(msg.contains("base64"))
             }
             other => panic!("expected InvalidCursor, got {other:?}"),
@@ -153,7 +153,7 @@ mod tests {
         let bogus = URL_SAFE_NO_PAD.encode(b"not json");
         let err = Cursor::from_str(&bogus).unwrap_err();
         match err {
-            ThingsError::Database(ThingsDatabaseError::InvalidCursor(msg)) => {
+            ThingsError::Query(ThingsQueryError::InvalidCursor(msg)) => {
                 assert!(msg.contains("payload parse failed"))
             }
             other => panic!("expected InvalidCursor, got {other:?}"),
@@ -165,7 +165,7 @@ mod tests {
         let bogus = URL_SAFE_NO_PAD.encode(b"{}");
         assert!(matches!(
             Cursor::from_str(&bogus),
-            Err(ThingsError::Database(ThingsDatabaseError::InvalidCursor(_)))
+            Err(ThingsError::Query(ThingsQueryError::InvalidCursor(_)))
         ));
     }
 

--- a/libs/things3-core/src/cursor.rs
+++ b/libs/things3-core/src/cursor.rs
@@ -61,8 +61,11 @@ impl Cursor {
         let bytes = URL_SAFE_NO_PAD
             .decode(self.0.as_bytes())
             .map_err(|e| ThingsQueryError::InvalidCursor(format!("base64 decode failed: {e}")))?;
-        serde_json::from_slice(&bytes)
-            .map_err(|e| ThingsQueryError::InvalidCursor(format!("payload parse failed: {e}")))
+        serde_json::from_slice(&bytes).map_err(|e| {
+            ThingsError::Query(ThingsQueryError::InvalidCursor(format!(
+                "payload parse failed: {e}"
+            )))
+        })
     }
 }
 

--- a/libs/things3-core/src/cursor.rs
+++ b/libs/things3-core/src/cursor.rs
@@ -27,7 +27,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::error::{Result, ThingsError};
+use crate::error::{Result, ThingsDatabaseError, ThingsError};
 
 /// Opaque pagination token. Constructed by
 /// [`crate::query::TaskQueryBuilder::execute_paged`] and round-tripped
@@ -58,11 +58,11 @@ impl Cursor {
 
     /// Decode the cursor back into its payload.
     pub(crate) fn decode(&self) -> Result<CursorPayload> {
-        let bytes = URL_SAFE_NO_PAD
-            .decode(self.0.as_bytes())
-            .map_err(|e| ThingsError::InvalidCursor(format!("base64 decode failed: {e}")))?;
+        let bytes = URL_SAFE_NO_PAD.decode(self.0.as_bytes()).map_err(|e| {
+            ThingsDatabaseError::InvalidCursor(format!("base64 decode failed: {e}"))
+        })?;
         serde_json::from_slice(&bytes)
-            .map_err(|e| ThingsError::InvalidCursor(format!("payload parse failed: {e}")))
+            .map_err(|e| ThingsDatabaseError::InvalidCursor(format!("payload parse failed: {e}")))
     }
 }
 
@@ -141,7 +141,9 @@ mod tests {
     fn test_cursor_rejects_invalid_base64() {
         let err = Cursor::from_str("!!!not base64!!!").unwrap_err();
         match err {
-            ThingsError::InvalidCursor(msg) => assert!(msg.contains("base64")),
+            ThingsError::Database(ThingsDatabaseError::InvalidCursor(msg)) => {
+                assert!(msg.contains("base64"))
+            }
             other => panic!("expected InvalidCursor, got {other:?}"),
         }
     }
@@ -151,7 +153,9 @@ mod tests {
         let bogus = URL_SAFE_NO_PAD.encode(b"not json");
         let err = Cursor::from_str(&bogus).unwrap_err();
         match err {
-            ThingsError::InvalidCursor(msg) => assert!(msg.contains("payload parse failed")),
+            ThingsError::Database(ThingsDatabaseError::InvalidCursor(msg)) => {
+                assert!(msg.contains("payload parse failed"))
+            }
             other => panic!("expected InvalidCursor, got {other:?}"),
         }
     }
@@ -161,7 +165,7 @@ mod tests {
         let bogus = URL_SAFE_NO_PAD.encode(b"{}");
         assert!(matches!(
             Cursor::from_str(&bogus),
-            Err(ThingsError::InvalidCursor(_))
+            Err(ThingsError::Database(ThingsDatabaseError::InvalidCursor(_)))
         ));
     }
 

--- a/libs/things3-core/src/database/mutations/bulk.rs
+++ b/libs/things3-core/src/database/mutations/bulk.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     database::{conversions::naive_date_to_things_timestamp, validators, ThingsDatabase},
-    error::{Result as ThingsResult, ThingsError},
+    error::{Result as ThingsResult, ThingsDatabaseError, ThingsError},
 };
 use chrono::Utc;
 use sqlx::Row;
@@ -93,9 +93,10 @@ impl ThingsDatabase {
             for id in &request.task_uuids {
                 if !found_uuids.contains(&id.to_string()) {
                     tx.rollback().await.ok();
-                    return Err(ThingsError::TaskNotFound {
+                    return Err(ThingsDatabaseError::TaskNotFound {
                         uuid: id.to_string(),
-                    });
+                    }
+                    .into());
                 }
             }
         }
@@ -212,9 +213,10 @@ impl ThingsDatabase {
             for id in &request.task_uuids {
                 if !found_uuids.contains(&id.to_string()) {
                     tx.rollback().await.ok();
-                    return Err(ThingsError::TaskNotFound {
+                    return Err(ThingsDatabaseError::TaskNotFound {
                         uuid: id.to_string(),
-                    });
+                    }
+                    .into());
                 }
             }
         }
@@ -366,9 +368,10 @@ impl ThingsDatabase {
             for id in &request.task_uuids {
                 if !found_uuids.contains(&id.to_string()) {
                     tx.rollback().await.ok();
-                    return Err(ThingsError::TaskNotFound {
+                    return Err(ThingsDatabaseError::TaskNotFound {
                         uuid: id.to_string(),
-                    });
+                    }
+                    .into());
                 }
             }
         }
@@ -478,9 +481,10 @@ impl ThingsDatabase {
             for id in &request.task_uuids {
                 if !found_uuids.contains(&id.to_string()) {
                     tx.rollback().await.ok();
-                    return Err(ThingsError::TaskNotFound {
+                    return Err(ThingsDatabaseError::TaskNotFound {
                         uuid: id.to_string(),
-                    });
+                    }
+                    .into());
                 }
             }
         }

--- a/libs/things3-core/src/database/tests.rs
+++ b/libs/things3-core/src/database/tests.rs
@@ -966,8 +966,8 @@ mod query_tasks_tests {
                 .fuzzy_search("anything")
                 .execute_stream(&db);
             match stream.next().await {
-                Some(Err(crate::error::ThingsError::Database(
-                    crate::error::ThingsDatabaseError::InvalidCursor(msg),
+                Some(Err(crate::error::ThingsError::Query(
+                    crate::error::ThingsQueryError::InvalidCursor(msg),
                 ))) => {
                     assert!(msg.contains("fuzzy"), "msg: {msg}");
                 }

--- a/libs/things3-core/src/database/tests.rs
+++ b/libs/things3-core/src/database/tests.rs
@@ -966,7 +966,9 @@ mod query_tasks_tests {
                 .fuzzy_search("anything")
                 .execute_stream(&db);
             match stream.next().await {
-                Some(Err(crate::error::ThingsError::InvalidCursor(msg))) => {
+                Some(Err(crate::error::ThingsError::Database(
+                    crate::error::ThingsDatabaseError::InvalidCursor(msg),
+                ))) => {
                     assert!(msg.contains("fuzzy"), "msg: {msg}");
                 }
                 other => panic!("expected first item to be InvalidCursor, got {other:?}"),

--- a/libs/things3-core/src/database/validators.rs
+++ b/libs/things3-core/src/database/validators.rs
@@ -4,7 +4,7 @@
 //! This module provides centralized validation functions to ensure
 //! referenced entities (tasks, projects, areas) exist before performing operations.
 
-use crate::error::{Result as ThingsResult, ThingsError};
+use crate::error::{Result as ThingsResult, ThingsDatabaseError, ThingsError};
 use crate::models::ThingsId;
 use sqlx::SqlitePool;
 use tracing::instrument;
@@ -44,9 +44,10 @@ pub async fn validate_project_exists(pool: &SqlitePool, id: &ThingsId) -> Things
         .is_some();
 
     if !exists {
-        return Err(ThingsError::ProjectNotFound {
+        return Err(ThingsDatabaseError::ProjectNotFound {
             uuid: id.to_string(),
-        });
+        }
+        .into());
     }
     Ok(())
 }

--- a/libs/things3-core/src/error.rs
+++ b/libs/things3-core/src/error.rs
@@ -28,9 +28,6 @@ pub enum ThingsDatabaseError {
     #[error("Area not found: {uuid}. The area may have been deleted. Verify the UUID or list all areas to find the correct one.")]
     AreaNotFound { uuid: String },
 
-    #[error("Invalid cursor: {0}")]
-    InvalidCursor(String),
-
     #[error("AppleScript automation failed: {message}")]
     AppleScript { message: String },
 
@@ -53,6 +50,9 @@ pub enum ThingsQueryError {
 
     #[error("Date conversion failed: {0}")]
     DateConversion(#[from] crate::database::DateConversionError),
+
+    #[error("Invalid cursor: {0}")]
+    InvalidCursor(String),
 }
 
 /// Export-specific errors (introduced in 3.0).
@@ -60,10 +60,10 @@ pub enum ThingsQueryError {
 #[derive(Error, Debug)]
 pub enum ThingsExportError {
     #[error("Export IO error: {0}")]
-    Io(String),
+    Io(#[from] std::io::Error),
 
     #[error("Export serialization error: {0}")]
-    Serialization(String),
+    Serialization(#[from] serde_json::Error),
 
     #[error("Export format unavailable: {message}")]
     FormatUnavailable { message: String },
@@ -473,7 +473,7 @@ mod tests {
     #[test]
     fn test_invalid_cursor_error() {
         let error: ThingsError =
-            ThingsDatabaseError::InvalidCursor("bad cursor data".to_string()).into();
+            ThingsQueryError::InvalidCursor("bad cursor data".to_string()).into();
         assert!(error.to_string().contains("Invalid cursor"));
         assert!(error.to_string().contains("bad cursor data"));
     }

--- a/libs/things3-core/src/error.rs
+++ b/libs/things3-core/src/error.rs
@@ -5,26 +5,43 @@ use thiserror::Error;
 /// Result type alias for Things operations
 pub type Result<T> = std::result::Result<T, ThingsError>;
 
-/// Main error type for Things operations
+/// Database-specific errors (introduced in 3.0).
 #[non_exhaustive]
 #[derive(Error, Debug)]
-pub enum ThingsError {
+pub enum ThingsDatabaseError {
     #[deprecated(
         since = "2.1.0",
-        note = "Will be replaced by domain-specific error types in 3.0. See the planned ThingsDatabaseError."
+        note = "Migrate to a specific ThingsDatabaseError variant."
     )]
     #[error("Database error: {0}")]
     Database(String),
 
-    #[error("Serialization error: {0}")]
-    Serialization(#[from] serde_json::Error),
-
-    #[error("IO error: {0}")]
-    Io(#[from] std::io::Error),
-
     #[error("Database not found: {path}. Ensure Things 3 is installed and has been opened at least once, or specify a custom database path.")]
     DatabaseNotFound { path: String },
 
+    #[error("Task not found: {uuid}. The task may have been deleted or moved. Try searching by title instead.")]
+    TaskNotFound { uuid: String },
+
+    #[error("Project not found: {uuid}. The project may have been deleted. Verify the UUID or list all projects to find the correct one.")]
+    ProjectNotFound { uuid: String },
+
+    #[error("Area not found: {uuid}. The area may have been deleted. Verify the UUID or list all areas to find the correct one.")]
+    AreaNotFound { uuid: String },
+
+    #[error("Invalid cursor: {0}")]
+    InvalidCursor(String),
+
+    #[error("AppleScript automation failed: {message}")]
+    AppleScript { message: String },
+
+    #[error("Configuration error: {message}")]
+    Configuration { message: String },
+}
+
+/// Query-specific errors (introduced in 3.0).
+#[non_exhaustive]
+#[derive(Error, Debug)]
+pub enum ThingsQueryError {
     #[error("Invalid UUID: {uuid}. UUIDs must be in format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")]
     InvalidUuid { uuid: String },
 
@@ -36,52 +53,88 @@ pub enum ThingsError {
 
     #[error("Date conversion failed: {0}")]
     DateConversion(#[from] crate::database::DateConversionError),
+}
 
-    #[error("Task not found: {uuid}. The task may have been deleted or moved. Try searching by title instead.")]
-    TaskNotFound { uuid: String },
+/// Export-specific errors (introduced in 3.0).
+#[non_exhaustive]
+#[derive(Error, Debug)]
+pub enum ThingsExportError {
+    #[error("Export IO error: {0}")]
+    Io(String),
 
-    #[error("Project not found: {uuid}. The project may have been deleted. Verify the UUID or list all projects to find the correct one.")]
-    ProjectNotFound { uuid: String },
+    #[error("Export serialization error: {0}")]
+    Serialization(String),
 
-    #[error("Area not found: {uuid}. The area may have been deleted. Verify the UUID or list all areas to find the correct one.")]
-    AreaNotFound { uuid: String },
+    #[error("Export format unavailable: {message}")]
+    FormatUnavailable { message: String },
+}
+
+/// Main error type for Things operations
+#[non_exhaustive]
+#[derive(Error, Debug)]
+pub enum ThingsError {
+    #[error(transparent)]
+    Database(#[from] ThingsDatabaseError),
+
+    #[error(transparent)]
+    Query(#[from] ThingsQueryError),
+
+    #[error(transparent)]
+    Export(#[from] ThingsExportError),
+
+    #[error("Serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
 
     #[error("Validation error: {message}")]
     Validation { message: String },
 
-    #[error("Invalid cursor: {0}")]
-    InvalidCursor(String),
-
-    #[error("Configuration error: {message}")]
-    Configuration { message: String },
-
-    #[error("AppleScript automation failed: {message}")]
-    AppleScript { message: String },
-
     #[deprecated(
         since = "2.1.0",
-        note = "Will be removed in 3.0. Use a specific variant such as ThingsError::Validation or ThingsError::Configuration instead."
+        note = "Will be removed in 3.0. Use a specific variant such as ThingsError::Validation or ThingsError::configuration() instead."
     )]
     #[error("Unknown error: {message}")]
     Unknown { message: String },
 }
 
+// Two-step From conversions so `?` works at DB-layer call sites.
+impl From<crate::database::DateValidationError> for ThingsError {
+    fn from(e: crate::database::DateValidationError) -> Self {
+        ThingsError::Query(ThingsQueryError::DateValidation(e))
+    }
+}
+
+impl From<crate::database::DateConversionError> for ThingsError {
+    fn from(e: crate::database::DateConversionError) -> Self {
+        ThingsError::Query(ThingsQueryError::DateConversion(e))
+    }
+}
+
 impl ThingsError {
-    /// Create a validation error
+    /// Create a validation error.
     pub fn validation(message: impl Into<String>) -> Self {
         Self::Validation {
             message: message.into(),
         }
     }
 
-    /// Create a configuration error
+    /// Create a configuration error.
     pub fn configuration(message: impl Into<String>) -> Self {
-        Self::Configuration {
+        Self::Database(ThingsDatabaseError::Configuration {
             message: message.into(),
-        }
+        })
     }
 
-    /// Create an unknown error
+    /// Create an AppleScript error.
+    pub fn applescript(message: impl Into<String>) -> Self {
+        Self::Database(ThingsDatabaseError::AppleScript {
+            message: message.into(),
+        })
+    }
+
+    /// Create an unknown error.
     #[deprecated(
         since = "2.1.0",
         note = "Will be removed in 3.0. Use a specific constructor such as ThingsError::validation() or ThingsError::configuration() instead."
@@ -92,13 +145,6 @@ impl ThingsError {
             message: message.into(),
         }
     }
-
-    /// Create an AppleScript error
-    pub fn applescript(message: impl Into<String>) -> Self {
-        Self::AppleScript {
-            message: message.into(),
-        }
-    }
 }
 
 #[cfg(test)]
@@ -106,12 +152,6 @@ impl ThingsError {
 mod tests {
     use super::*;
     use std::io;
-
-    #[test]
-    fn test_database_error_from_rusqlite() {
-        // Skip this test since rusqlite is not available in this build
-        // This test would verify rusqlite error conversion if the dependency was available
-    }
 
     #[test]
     fn test_serialization_error_from_serde() {
@@ -137,9 +177,10 @@ mod tests {
 
     #[test]
     fn test_database_not_found_error() {
-        let error = ThingsError::DatabaseNotFound {
+        let error: ThingsError = ThingsDatabaseError::DatabaseNotFound {
             path: "/path/to/db".to_string(),
-        };
+        }
+        .into();
 
         assert!(error.to_string().contains("Database not found"));
         assert!(error.to_string().contains("/path/to/db"));
@@ -147,9 +188,10 @@ mod tests {
 
     #[test]
     fn test_invalid_uuid_error() {
-        let error = ThingsError::InvalidUuid {
+        let error: ThingsError = ThingsQueryError::InvalidUuid {
             uuid: "invalid-uuid".to_string(),
-        };
+        }
+        .into();
 
         assert!(error.to_string().contains("Invalid UUID"));
         assert!(error.to_string().contains("invalid-uuid"));
@@ -157,9 +199,10 @@ mod tests {
 
     #[test]
     fn test_invalid_date_error() {
-        let error = ThingsError::InvalidDate {
+        let error: ThingsError = ThingsQueryError::InvalidDate {
             date: "2023-13-45".to_string(),
-        };
+        }
+        .into();
 
         assert!(error.to_string().contains("Invalid date"));
         assert!(error.to_string().contains("2023-13-45"));
@@ -167,9 +210,10 @@ mod tests {
 
     #[test]
     fn test_task_not_found_error() {
-        let error = ThingsError::TaskNotFound {
+        let error: ThingsError = ThingsDatabaseError::TaskNotFound {
             uuid: "task-uuid-123".to_string(),
-        };
+        }
+        .into();
 
         assert!(error.to_string().contains("Task not found"));
         assert!(error.to_string().contains("task-uuid-123"));
@@ -177,9 +221,10 @@ mod tests {
 
     #[test]
     fn test_project_not_found_error() {
-        let error = ThingsError::ProjectNotFound {
+        let error: ThingsError = ThingsDatabaseError::ProjectNotFound {
             uuid: "project-uuid-456".to_string(),
-        };
+        }
+        .into();
 
         assert!(error.to_string().contains("Project not found"));
         assert!(error.to_string().contains("project-uuid-456"));
@@ -187,9 +232,10 @@ mod tests {
 
     #[test]
     fn test_area_not_found_error() {
-        let error = ThingsError::AreaNotFound {
+        let error: ThingsError = ThingsDatabaseError::AreaNotFound {
             uuid: "area-uuid-789".to_string(),
-        };
+        }
+        .into();
 
         assert!(error.to_string().contains("Area not found"));
         assert!(error.to_string().contains("area-uuid-789"));
@@ -207,9 +253,10 @@ mod tests {
 
     #[test]
     fn test_configuration_error() {
-        let error = ThingsError::Configuration {
+        let error: ThingsError = ThingsDatabaseError::Configuration {
             message: "Missing required config".to_string(),
-        };
+        }
+        .into();
 
         assert!(error.to_string().contains("Configuration error"));
         assert!(error.to_string().contains("Missing required config"));
@@ -227,9 +274,10 @@ mod tests {
 
     #[test]
     fn test_applescript_error() {
-        let error = ThingsError::AppleScript {
+        let error: ThingsError = ThingsDatabaseError::AppleScript {
             message: "macOS Automation permission denied".to_string(),
-        };
+        }
+        .into();
 
         assert!(error.to_string().contains("AppleScript automation failed"));
         assert!(error
@@ -242,7 +290,7 @@ mod tests {
         let error = ThingsError::applescript("osascript not available");
 
         match error {
-            ThingsError::AppleScript { message } => {
+            ThingsError::Database(ThingsDatabaseError::AppleScript { message }) => {
                 assert_eq!(message, "osascript not available");
             }
             _ => panic!("Expected AppleScript error"),
@@ -279,7 +327,7 @@ mod tests {
         let error = ThingsError::configuration("Test config message");
 
         match error {
-            ThingsError::Configuration { message } => {
+            ThingsError::Database(ThingsDatabaseError::Configuration { message }) => {
                 assert_eq!(message, "Test config message");
             }
             _ => panic!("Expected Configuration error"),
@@ -292,7 +340,7 @@ mod tests {
         let error = ThingsError::configuration(message);
 
         match error {
-            ThingsError::Configuration { message } => {
+            ThingsError::Database(ThingsDatabaseError::Configuration { message }) => {
                 assert_eq!(message, "Test config message");
             }
             _ => panic!("Expected Configuration error"),
@@ -326,31 +374,38 @@ mod tests {
 
     #[test]
     fn test_error_display_formatting() {
-        let errors = vec![
-            ThingsError::DatabaseNotFound {
+        let errors: Vec<ThingsError> = vec![
+            ThingsDatabaseError::DatabaseNotFound {
                 path: "test.db".to_string(),
-            },
-            ThingsError::InvalidUuid {
+            }
+            .into(),
+            ThingsQueryError::InvalidUuid {
                 uuid: "bad-uuid".to_string(),
-            },
-            ThingsError::InvalidDate {
+            }
+            .into(),
+            ThingsQueryError::InvalidDate {
                 date: "bad-date".to_string(),
-            },
-            ThingsError::TaskNotFound {
+            }
+            .into(),
+            ThingsDatabaseError::TaskNotFound {
                 uuid: "task-123".to_string(),
-            },
-            ThingsError::ProjectNotFound {
+            }
+            .into(),
+            ThingsDatabaseError::ProjectNotFound {
                 uuid: "project-456".to_string(),
-            },
-            ThingsError::AreaNotFound {
+            }
+            .into(),
+            ThingsDatabaseError::AreaNotFound {
                 uuid: "area-789".to_string(),
-            },
+            }
+            .into(),
             ThingsError::Validation {
                 message: "validation failed".to_string(),
             },
-            ThingsError::Configuration {
+            ThingsDatabaseError::Configuration {
                 message: "config error".to_string(),
-            },
+            }
+            .into(),
             ThingsError::Unknown {
                 message: "unknown error".to_string(),
             },
@@ -359,7 +414,7 @@ mod tests {
         for error in errors {
             let error_string = error.to_string();
             assert!(!error_string.is_empty());
-            assert!(error_string.len() > 10); // Should have meaningful content
+            assert!(error_string.len() > 10);
         }
     }
 
@@ -376,16 +431,10 @@ mod tests {
 
     #[test]
     fn test_result_type_alias() {
-        // Test that the Result type alias works correctly
-        fn returns_result() -> String {
-            "success".to_string()
-        }
-
         fn returns_error() -> Result<String> {
             Err(ThingsError::validation("test error"))
         }
 
-        assert_eq!(returns_result(), "success");
         assert!(returns_error().is_err());
 
         match returns_error() {
@@ -394,5 +443,38 @@ mod tests {
             }
             _ => panic!("Expected Validation error"),
         }
+    }
+
+    #[test]
+    fn test_database_error_deprecated_variant() {
+        let inner = ThingsDatabaseError::Database("raw db error".to_string());
+        let error: ThingsError = inner.into();
+        assert!(error.to_string().contains("Database error"));
+    }
+
+    #[test]
+    fn test_from_impls() {
+        let db_err = ThingsDatabaseError::DatabaseNotFound {
+            path: "p".to_string(),
+        };
+        let _: ThingsError = db_err.into();
+
+        let q_err = ThingsQueryError::InvalidUuid {
+            uuid: "u".to_string(),
+        };
+        let _: ThingsError = q_err.into();
+
+        let ex_err = ThingsExportError::FormatUnavailable {
+            message: "csv not enabled".to_string(),
+        };
+        let _: ThingsError = ex_err.into();
+    }
+
+    #[test]
+    fn test_invalid_cursor_error() {
+        let error: ThingsError =
+            ThingsDatabaseError::InvalidCursor("bad cursor data".to_string()).into();
+        assert!(error.to_string().contains("Invalid cursor"));
+        assert!(error.to_string().contains("bad cursor data"));
     }
 }

--- a/libs/things3-core/src/lib.rs
+++ b/libs/things3-core/src/lib.rs
@@ -114,7 +114,7 @@ pub use database::{
     PoolHealthStatus, PoolMetrics, SqliteOptimizations, ThingsDatabase,
 };
 pub use disk_cache::{DiskCache, DiskCacheConfig, DiskCacheStats};
-pub use error::{Result, ThingsError};
+pub use error::{Result, ThingsDatabaseError, ThingsError, ThingsExportError, ThingsQueryError};
 
 #[cfg(any(
     feature = "export-csv",

--- a/libs/things3-core/src/mutations/applescript/parse.rs
+++ b/libs/things3-core/src/mutations/applescript/parse.rs
@@ -123,6 +123,7 @@ pub(crate) fn parse_atomic_bulk_create_result(stdout: &str) -> Result<BulkOperat
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::ThingsDatabaseError;
 
     const SAMPLE_UUID: &str = "9d3f1e44-5c2a-4b8e-9c1f-7e2d8a4b3c5e";
     const SAMPLE_THINGS_ID: &str = "R4t2G8Q63aGZq4epMHNeCr";
@@ -188,7 +189,7 @@ mod tests {
     fn rejects_empty_input() {
         let err = extract_id("").unwrap_err();
         match err {
-            ThingsError::AppleScript { message } => {
+            ThingsError::Database(ThingsDatabaseError::AppleScript { message }) => {
                 assert!(message.contains("could not extract ID"));
             }
             _ => panic!("expected AppleScript error, got {err:?}"),
@@ -243,7 +244,7 @@ mod tests {
     fn parse_bulk_rejects_garbage_header() {
         let err = parse_bulk_result("garbage", 1).unwrap_err();
         match err {
-            ThingsError::AppleScript { message } => {
+            ThingsError::Database(ThingsDatabaseError::AppleScript { message }) => {
                 assert!(message.contains("unexpected output"));
             }
             _ => panic!("expected AppleScript error, got {err:?}"),
@@ -271,7 +272,7 @@ mod tests {
             parse_atomic_bulk_create_result("ROLLBACK: project id \"bad-uuid\" doesn't exist")
                 .unwrap_err();
         match err {
-            ThingsError::AppleScript { message } => {
+            ThingsError::Database(ThingsDatabaseError::AppleScript { message }) => {
                 assert!(message.contains("rolled back"));
                 assert!(message.contains("bad-uuid"));
             }
@@ -283,7 +284,7 @@ mod tests {
     fn parse_atomic_bulk_create_rejects_garbage() {
         let err = parse_atomic_bulk_create_result("garbage").unwrap_err();
         match err {
-            ThingsError::AppleScript { message } => {
+            ThingsError::Database(ThingsDatabaseError::AppleScript { message }) => {
                 assert!(message.contains("unexpected output"));
             }
             _ => panic!("expected AppleScript error, got {err:?}"),

--- a/libs/things3-core/src/mutations/applescript/runner.rs
+++ b/libs/things3-core/src/mutations/applescript/runner.rs
@@ -80,12 +80,13 @@ fn map_failure(stderr: &str) -> ThingsError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::ThingsDatabaseError;
 
     #[test]
     fn map_failure_tcc_denied() {
         let err = map_failure("execution error: Not authorized to send Apple events. (-1743)");
         match err {
-            ThingsError::AppleScript { message } => {
+            ThingsError::Database(ThingsDatabaseError::AppleScript { message }) => {
                 assert!(message.contains("Automation permission denied"));
                 assert!(message.contains("System Settings"));
             }
@@ -98,7 +99,7 @@ mod tests {
         let err =
             map_failure("execution error: Things3 got an error: Application isn't running. (-600)");
         match err {
-            ThingsError::AppleScript { message } => {
+            ThingsError::Database(ThingsDatabaseError::AppleScript { message }) => {
                 assert!(message.contains("Things 3 is not running"));
             }
             _ => panic!("expected AppleScript error"),
@@ -109,7 +110,7 @@ mod tests {
     fn map_failure_not_installed() {
         let err = map_failure("execution error: NSWorkspaceNotFound (-10810)");
         match err {
-            ThingsError::AppleScript { message } => {
+            ThingsError::Database(ThingsDatabaseError::AppleScript { message }) => {
                 assert!(message.contains("not installed"));
             }
             _ => panic!("expected AppleScript error"),
@@ -120,7 +121,7 @@ mod tests {
     fn map_failure_generic() {
         let err = map_failure("syntax error: bad keyword");
         match err {
-            ThingsError::AppleScript { message } => {
+            ThingsError::Database(ThingsDatabaseError::AppleScript { message }) => {
                 assert!(message.contains("osascript failed"));
                 assert!(message.contains("syntax error"));
             }
@@ -132,7 +133,7 @@ mod tests {
     fn map_failure_trims_whitespace() {
         let err = map_failure("  some error\n");
         match err {
-            ThingsError::AppleScript { message } => {
+            ThingsError::Database(ThingsDatabaseError::AppleScript { message }) => {
                 assert_eq!(message, "osascript failed: some error");
             }
             _ => panic!("expected AppleScript error"),
@@ -154,7 +155,7 @@ mod tests {
             .await
             .expect_err("script should fail");
         match err {
-            ThingsError::AppleScript { message } => {
+            ThingsError::Database(ThingsDatabaseError::AppleScript { message }) => {
                 assert!(message.contains("osascript failed"));
                 assert!(message.contains("deliberate failure"));
             }

--- a/libs/things3-core/src/query.rs
+++ b/libs/things3-core/src/query.rs
@@ -404,12 +404,12 @@ impl TaskQueryBuilder {
         db: &crate::database::ThingsDatabase,
     ) -> crate::error::Result<crate::cursor::Page<crate::models::Task>> {
         if self.fuzzy_query.is_some() {
-            return Err(crate::error::ThingsError::InvalidCursor(
+            return Err(crate::error::ThingsDatabaseError::InvalidCursor(
                 "execute_paged and execute_stream do not support fuzzy_search; use execute_ranked instead".to_string(),
             ));
         }
         if self.filters.offset.is_some() && self.after.is_some() {
-            return Err(crate::error::ThingsError::InvalidCursor(
+            return Err(crate::error::ThingsDatabaseError::InvalidCursor(
                 "offset and after are mutually exclusive".to_string(),
             ));
         }
@@ -462,7 +462,7 @@ impl TaskQueryBuilder {
                 .last()
                 .map(|last| {
                     let u = uuid::Uuid::parse_str(last.uuid.as_str()).map_err(|e| {
-                        crate::error::ThingsError::InvalidCursor(format!(
+                        crate::error::ThingsDatabaseError::InvalidCursor(format!(
                             "task uuid is not RFC-4122: {e}"
                         ))
                     })?;
@@ -879,7 +879,9 @@ mod tests {
                 .execute_paged(&db)
                 .await;
             match result {
-                Err(crate::error::ThingsError::InvalidCursor(msg)) => {
+                Err(crate::error::ThingsError::Database(
+                    crate::error::ThingsDatabaseError::InvalidCursor(msg),
+                )) => {
                     assert!(msg.contains("offset and after"), "msg: {msg}");
                 }
                 other => panic!("expected InvalidCursor, got {other:?}"),
@@ -904,7 +906,9 @@ mod tests {
                 .execute_paged(&db)
                 .await;
             match result {
-                Err(crate::error::ThingsError::InvalidCursor(msg)) => {
+                Err(crate::error::ThingsError::Database(
+                    crate::error::ThingsDatabaseError::InvalidCursor(msg),
+                )) => {
                     assert!(msg.contains("fuzzy"), "msg: {msg}");
                 }
                 other => panic!("expected InvalidCursor, got {other:?}"),

--- a/libs/things3-core/src/query.rs
+++ b/libs/things3-core/src/query.rs
@@ -173,7 +173,7 @@ impl TaskQueryBuilder {
     /// The cursor identifies the last task delivered on the previous page;
     /// [`Self::execute_paged`] will return tasks strictly after it in the
     /// `(creationDate DESC, uuid DESC)` ordering. Mutually exclusive with
-    /// `.offset(...)` — `execute_paged` will return [`crate::error::ThingsError::InvalidCursor`]
+    /// `.offset(...)` — `execute_paged` will return [`crate::error::ThingsQueryError::InvalidCursor`]
     /// if both are set.
     ///
     /// Requires the `batch-operations` feature flag.
@@ -394,7 +394,7 @@ impl TaskQueryBuilder {
     ///
     /// # Errors
     ///
-    /// - [`crate::error::ThingsError::InvalidCursor`] if `.offset(...)` and
+    /// - [`crate::error::ThingsQueryError::InvalidCursor`] if `.offset(...)` and
     ///   `.after(...)` are both set, or if `.fuzzy_search(...)` and
     ///   `.after(...)` are both set, or if the cursor itself is malformed.
     /// - Any error returned by [`crate::database::ThingsDatabase::query_tasks`].
@@ -404,12 +404,12 @@ impl TaskQueryBuilder {
         db: &crate::database::ThingsDatabase,
     ) -> crate::error::Result<crate::cursor::Page<crate::models::Task>> {
         if self.fuzzy_query.is_some() {
-            return Err(crate::error::ThingsDatabaseError::InvalidCursor(
+            return Err(crate::error::ThingsQueryError::InvalidCursor(
                 "execute_paged and execute_stream do not support fuzzy_search; use execute_ranked instead".to_string(),
             ));
         }
         if self.filters.offset.is_some() && self.after.is_some() {
-            return Err(crate::error::ThingsDatabaseError::InvalidCursor(
+            return Err(crate::error::ThingsQueryError::InvalidCursor(
                 "offset and after are mutually exclusive".to_string(),
             ));
         }
@@ -462,7 +462,7 @@ impl TaskQueryBuilder {
                 .last()
                 .map(|last| {
                     let u = uuid::Uuid::parse_str(last.uuid.as_str()).map_err(|e| {
-                        crate::error::ThingsDatabaseError::InvalidCursor(format!(
+                        crate::error::ThingsQueryError::InvalidCursor(format!(
                             "task uuid is not RFC-4122: {e}"
                         ))
                     })?;
@@ -879,8 +879,8 @@ mod tests {
                 .execute_paged(&db)
                 .await;
             match result {
-                Err(crate::error::ThingsError::Database(
-                    crate::error::ThingsDatabaseError::InvalidCursor(msg),
+                Err(crate::error::ThingsError::Query(
+                    crate::error::ThingsQueryError::InvalidCursor(msg),
                 )) => {
                     assert!(msg.contains("offset and after"), "msg: {msg}");
                 }
@@ -906,8 +906,8 @@ mod tests {
                 .execute_paged(&db)
                 .await;
             match result {
-                Err(crate::error::ThingsError::Database(
-                    crate::error::ThingsDatabaseError::InvalidCursor(msg),
+                Err(crate::error::ThingsError::Query(
+                    crate::error::ThingsQueryError::InvalidCursor(msg),
                 )) => {
                     assert!(msg.contains("fuzzy"), "msg: {msg}");
                 }

--- a/libs/things3-core/src/query.rs
+++ b/libs/things3-core/src/query.rs
@@ -404,13 +404,15 @@ impl TaskQueryBuilder {
         db: &crate::database::ThingsDatabase,
     ) -> crate::error::Result<crate::cursor::Page<crate::models::Task>> {
         if self.fuzzy_query.is_some() {
-            return Err(crate::error::ThingsQueryError::InvalidCursor(
+            return Err(crate::error::ThingsError::Query(crate::error::ThingsQueryError::InvalidCursor(
                 "execute_paged and execute_stream do not support fuzzy_search; use execute_ranked instead".to_string(),
-            ));
+            )));
         }
         if self.filters.offset.is_some() && self.after.is_some() {
-            return Err(crate::error::ThingsQueryError::InvalidCursor(
-                "offset and after are mutually exclusive".to_string(),
+            return Err(crate::error::ThingsError::Query(
+                crate::error::ThingsQueryError::InvalidCursor(
+                    "offset and after are mutually exclusive".to_string(),
+                ),
             ));
         }
 
@@ -462,9 +464,11 @@ impl TaskQueryBuilder {
                 .last()
                 .map(|last| {
                     let u = uuid::Uuid::parse_str(last.uuid.as_str()).map_err(|e| {
-                        crate::error::ThingsQueryError::InvalidCursor(format!(
-                            "task uuid is not RFC-4122: {e}"
-                        ))
+                        crate::error::ThingsError::Query(
+                            crate::error::ThingsQueryError::InvalidCursor(format!(
+                                "task uuid is not RFC-4122: {e}"
+                            )),
+                        )
                     })?;
                     let payload = crate::cursor::CursorPayload { c: last.created, u };
                     crate::cursor::Cursor::encode(&payload)

--- a/libs/things3-core/src/test_utils.rs
+++ b/libs/things3-core/src/test_utils.rs
@@ -19,7 +19,7 @@ pub async fn create_test_database<P: AsRef<Path>>(db_path: P) -> crate::Result<(
     let database_url = format!("sqlite:{}", db_path.as_ref().display());
     let pool = SqlitePool::connect(&database_url)
         .await
-        .map_err(|e| crate::ThingsError::Database(format!("Failed to connect to database: {e}")))?;
+        .map_err(|e| crate::ThingsError::unknown(format!("Failed to connect to database: {e}")))?;
 
     // Create the Things 3 schema - matches real database structure
     sqlx::query(
@@ -48,7 +48,7 @@ pub async fn create_test_database<P: AsRef<Path>>(db_path: P) -> crate::Result<(
     )
     .execute(&pool)
     .await
-    .map_err(|e| crate::ThingsError::Database(format!("Failed to create TMTask table: {e}")))?;
+    .map_err(|e| crate::ThingsError::unknown(format!("Failed to create TMTask table: {e}")))?;
 
     // Note: Projects are stored in TMTask table with type=1, no separate TMProject table
 
@@ -67,7 +67,7 @@ pub async fn create_test_database<P: AsRef<Path>>(db_path: P) -> crate::Result<(
     )
     .execute(&pool)
     .await
-    .map_err(|e| crate::ThingsError::Database(format!("Failed to create TMArea table: {e}")))?;
+    .map_err(|e| crate::ThingsError::unknown(format!("Failed to create TMArea table: {e}")))?;
 
     // Create TMTag table — schema mirrors real Things 3 (no creationDate/userModificationDate).
     sqlx::query(
@@ -85,7 +85,7 @@ pub async fn create_test_database<P: AsRef<Path>>(db_path: P) -> crate::Result<(
     )
     .execute(&pool)
     .await
-    .map_err(|e| crate::ThingsError::Database(format!("Failed to create TMTag table: {e}")))?;
+    .map_err(|e| crate::ThingsError::unknown(format!("Failed to create TMTag table: {e}")))?;
 
     // Create TMTaskTag join table — maps tasks to tags by UUID
     sqlx::query(
@@ -99,7 +99,7 @@ pub async fn create_test_database<P: AsRef<Path>>(db_path: P) -> crate::Result<(
     )
     .execute(&pool)
     .await
-    .map_err(|e| crate::ThingsError::Database(format!("Failed to create TMTaskTag table: {e}")))?;
+    .map_err(|e| crate::ThingsError::unknown(format!("Failed to create TMTaskTag table: {e}")))?;
 
     // Insert test data
     insert_test_data(&pool).await?;
@@ -134,7 +134,7 @@ async fn insert_test_data(pool: &sqlx::SqlitePool) -> crate::Result<()> {
         .bind(now) // userModificationDate
         .execute(pool)
         .await
-        .map_err(|e| crate::ThingsError::Database(format!("Failed to insert test area: {e}")))?;
+        .map_err(|e| crate::ThingsError::unknown(format!("Failed to insert test area: {e}")))?;
 
     // Insert test projects (as TMTask with type=1)
     sqlx::query(
@@ -149,7 +149,7 @@ async fn insert_test_data(pool: &sqlx::SqlitePool) -> crate::Result<()> {
     .bind(now_timestamp)
     .bind(0) // Not trashed
     .execute(pool).await
-    .map_err(|e| crate::ThingsError::Database(format!("Failed to insert test project: {e}")))?;
+    .map_err(|e| crate::ThingsError::unknown(format!("Failed to insert test project: {e}")))?;
 
     // Insert test tasks - one in inbox (no project), one in project
     let inbox_task_uuid = ThingsId::new_v4().into_string();
@@ -165,7 +165,7 @@ async fn insert_test_data(pool: &sqlx::SqlitePool) -> crate::Result<()> {
     .bind(now_timestamp)
     .bind(0) // Not trashed
     .execute(pool).await
-    .map_err(|e| crate::ThingsError::Database(format!("Failed to insert inbox test task: {e}")))?;
+    .map_err(|e| crate::ThingsError::unknown(format!("Failed to insert inbox test task: {e}")))?;
 
     sqlx::query(
         "INSERT INTO TMTask (uuid, title, type, status, project, creationDate, userModificationDate, trashed) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
@@ -179,7 +179,7 @@ async fn insert_test_data(pool: &sqlx::SqlitePool) -> crate::Result<()> {
     .bind(now_timestamp)
     .bind(0) // Not trashed
     .execute(pool).await
-    .map_err(|e| crate::ThingsError::Database(format!("Failed to insert test task: {e}")))?;
+    .map_err(|e| crate::ThingsError::unknown(format!("Failed to insert test task: {e}")))?;
 
     // Insert a heading task (type=2) inside the project
     let heading_uuid = ThingsId::new_v4().into_string();
@@ -195,7 +195,7 @@ async fn insert_test_data(pool: &sqlx::SqlitePool) -> crate::Result<()> {
     .bind(now_timestamp)
     .bind(0) // Not trashed
     .execute(pool).await
-    .map_err(|e| crate::ThingsError::Database(format!("Failed to insert test heading: {e}")))?;
+    .map_err(|e| crate::ThingsError::unknown(format!("Failed to insert test heading: {e}")))?;
 
     Ok(())
 }
@@ -806,7 +806,7 @@ mod tests {
 pub async fn create_test_database_and_connect(
 ) -> Result<(ThingsDatabase, NamedTempFile), crate::ThingsError> {
     let temp_file = NamedTempFile::new()
-        .map_err(|e| crate::ThingsError::Database(format!("Failed to create temp file: {e}")))?;
+        .map_err(|e| crate::ThingsError::unknown(format!("Failed to create temp file: {e}")))?;
     let db_path = temp_file.path();
     create_test_database(db_path).await?;
     let db = ThingsDatabase::new(db_path).await?;

--- a/libs/things3-core/src/test_utils.rs
+++ b/libs/things3-core/src/test_utils.rs
@@ -17,9 +17,11 @@ pub async fn create_test_database<P: AsRef<Path>>(db_path: P) -> crate::Result<(
     use sqlx::SqlitePool;
 
     let database_url = format!("sqlite:{}", db_path.as_ref().display());
-    let pool = SqlitePool::connect(&database_url)
-        .await
-        .map_err(|e| crate::ThingsError::unknown(format!("Failed to connect to database: {e}")))?;
+    let pool = SqlitePool::connect(&database_url).await.map_err(|e| {
+        crate::ThingsError::Database(crate::ThingsDatabaseError::Database(format!(
+            "Failed to connect to database: {e}"
+        )))
+    })?;
 
     // Create the Things 3 schema - matches real database structure
     sqlx::query(
@@ -48,7 +50,11 @@ pub async fn create_test_database<P: AsRef<Path>>(db_path: P) -> crate::Result<(
     )
     .execute(&pool)
     .await
-    .map_err(|e| crate::ThingsError::unknown(format!("Failed to create TMTask table: {e}")))?;
+    .map_err(|e| {
+        crate::ThingsError::Database(crate::ThingsDatabaseError::Database(format!(
+            "Failed to create TMTask table: {e}"
+        )))
+    })?;
 
     // Note: Projects are stored in TMTask table with type=1, no separate TMProject table
 
@@ -67,7 +73,11 @@ pub async fn create_test_database<P: AsRef<Path>>(db_path: P) -> crate::Result<(
     )
     .execute(&pool)
     .await
-    .map_err(|e| crate::ThingsError::unknown(format!("Failed to create TMArea table: {e}")))?;
+    .map_err(|e| {
+        crate::ThingsError::Database(crate::ThingsDatabaseError::Database(format!(
+            "Failed to create TMArea table: {e}"
+        )))
+    })?;
 
     // Create TMTag table — schema mirrors real Things 3 (no creationDate/userModificationDate).
     sqlx::query(
@@ -85,7 +95,11 @@ pub async fn create_test_database<P: AsRef<Path>>(db_path: P) -> crate::Result<(
     )
     .execute(&pool)
     .await
-    .map_err(|e| crate::ThingsError::unknown(format!("Failed to create TMTag table: {e}")))?;
+    .map_err(|e| {
+        crate::ThingsError::Database(crate::ThingsDatabaseError::Database(format!(
+            "Failed to create TMTag table: {e}"
+        )))
+    })?;
 
     // Create TMTaskTag join table — maps tasks to tags by UUID
     sqlx::query(
@@ -99,7 +113,11 @@ pub async fn create_test_database<P: AsRef<Path>>(db_path: P) -> crate::Result<(
     )
     .execute(&pool)
     .await
-    .map_err(|e| crate::ThingsError::unknown(format!("Failed to create TMTaskTag table: {e}")))?;
+    .map_err(|e| {
+        crate::ThingsError::Database(crate::ThingsDatabaseError::Database(format!(
+            "Failed to create TMTaskTag table: {e}"
+        )))
+    })?;
 
     // Insert test data
     insert_test_data(&pool).await?;
@@ -134,7 +152,7 @@ async fn insert_test_data(pool: &sqlx::SqlitePool) -> crate::Result<()> {
         .bind(now) // userModificationDate
         .execute(pool)
         .await
-        .map_err(|e| crate::ThingsError::unknown(format!("Failed to insert test area: {e}")))?;
+        .map_err(|e| crate::ThingsError::Database(crate::ThingsDatabaseError::Database(format!("Failed to insert test area: {e}"))))?;
 
     // Insert test projects (as TMTask with type=1)
     sqlx::query(
@@ -149,7 +167,7 @@ async fn insert_test_data(pool: &sqlx::SqlitePool) -> crate::Result<()> {
     .bind(now_timestamp)
     .bind(0) // Not trashed
     .execute(pool).await
-    .map_err(|e| crate::ThingsError::unknown(format!("Failed to insert test project: {e}")))?;
+    .map_err(|e| crate::ThingsError::Database(crate::ThingsDatabaseError::Database(format!("Failed to insert test project: {e}"))))?;
 
     // Insert test tasks - one in inbox (no project), one in project
     let inbox_task_uuid = ThingsId::new_v4().into_string();
@@ -165,7 +183,7 @@ async fn insert_test_data(pool: &sqlx::SqlitePool) -> crate::Result<()> {
     .bind(now_timestamp)
     .bind(0) // Not trashed
     .execute(pool).await
-    .map_err(|e| crate::ThingsError::unknown(format!("Failed to insert inbox test task: {e}")))?;
+    .map_err(|e| crate::ThingsError::Database(crate::ThingsDatabaseError::Database(format!("Failed to insert inbox test task: {e}"))))?;
 
     sqlx::query(
         "INSERT INTO TMTask (uuid, title, type, status, project, creationDate, userModificationDate, trashed) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
@@ -179,7 +197,7 @@ async fn insert_test_data(pool: &sqlx::SqlitePool) -> crate::Result<()> {
     .bind(now_timestamp)
     .bind(0) // Not trashed
     .execute(pool).await
-    .map_err(|e| crate::ThingsError::unknown(format!("Failed to insert test task: {e}")))?;
+    .map_err(|e| crate::ThingsError::Database(crate::ThingsDatabaseError::Database(format!("Failed to insert test task: {e}"))))?;
 
     // Insert a heading task (type=2) inside the project
     let heading_uuid = ThingsId::new_v4().into_string();
@@ -195,7 +213,7 @@ async fn insert_test_data(pool: &sqlx::SqlitePool) -> crate::Result<()> {
     .bind(now_timestamp)
     .bind(0) // Not trashed
     .execute(pool).await
-    .map_err(|e| crate::ThingsError::unknown(format!("Failed to insert test heading: {e}")))?;
+    .map_err(|e| crate::ThingsError::Database(crate::ThingsDatabaseError::Database(format!("Failed to insert test heading: {e}"))))?;
 
     Ok(())
 }
@@ -805,8 +823,7 @@ mod tests {
 /// Returns an error if database creation or connection fails
 pub async fn create_test_database_and_connect(
 ) -> Result<(ThingsDatabase, NamedTempFile), crate::ThingsError> {
-    let temp_file = NamedTempFile::new()
-        .map_err(|e| crate::ThingsError::unknown(format!("Failed to create temp file: {e}")))?;
+    let temp_file = NamedTempFile::new()?;
     let db_path = temp_file.path();
     create_test_database(db_path).await?;
     let db = ThingsDatabase::new(db_path).await?;

--- a/libs/things3-core/tests/bulk_operations_tests.rs
+++ b/libs/things3-core/tests/bulk_operations_tests.rs
@@ -7,7 +7,7 @@ use things3_core::models::{
     BulkCompleteRequest, BulkDeleteRequest, BulkMoveRequest, BulkUpdateDatesRequest,
 };
 use things3_core::test_utils::{create_test_database_and_connect, TaskRequestBuilder};
-use things3_core::{ThingsError, ThingsId};
+use things3_core::{ThingsDatabaseError, ThingsError, ThingsId, ThingsQueryError};
 
 // ============================================================================
 // Bulk Move Tests
@@ -138,7 +138,12 @@ async fn test_bulk_move_invalid_uuid() {
 
     let result = db.bulk_move(bulk_request).await;
     assert!(result.is_err());
-    assert!(matches!(result, Err(ThingsError::TaskNotFound { .. })));
+    assert!(matches!(
+        result,
+        Err(ThingsError::Database(
+            ThingsDatabaseError::TaskNotFound { .. }
+        ))
+    ));
 
     // Verify the valid task was NOT moved (transaction rolled back)
     let task = db.get_task_by_uuid(&valid_uuid).await.unwrap().unwrap();
@@ -166,7 +171,12 @@ async fn test_bulk_move_nonexistent_project() {
 
     let result = db.bulk_move(bulk_request).await;
     assert!(result.is_err());
-    assert!(matches!(result, Err(ThingsError::ProjectNotFound { .. })));
+    assert!(matches!(
+        result,
+        Err(ThingsError::Database(
+            ThingsDatabaseError::ProjectNotFound { .. }
+        ))
+    ));
 }
 
 // ============================================================================
@@ -268,7 +278,10 @@ async fn test_bulk_update_dates_invalid_range() {
 
     let result = db.bulk_update_dates(bulk_request).await;
     assert!(result.is_err());
-    assert!(matches!(result, Err(ThingsError::DateValidation(_))));
+    assert!(matches!(
+        result,
+        Err(ThingsError::Query(ThingsQueryError::DateValidation(_)))
+    ));
 }
 
 #[tokio::test]
@@ -294,7 +307,10 @@ async fn test_bulk_update_dates_merge_validation() {
 
     let result = db.bulk_update_dates(bulk_request).await;
     assert!(result.is_err());
-    assert!(matches!(result, Err(ThingsError::DateValidation(_))));
+    assert!(matches!(
+        result,
+        Err(ThingsError::Query(ThingsQueryError::DateValidation(_)))
+    ));
 }
 
 // ============================================================================

--- a/libs/things3-core/tests/date_handling_tests.rs
+++ b/libs/things3-core/tests/date_handling_tests.rs
@@ -9,7 +9,7 @@ use things3_core::database::{
     is_valid_things_timestamp, parse_date_from_string, safe_naive_date_to_things_timestamp,
     safe_things_date_to_naive_date, validate_date_range, DateConversionError, DateValidationError,
 };
-use things3_core::ThingsError;
+use things3_core::{ThingsError, ThingsQueryError};
 
 #[cfg(feature = "test-utils")]
 use things3_core::test_utils::{create_test_database_and_connect, TaskRequestBuilder};
@@ -293,7 +293,10 @@ async fn test_create_task_with_invalid_dates() {
     // This should fail validation
     let result = db.create_task(request).await;
     assert!(result.is_err());
-    assert!(matches!(result, Err(ThingsError::DateValidation(_))));
+    assert!(matches!(
+        result,
+        Err(ThingsError::Query(ThingsQueryError::DateValidation(_)))
+    ));
 }
 
 #[cfg(feature = "test-utils")]
@@ -324,7 +327,10 @@ async fn test_update_task_deadline_before_start() {
     // This should fail validation
     let result = db.update_task(update_request).await;
     assert!(result.is_err());
-    assert!(matches!(result, Err(ThingsError::DateValidation(_))));
+    assert!(matches!(
+        result,
+        Err(ThingsError::Query(ThingsQueryError::DateValidation(_)))
+    ));
 }
 
 #[cfg(feature = "test-utils")]


### PR DESCRIPTION
Closes #200

## Summary

- Introduces three `#[non_exhaustive]` domain-specific error enums as part of the 3.0 API evolution:
  - **`ThingsDatabaseError`** — DB/connection/not-found/AppleScript/configuration variants (moved out of `ThingsError`)
  - **`ThingsQueryError`** — UUID/date parse and validation variants (moved out of `ThingsError`)
  - **`ThingsExportError`** — export IO/serialization failures (new, for future 3.0 use)
- `ThingsError` is retained as a `#[non_exhaustive]` sum type wrapping the three new enums plus `Io`, `Serialization`, `Validation`, and deprecated `Unknown`
- `From<SubError> for ThingsError` impls are generated via `#[from]`; two explicit `From` impls preserve the `DateValidationError`/`DateConversionError` → `ThingsError` chains used at DB-layer call sites
- All call sites updated across `things3-core` and `things3-cli` (15 source files + 2 integration test files)

## Test plan

- [x] `cargo test -p things3-core --lib` — 541 passed
- [x] `cargo test -p things3-core --features advanced-queries --lib` — 618 passed
- [x] `cargo test --features test-utils` (pre-push hook) — all integration tests pass
- [x] `cargo clippy -p things3-core --lib --features advanced-queries -- -D warnings` — clean
- [x] `cargo clippy -p things3-cli -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)