### PR TITLE
feat(core): trait-based ThingsDatabase abstraction — async trait + SqliteThingsDatabase (3.0) (#202)

### DIFF
--- a/apps/things3-cli/src/bin/test_mcp_real_data.rs
+++ b/apps/things3-cli/src/bin/test_mcp_real_data.rs
@@ -10,7 +10,7 @@ use serde_json::Value;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
-use things3_core::ThingsDatabase;
+use things3_core::SqliteThingsDatabase;
 use tracing::{error, info, warn};
 
 /// Test mode selection
@@ -91,7 +91,7 @@ async fn main() -> Result<()> {
 }
 
 struct TestRunner {
-    db: Arc<ThingsDatabase>,
+    db: Arc<SqliteThingsDatabase>,
     verbose: bool,
     #[allow(dead_code)]
     json_output: bool,
@@ -102,7 +102,7 @@ impl TestRunner {
         info!("Setting up test environment...");
 
         // Create database connection in read-only mode
-        let db = ThingsDatabase::new(&db_path).await?;
+        let db = SqliteThingsDatabase::new(&db_path).await?;
 
         Ok(Self {
             db: Arc::new(db),

--- a/apps/things3-cli/src/bin/test_mcp_real_data.rs
+++ b/apps/things3-cli/src/bin/test_mcp_real_data.rs
@@ -10,7 +10,7 @@ use serde_json::Value;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
-use things3_core::{ThingsConfig, ThingsDatabase};
+use things3_core::ThingsDatabase;
 use tracing::{error, info, warn};
 
 /// Test mode selection
@@ -102,8 +102,7 @@ impl TestRunner {
         info!("Setting up test environment...");
 
         // Create database connection in read-only mode
-        let config = ThingsConfig::new(db_path, false);
-        let db = ThingsDatabase::new(&config.database_path).await?;
+        let db = ThingsDatabase::new(&db_path).await?;
 
         Ok(Self {
             db: Arc::new(db),

--- a/apps/things3-cli/src/bulk_operations.rs
+++ b/apps/things3-cli/src/bulk_operations.rs
@@ -6,7 +6,7 @@ use crate::progress::{ProgressManager, ProgressTracker};
 use std::sync::Arc;
 use things3_core::models::ThingsId;
 use things3_core::Result;
-use things3_core::{Task, ThingsDatabase};
+use things3_core::{SqliteThingsDatabase, Task};
 
 /// Bulk operations manager
 pub struct BulkOperationsManager {
@@ -28,7 +28,11 @@ impl BulkOperationsManager {
     ///
     /// # Errors
     /// Returns an error if the export operation fails
-    pub async fn export_all_tasks(&self, db: &ThingsDatabase, format: &str) -> Result<Vec<Task>> {
+    pub async fn export_all_tasks(
+        &self,
+        db: &SqliteThingsDatabase,
+        format: &str,
+    ) -> Result<Vec<Task>> {
         let tracker = self.progress_manager.create_tracker(
             "Export All Tasks",
             None, // We don't know the total count yet
@@ -83,7 +87,7 @@ impl BulkOperationsManager {
     /// Returns an error if the bulk update operation fails
     pub async fn bulk_update_task_status(
         &self,
-        _db: &ThingsDatabase,
+        _db: &SqliteThingsDatabase,
         task_ids: Vec<ThingsId>,
         new_status: things3_core::TaskStatus,
     ) -> Result<usize> {
@@ -139,7 +143,7 @@ impl BulkOperationsManager {
     /// Returns an error if the search or processing operation fails
     pub async fn search_and_process_tasks(
         &self,
-        db: &ThingsDatabase,
+        db: &SqliteThingsDatabase,
         query: &str,
         processor: impl Fn(&Task) -> Result<()> + Send + Sync + 'static,
     ) -> Result<Vec<Task>> {
@@ -257,7 +261,7 @@ mod tests {
         let temp_file = tempfile::NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
         create_test_database(db_path).await.unwrap();
-        let db = ThingsDatabase::new(db_path).await.unwrap();
+        let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
         // Note: Progress manager is not started in tests to avoid hanging
         // In real usage, the progress manager would be started separately
@@ -284,7 +288,7 @@ mod tests {
         let temp_file = tempfile::NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
         create_test_database(db_path).await.unwrap();
-        let db = ThingsDatabase::new(db_path).await.unwrap();
+        let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
         // Note: Progress manager is not started in tests to avoid hanging
         // In real usage, the progress manager would be started separately
@@ -304,7 +308,7 @@ mod tests {
         let temp_file = tempfile::NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
         create_test_database(db_path).await.unwrap();
-        let db = ThingsDatabase::new(db_path).await.unwrap();
+        let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
         // Note: Progress manager is not started in tests to avoid hanging
         // In real usage, the progress manager would be started separately
@@ -326,7 +330,7 @@ mod tests {
         let temp_file = tempfile::NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
         create_test_database(db_path).await.unwrap();
-        let db = ThingsDatabase::new(db_path).await.unwrap();
+        let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
         // Note: Progress manager is not started in tests to avoid hanging
         // In real usage, the progress manager would be started separately
@@ -349,7 +353,7 @@ mod tests {
         let temp_file = tempfile::NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
         create_test_database(db_path).await.unwrap();
-        let db = ThingsDatabase::new(db_path).await.unwrap();
+        let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
         let task_ids = vec![];
         let statuses = vec![
@@ -375,7 +379,7 @@ mod tests {
         let temp_file = tempfile::NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
         create_test_database(db_path).await.unwrap();
-        let db = ThingsDatabase::new(db_path).await.unwrap();
+        let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
         // Note: Progress manager is not started in tests to avoid hanging
         // In real usage, the progress manager would be started separately
@@ -397,7 +401,7 @@ mod tests {
         let temp_file = tempfile::NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
         create_test_database(db_path).await.unwrap();
-        let db = ThingsDatabase::new(db_path).await.unwrap();
+        let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
         // Note: Progress manager is not started in tests to avoid hanging
         // In real usage, the progress manager would be started separately
@@ -419,7 +423,7 @@ mod tests {
         let temp_file = tempfile::NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
         create_test_database(db_path).await.unwrap();
-        let db = ThingsDatabase::new(db_path).await.unwrap();
+        let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
         let limits = vec![1, 5, 10, 100];
 
@@ -497,7 +501,7 @@ mod tests {
         let temp_file = tempfile::NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
         create_test_database(db_path).await.unwrap();
-        let db = ThingsDatabase::new(db_path).await.unwrap();
+        let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
         // Note: Progress manager is not started in tests to avoid hanging
         // In real usage, the progress manager would be started separately
@@ -517,7 +521,7 @@ mod tests {
         let temp_file = tempfile::NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
         create_test_database(db_path).await.unwrap();
-        let db = ThingsDatabase::new(db_path).await.unwrap();
+        let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
         // Note: Progress manager is not started in tests to avoid hanging
         // In real usage, the progress manager would be started separately
@@ -539,7 +543,7 @@ mod tests {
         let temp_file = tempfile::NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
         create_test_database(db_path).await.unwrap();
-        let db = ThingsDatabase::new(db_path).await.unwrap();
+        let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
         // Note: Progress manager is not started in tests to avoid hanging
         // In real usage, the progress manager would be started separately
@@ -561,7 +565,7 @@ mod tests {
         let temp_file = tempfile::NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
         create_test_database(db_path).await.unwrap();
-        let db = ThingsDatabase::new(db_path).await.unwrap();
+        let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
         // Note: Progress manager is not started in tests to avoid hanging
         // In real usage, the progress manager would be started separately
@@ -579,7 +583,7 @@ mod tests {
         let temp_file = tempfile::NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
         create_test_database(db_path).await.unwrap();
-        let _db = ThingsDatabase::new(db_path).await.unwrap();
+        let _db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
         // Note: Progress manager is not started in tests to avoid hanging
         // In real usage, the progress manager would be started separately
@@ -623,7 +627,7 @@ mod tests {
         let db_path = temp_file.path();
         create_test_database(db_path).await.unwrap();
 
-        let db = ThingsDatabase::new(db_path).await.unwrap();
+        let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
         // Test direct database query without progress tracking
         let tasks = db.get_inbox(None).await.unwrap();
@@ -640,7 +644,7 @@ mod tests {
         let db_path = temp_file.path();
         create_test_database(db_path).await.unwrap();
 
-        let db = ThingsDatabase::new(db_path).await.unwrap();
+        let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
         // Test the core functionality without the progress manager
         let tasks = db.get_inbox(Some(5)).await.unwrap();
@@ -663,7 +667,7 @@ mod tests {
         let db_path = temp_file.path();
         create_test_database(db_path).await.unwrap();
 
-        let db = ThingsDatabase::new(db_path).await.unwrap();
+        let db = SqliteThingsDatabase::new(db_path).await.unwrap();
         let manager = BulkOperationsManager::new();
 
         let result = manager

--- a/apps/things3-cli/src/dashboard.rs
+++ b/apps/things3-cli/src/dashboard.rs
@@ -106,7 +106,7 @@ use axum::{
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
-use things3_core::{HealthStatus, ObservabilityManager, ThingsDatabase};
+use things3_core::{HealthStatus, ObservabilityManager, SqliteThingsDatabase};
 use tokio::net::TcpListener;
 use tower_http::cors::CorsLayer;
 use tracing::{info, instrument};
@@ -116,7 +116,7 @@ use tracing::{info, instrument};
 #[derive(Clone)]
 pub struct DashboardState {
     pub observability: Arc<ObservabilityManager>,
-    pub database: Arc<ThingsDatabase>,
+    pub database: Arc<SqliteThingsDatabase>,
 }
 
 /// Dashboard metrics
@@ -188,7 +188,7 @@ impl DashboardServer {
     pub fn new(
         port: u16,
         observability: Arc<ObservabilityManager>,
-        database: Arc<ThingsDatabase>,
+        database: Arc<SqliteThingsDatabase>,
     ) -> Self {
         Self {
             port,
@@ -230,7 +230,7 @@ impl DashboardServer {
 pub struct DashboardServer {
     port: u16,
     observability: Arc<ObservabilityManager>,
-    database: Arc<ThingsDatabase>,
+    database: Arc<SqliteThingsDatabase>,
 }
 
 /// Start the dashboard server
@@ -241,7 +241,7 @@ pub struct DashboardServer {
 pub async fn start_dashboard_server(
     port: u16,
     observability: Arc<ObservabilityManager>,
-    database: Arc<ThingsDatabase>,
+    database: Arc<SqliteThingsDatabase>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let server = DashboardServer::new(port, observability, database);
     server.start().await
@@ -259,7 +259,8 @@ mod tests {
         let db_path = temp_file.path();
 
         let rt = tokio::runtime::Runtime::new().unwrap();
-        let database = Arc::new(rt.block_on(async { ThingsDatabase::new(db_path).await.unwrap() }));
+        let database =
+            Arc::new(rt.block_on(async { SqliteThingsDatabase::new(db_path).await.unwrap() }));
 
         let observability = Arc::new(
             things3_core::ObservabilityManager::new(things3_core::ObservabilityConfig::default())
@@ -453,7 +454,8 @@ mod tests {
         let db_path = temp_file.path();
 
         let rt = tokio::runtime::Runtime::new().unwrap();
-        let database = Arc::new(rt.block_on(async { ThingsDatabase::new(db_path).await.unwrap() }));
+        let database =
+            Arc::new(rt.block_on(async { SqliteThingsDatabase::new(db_path).await.unwrap() }));
 
         let observability = Arc::new(
             things3_core::ObservabilityManager::new(things3_core::ObservabilityConfig::default())

--- a/apps/things3-cli/src/dashboard.rs
+++ b/apps/things3-cli/src/dashboard.rs
@@ -258,11 +258,8 @@ mod tests {
         let temp_file = NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
 
-        let config = things3_core::ThingsConfig::new(db_path, false);
         let rt = tokio::runtime::Runtime::new().unwrap();
-        let database = Arc::new(
-            rt.block_on(async { ThingsDatabase::new(&config.database_path).await.unwrap() }),
-        );
+        let database = Arc::new(rt.block_on(async { ThingsDatabase::new(db_path).await.unwrap() }));
 
         let observability = Arc::new(
             things3_core::ObservabilityManager::new(things3_core::ObservabilityConfig::default())
@@ -455,11 +452,8 @@ mod tests {
         let temp_file = NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
 
-        let config = things3_core::ThingsConfig::new(db_path, false);
         let rt = tokio::runtime::Runtime::new().unwrap();
-        let database = Arc::new(
-            rt.block_on(async { ThingsDatabase::new(&config.database_path).await.unwrap() }),
-        );
+        let database = Arc::new(rt.block_on(async { ThingsDatabase::new(db_path).await.unwrap() }));
 
         let observability = Arc::new(
             things3_core::ObservabilityManager::new(things3_core::ObservabilityConfig::default())

--- a/apps/things3-cli/src/health.rs
+++ b/apps/things3-cli/src/health.rs
@@ -171,11 +171,8 @@ mod tests {
         let temp_file = NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
 
-        let config = things3_core::ThingsConfig::new(db_path, false);
         let rt = tokio::runtime::Runtime::new().unwrap();
-        let database = Arc::new(
-            rt.block_on(async { ThingsDatabase::new(&config.database_path).await.unwrap() }),
-        );
+        let database = Arc::new(rt.block_on(async { ThingsDatabase::new(db_path).await.unwrap() }));
 
         let observability = Arc::new(
             things3_core::ObservabilityManager::new(things3_core::ObservabilityConfig::default())
@@ -267,11 +264,8 @@ mod tests {
         let temp_file = NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
 
-        let config = things3_core::ThingsConfig::new(db_path, false);
         let rt = tokio::runtime::Runtime::new().unwrap();
-        let database = Arc::new(
-            rt.block_on(async { ThingsDatabase::new(&config.database_path).await.unwrap() }),
-        );
+        let database = Arc::new(rt.block_on(async { ThingsDatabase::new(db_path).await.unwrap() }));
 
         let observability = Arc::new(
             things3_core::ObservabilityManager::new(things3_core::ObservabilityConfig::default())
@@ -292,11 +286,8 @@ mod tests {
         let temp_file = NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
 
-        let config = things3_core::ThingsConfig::new(db_path, false);
         let rt = tokio::runtime::Runtime::new().unwrap();
-        let database = Arc::new(
-            rt.block_on(async { ThingsDatabase::new(&config.database_path).await.unwrap() }),
-        );
+        let database = Arc::new(rt.block_on(async { ThingsDatabase::new(db_path).await.unwrap() }));
 
         let observability = Arc::new(
             things3_core::ObservabilityManager::new(things3_core::ObservabilityConfig::default())

--- a/apps/things3-cli/src/health.rs
+++ b/apps/things3-cli/src/health.rs
@@ -66,7 +66,7 @@ async fn metrics_endpoint(State(state): State<AppState>) -> Result<String, Statu
 use axum::{extract::State, http::StatusCode, response::Json, routing::get, Router};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use things3_core::{ObservabilityManager, ThingsDatabase};
+use things3_core::{ObservabilityManager, SqliteThingsDatabase};
 use tokio::net::TcpListener;
 use tower_http::cors::CorsLayer;
 use tracing::{info, instrument};
@@ -76,7 +76,7 @@ use tracing::{info, instrument};
 #[derive(Clone)]
 pub struct AppState {
     pub observability: Arc<ObservabilityManager>,
-    pub database: Arc<ThingsDatabase>,
+    pub database: Arc<SqliteThingsDatabase>,
 }
 
 /// Health response
@@ -103,7 +103,7 @@ impl HealthServer {
     pub fn new(
         port: u16,
         observability: Arc<ObservabilityManager>,
-        database: Arc<ThingsDatabase>,
+        database: Arc<SqliteThingsDatabase>,
     ) -> Self {
         Self {
             port,
@@ -143,7 +143,7 @@ impl HealthServer {
 pub struct HealthServer {
     port: u16,
     observability: Arc<ObservabilityManager>,
-    database: Arc<ThingsDatabase>,
+    database: Arc<SqliteThingsDatabase>,
 }
 
 /// Start the health check server
@@ -154,7 +154,7 @@ pub struct HealthServer {
 pub async fn start_health_server(
     port: u16,
     observability: Arc<ObservabilityManager>,
-    database: Arc<ThingsDatabase>,
+    database: Arc<SqliteThingsDatabase>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let server = HealthServer::new(port, observability, database);
     server.start().await
@@ -172,7 +172,8 @@ mod tests {
         let db_path = temp_file.path();
 
         let rt = tokio::runtime::Runtime::new().unwrap();
-        let database = Arc::new(rt.block_on(async { ThingsDatabase::new(db_path).await.unwrap() }));
+        let database =
+            Arc::new(rt.block_on(async { SqliteThingsDatabase::new(db_path).await.unwrap() }));
 
         let observability = Arc::new(
             things3_core::ObservabilityManager::new(things3_core::ObservabilityConfig::default())
@@ -265,7 +266,8 @@ mod tests {
         let db_path = temp_file.path();
 
         let rt = tokio::runtime::Runtime::new().unwrap();
-        let database = Arc::new(rt.block_on(async { ThingsDatabase::new(db_path).await.unwrap() }));
+        let database =
+            Arc::new(rt.block_on(async { SqliteThingsDatabase::new(db_path).await.unwrap() }));
 
         let observability = Arc::new(
             things3_core::ObservabilityManager::new(things3_core::ObservabilityConfig::default())
@@ -287,7 +289,8 @@ mod tests {
         let db_path = temp_file.path();
 
         let rt = tokio::runtime::Runtime::new().unwrap();
-        let database = Arc::new(rt.block_on(async { ThingsDatabase::new(db_path).await.unwrap() }));
+        let database =
+            Arc::new(rt.block_on(async { SqliteThingsDatabase::new(db_path).await.unwrap() }));
 
         let observability = Arc::new(
             things3_core::ObservabilityManager::new(things3_core::ObservabilityConfig::default())

--- a/apps/things3-cli/src/lib.rs
+++ b/apps/things3-cli/src/lib.rs
@@ -24,7 +24,7 @@ pub mod metrics;
 pub mod monitoring;
 
 pub mod progress;
-// pub mod thread_safe_db; // Removed - ThingsDatabase is now Send + Sync
+// pub mod thread_safe_db; // Removed - SqliteThingsDatabase is now Send + Sync
 pub mod websocket;
 
 use crate::events::EventBroadcaster;
@@ -33,7 +33,7 @@ use clap::{Parser, Subcommand};
 use std::io::Write;
 use std::path::PathBuf;
 use std::sync::Arc;
-use things3_core::{Result, ThingsDatabase};
+use things3_core::{Result, SqliteThingsDatabase};
 
 #[derive(Parser, Debug)]
 #[command(name = "things3")]
@@ -170,11 +170,11 @@ pub enum BulkOperation {
 ///
 /// ```no_run
 /// use things3_cli::print_tasks;
-/// use things3_core::ThingsDatabase;
+/// use things3_core::SqliteThingsDatabase;
 /// use std::io;
 ///
 /// # async fn example() -> things3_core::Result<()> {
-/// let db = ThingsDatabase::new(std::path::Path::new("test.db")).await?;
+/// let db = SqliteThingsDatabase::new(std::path::Path::new("test.db")).await?;
 /// let tasks = db.get_inbox(Some(10)).await?;
 /// print_tasks(&db, &tasks, &mut io::stdout())?;
 /// # Ok(())
@@ -184,7 +184,7 @@ pub enum BulkOperation {
 /// # Errors
 /// Returns an error if writing fails
 pub fn print_tasks<W: Write>(
-    _db: &ThingsDatabase,
+    _db: &SqliteThingsDatabase,
     tasks: &[things3_core::Task],
     writer: &mut W,
 ) -> Result<()> {
@@ -216,11 +216,11 @@ pub fn print_tasks<W: Write>(
 ///
 /// ```no_run
 /// use things3_cli::print_projects;
-/// use things3_core::ThingsDatabase;
+/// use things3_core::SqliteThingsDatabase;
 /// use std::io;
 ///
 /// # async fn example() -> things3_core::Result<()> {
-/// let db = ThingsDatabase::new(std::path::Path::new("test.db")).await?;
+/// let db = SqliteThingsDatabase::new(std::path::Path::new("test.db")).await?;
 /// let projects = db.get_projects(None).await?;
 /// print_projects(&db, &projects, &mut io::stdout())?;
 /// # Ok(())
@@ -230,7 +230,7 @@ pub fn print_tasks<W: Write>(
 /// # Errors
 /// Returns an error if writing fails
 pub fn print_projects<W: Write>(
-    _db: &ThingsDatabase,
+    _db: &SqliteThingsDatabase,
     projects: &[things3_core::Project],
     writer: &mut W,
 ) -> Result<()> {
@@ -262,11 +262,11 @@ pub fn print_projects<W: Write>(
 ///
 /// ```no_run
 /// use things3_cli::print_areas;
-/// use things3_core::ThingsDatabase;
+/// use things3_core::SqliteThingsDatabase;
 /// use std::io;
 ///
 /// # async fn example() -> things3_core::Result<()> {
-/// let db = ThingsDatabase::new(std::path::Path::new("test.db")).await?;
+/// let db = SqliteThingsDatabase::new(std::path::Path::new("test.db")).await?;
 /// let areas = db.get_areas().await?;
 /// print_areas(&db, &areas, &mut io::stdout())?;
 /// # Ok(())
@@ -276,7 +276,7 @@ pub fn print_projects<W: Write>(
 /// # Errors
 /// Returns an error if writing fails
 pub fn print_areas<W: Write>(
-    _db: &ThingsDatabase,
+    _db: &SqliteThingsDatabase,
     areas: &[things3_core::Area],
     writer: &mut W,
 ) -> Result<()> {
@@ -305,10 +305,10 @@ pub fn print_areas<W: Write>(
 ///
 /// ```no_run
 /// use things3_cli::health_check;
-/// use things3_core::ThingsDatabase;
+/// use things3_core::SqliteThingsDatabase;
 ///
 /// # async fn example() -> things3_core::Result<()> {
-/// let db = ThingsDatabase::new(std::path::Path::new("test.db")).await?;
+/// let db = SqliteThingsDatabase::new(std::path::Path::new("test.db")).await?;
 /// health_check(&db).await?;
 /// # Ok(())
 /// # }
@@ -316,7 +316,7 @@ pub fn print_areas<W: Write>(
 ///
 /// # Errors
 /// Returns an error if the database is not accessible
-pub async fn health_check(db: &ThingsDatabase) -> Result<()> {
+pub async fn health_check(db: &SqliteThingsDatabase) -> Result<()> {
     println!("🔍 Checking Things 3 database connection...");
 
     // Check if database is connected
@@ -343,7 +343,7 @@ pub async fn health_check(db: &ThingsDatabase) -> Result<()> {
 // ///
 // /// # Errors
 // /// Returns an error if the server fails to start
-// pub fn start_mcp_server(db: Arc<SqlxThingsDatabase>, config: ThingsConfig) -> Result<()> {
+// pub fn start_mcp_server(db: Arc<SqlxSqliteThingsDatabase>, config: ThingsConfig) -> Result<()> {
 //     println!("🚀 Starting MCP server...");
 //     println!("🚧 MCP server is temporarily disabled during SQLx migration");
 //     Err(things3_core::ThingsError::unknown("MCP server temporarily disabled".to_string()))
@@ -419,7 +419,7 @@ mod tests {
         let db_path = temp_file.path();
         let rt = Runtime::new().unwrap();
         rt.block_on(async { create_test_database(db_path).await.unwrap() });
-        let db = rt.block_on(async { ThingsDatabase::new(db_path).await.unwrap() });
+        let db = rt.block_on(async { SqliteThingsDatabase::new(db_path).await.unwrap() });
         let result = rt.block_on(async { health_check(&db).await });
         assert!(result.is_ok());
     }
@@ -430,7 +430,7 @@ mod tests {
         let temp_file = tempfile::NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
         create_test_database(db_path).await.unwrap();
-        let db = ThingsDatabase::new(db_path).await.unwrap();
+        let db = SqliteThingsDatabase::new(db_path).await.unwrap();
         let config = things3_core::ThingsConfig::default();
 
         // Note: We can't actually run start_mcp_server in a test because it's an infinite

--- a/apps/things3-cli/src/main.rs
+++ b/apps/things3-cli/src/main.rs
@@ -80,13 +80,16 @@ This flag exists for emergency recovery only and will be removed.
 
     // Create configuration
     let config = if let Some(db_path) = cli.database {
-        ThingsConfig::new(db_path, cli.fallback_to_default)
+        ThingsConfig::builder()
+            .database_path(db_path)
+            .fallback_to_default(cli.fallback_to_default)
+            .build()?
     } else {
         ThingsConfig::from_env()
     };
 
     // Create database connection
-    let db = ThingsDatabase::new(&config.database_path).await?;
+    let db = ThingsDatabase::new(config.database_path()).await?;
     let db = Arc::new(db);
 
     match cli.command {
@@ -197,7 +200,6 @@ This flag exists for emergency recovery only and will be removed.
 }
 
 #[cfg(test)]
-#[allow(deprecated)]
 mod tests {
     use super::*;
     use std::io::Cursor;
@@ -212,8 +214,7 @@ mod tests {
         let db_path = temp_file.path();
         create_test_database(db_path).await.unwrap();
 
-        let config = ThingsConfig::new(db_path, false);
-        let db = ThingsDatabase::new(&config.database_path).await.unwrap();
+        let db = ThingsDatabase::new(db_path).await.unwrap();
 
         // Test inbox command
         let cli = Cli::try_parse_from(["things-cli", "inbox"]).unwrap();
@@ -235,8 +236,7 @@ mod tests {
         let db_path = temp_file.path();
         create_test_database(db_path).await.unwrap();
 
-        let config = ThingsConfig::new(db_path, false);
-        let db = ThingsDatabase::new(&config.database_path).await.unwrap();
+        let db = ThingsDatabase::new(db_path).await.unwrap();
 
         // Test today command
         let cli = Cli::try_parse_from(["things-cli", "today"]).unwrap();
@@ -258,8 +258,7 @@ mod tests {
         let db_path = temp_file.path();
         create_test_database(db_path).await.unwrap();
 
-        let config = ThingsConfig::new(db_path, false);
-        let db = ThingsDatabase::new(&config.database_path).await.unwrap();
+        let db = ThingsDatabase::new(db_path).await.unwrap();
 
         // Test projects command
         let cli = Cli::try_parse_from(["things-cli", "projects"]).unwrap();
@@ -287,8 +286,7 @@ mod tests {
         let db_path = temp_file.path();
         create_test_database(db_path).await.unwrap();
 
-        let config = ThingsConfig::new(db_path, false);
-        let db = ThingsDatabase::new(&config.database_path).await.unwrap();
+        let db = ThingsDatabase::new(db_path).await.unwrap();
 
         // Test areas command
         let cli = Cli::try_parse_from(["things-cli", "areas"]).unwrap();
@@ -315,8 +313,7 @@ mod tests {
         let db_path = temp_file.path();
         create_test_database(db_path).await.unwrap();
 
-        let config = ThingsConfig::new(db_path, false);
-        let db = ThingsDatabase::new(&config.database_path).await.unwrap();
+        let db = ThingsDatabase::new(db_path).await.unwrap();
 
         // Test search command
         let cli = Cli::try_parse_from(["things-cli", "search", "test"]).unwrap();
@@ -338,8 +335,7 @@ mod tests {
         let db_path = temp_file.path();
         create_test_database(db_path).await.unwrap();
 
-        let config = ThingsConfig::new(db_path, false);
-        let db = ThingsDatabase::new(&config.database_path).await.unwrap();
+        let db = ThingsDatabase::new(db_path).await.unwrap();
 
         // Test health command
         let cli = Cli::try_parse_from(["things-cli", "health"]).unwrap();
@@ -358,8 +354,11 @@ mod tests {
         let db_path = temp_file.path();
         create_test_database(db_path).await.unwrap();
 
-        let config = ThingsConfig::new(db_path, false);
-        let db = ThingsDatabase::new(&config.database_path).await.unwrap();
+        let config = ThingsConfig::builder()
+            .database_path(db_path)
+            .build()
+            .unwrap();
+        let db = ThingsDatabase::new(config.database_path()).await.unwrap();
 
         // Test MCP command
         let cli = Cli::try_parse_from(["things-cli", "mcp"]).unwrap();
@@ -380,8 +379,7 @@ mod tests {
         let db_path = temp_file.path();
         create_test_database(db_path).await.unwrap();
 
-        let config = ThingsConfig::new(db_path, false);
-        let db = ThingsDatabase::new(&config.database_path).await.unwrap();
+        let db = ThingsDatabase::new(db_path).await.unwrap();
 
         // Test with verbose flag
         let cli = Cli::try_parse_from(["things-cli", "--verbose", "inbox"]).unwrap();
@@ -415,8 +413,7 @@ mod tests {
         .unwrap();
         assert_eq!(cli.database, Some(db_path.to_path_buf()));
 
-        let config = ThingsConfig::new(db_path, false);
-        let db = ThingsDatabase::new(&config.database_path).await.unwrap();
+        let db = ThingsDatabase::new(db_path).await.unwrap();
 
         match cli.command {
             Commands::Inbox { limit } => {
@@ -440,8 +437,7 @@ mod tests {
         let cli = Cli::try_parse_from(["things-cli", "--fallback-to-default", "inbox"]).unwrap();
         assert!(cli.fallback_to_default);
 
-        let config = ThingsConfig::new(db_path, false);
-        let db = ThingsDatabase::new(&config.database_path).await.unwrap();
+        let db = ThingsDatabase::new(db_path).await.unwrap();
 
         match cli.command {
             Commands::Inbox { limit } => {
@@ -461,8 +457,7 @@ mod tests {
         let db_path = temp_file.path();
         create_test_database(db_path).await.unwrap();
 
-        let config = ThingsConfig::new(db_path, false);
-        let db = ThingsDatabase::new(&config.database_path).await.unwrap();
+        let db = ThingsDatabase::new(db_path).await.unwrap();
 
         // Test with limit
         let cli = Cli::try_parse_from(["things-cli", "inbox", "--limit", "5"]).unwrap();
@@ -484,14 +479,16 @@ mod tests {
         // Test configuration creation from environment
         let cli = Cli::try_parse_from(["things-cli", "inbox"]).unwrap();
 
-        // Test that config creation doesn't panic
         let config = if let Some(db_path) = cli.database {
-            ThingsConfig::new(db_path, cli.fallback_to_default)
+            ThingsConfig::builder()
+                .database_path(db_path)
+                .fallback_to_default(cli.fallback_to_default)
+                .build()
+                .unwrap()
         } else {
             ThingsConfig::from_env()
         };
 
-        // Just verify it creates a config (it might fail due to missing database, but that's ok)
         let _ = config;
     }
 
@@ -500,7 +497,6 @@ mod tests {
         let temp_file = NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
 
-        // Test configuration creation with database path
         let cli = Cli::try_parse_from([
             "things-cli",
             "--database",
@@ -510,13 +506,15 @@ mod tests {
         .unwrap();
 
         let config = if let Some(db_path) = cli.database {
-            ThingsConfig::new(db_path, cli.fallback_to_default)
+            ThingsConfig::builder()
+                .database_path(db_path)
+                .fallback_to_default(cli.fallback_to_default)
+                .build()
+                .unwrap()
         } else {
             ThingsConfig::from_env()
         };
 
-        // This should work since we're providing a valid path
-        // Just verify it creates a config (ThingsConfig::new doesn't return a Result)
         let _ = config;
     }
 

--- a/apps/things3-cli/src/main.rs
+++ b/apps/things3-cli/src/main.rs
@@ -8,7 +8,7 @@ use things3_cli::mcp::start_mcp_server;
 #[cfg(all(feature = "mcp-server", feature = "observability"))]
 use things3_cli::mcp::start_mcp_server_with_config;
 use things3_cli::{start_websocket_server, watch_updates, Cli, Commands};
-use things3_core::{Result, ThingsConfig, ThingsDatabase};
+use things3_core::{Result, SqliteThingsDatabase, ThingsConfig};
 
 #[cfg(all(feature = "mcp-server", feature = "observability"))]
 use things3_core::load_config;
@@ -89,7 +89,7 @@ This flag exists for emergency recovery only and will be removed.
     };
 
     // Create database connection
-    let db = ThingsDatabase::new(config.database_path()).await?;
+    let db = SqliteThingsDatabase::new(config.database_path()).await?;
     let db = Arc::new(db);
 
     match cli.command {
@@ -214,7 +214,7 @@ mod tests {
         let db_path = temp_file.path();
         create_test_database(db_path).await.unwrap();
 
-        let db = ThingsDatabase::new(db_path).await.unwrap();
+        let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
         // Test inbox command
         let cli = Cli::try_parse_from(["things-cli", "inbox"]).unwrap();
@@ -236,7 +236,7 @@ mod tests {
         let db_path = temp_file.path();
         create_test_database(db_path).await.unwrap();
 
-        let db = ThingsDatabase::new(db_path).await.unwrap();
+        let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
         // Test today command
         let cli = Cli::try_parse_from(["things-cli", "today"]).unwrap();
@@ -258,7 +258,7 @@ mod tests {
         let db_path = temp_file.path();
         create_test_database(db_path).await.unwrap();
 
-        let db = ThingsDatabase::new(db_path).await.unwrap();
+        let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
         // Test projects command
         let cli = Cli::try_parse_from(["things-cli", "projects"]).unwrap();
@@ -286,7 +286,7 @@ mod tests {
         let db_path = temp_file.path();
         create_test_database(db_path).await.unwrap();
 
-        let db = ThingsDatabase::new(db_path).await.unwrap();
+        let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
         // Test areas command
         let cli = Cli::try_parse_from(["things-cli", "areas"]).unwrap();
@@ -313,7 +313,7 @@ mod tests {
         let db_path = temp_file.path();
         create_test_database(db_path).await.unwrap();
 
-        let db = ThingsDatabase::new(db_path).await.unwrap();
+        let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
         // Test search command
         let cli = Cli::try_parse_from(["things-cli", "search", "test"]).unwrap();
@@ -335,7 +335,7 @@ mod tests {
         let db_path = temp_file.path();
         create_test_database(db_path).await.unwrap();
 
-        let db = ThingsDatabase::new(db_path).await.unwrap();
+        let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
         // Test health command
         let cli = Cli::try_parse_from(["things-cli", "health"]).unwrap();
@@ -358,7 +358,9 @@ mod tests {
             .database_path(db_path)
             .build()
             .unwrap();
-        let db = ThingsDatabase::new(config.database_path()).await.unwrap();
+        let db = SqliteThingsDatabase::new(config.database_path())
+            .await
+            .unwrap();
 
         // Test MCP command
         let cli = Cli::try_parse_from(["things-cli", "mcp"]).unwrap();
@@ -379,7 +381,7 @@ mod tests {
         let db_path = temp_file.path();
         create_test_database(db_path).await.unwrap();
 
-        let db = ThingsDatabase::new(db_path).await.unwrap();
+        let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
         // Test with verbose flag
         let cli = Cli::try_parse_from(["things-cli", "--verbose", "inbox"]).unwrap();
@@ -413,7 +415,7 @@ mod tests {
         .unwrap();
         assert_eq!(cli.database, Some(db_path.to_path_buf()));
 
-        let db = ThingsDatabase::new(db_path).await.unwrap();
+        let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
         match cli.command {
             Commands::Inbox { limit } => {
@@ -437,7 +439,7 @@ mod tests {
         let cli = Cli::try_parse_from(["things-cli", "--fallback-to-default", "inbox"]).unwrap();
         assert!(cli.fallback_to_default);
 
-        let db = ThingsDatabase::new(db_path).await.unwrap();
+        let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
         match cli.command {
             Commands::Inbox { limit } => {
@@ -457,7 +459,7 @@ mod tests {
         let db_path = temp_file.path();
         create_test_database(db_path).await.unwrap();
 
-        let db = ThingsDatabase::new(db_path).await.unwrap();
+        let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
         // Test with limit
         let cli = Cli::try_parse_from(["things-cli", "inbox", "--limit", "5"]).unwrap();

--- a/apps/things3-cli/src/mcp/mod.rs
+++ b/apps/things3-cli/src/mcp/mod.rs
@@ -727,10 +727,10 @@ pub async fn start_mcp_server_with_config_generic<I: McpIo>(
     unsafe_direct_db: bool,
 ) -> things3_core::Result<()> {
     // Convert McpServerConfig to ThingsConfig for backward compatibility
-    let things_config = ThingsConfig::new(
-        mcp_config.database.path.clone(),
-        mcp_config.database.fallback_to_default,
-    );
+    let things_config = ThingsConfig::builder()
+        .database_path(&mcp_config.database.path)
+        .fallback_to_default(mcp_config.database.fallback_to_default)
+        .build()?;
 
     let server = Arc::new(tokio::sync::Mutex::new(
         ThingsMcpServer::new_with_mcp_config(db, things_config, mcp_config, unsafe_direct_db),
@@ -2603,7 +2603,10 @@ mod backend_selection_tests {
         .join()
         .unwrap();
 
-        let config = ThingsConfig::new(&db_path, false);
+        let config = ThingsConfig::builder()
+            .database_path(&db_path)
+            .build()
+            .unwrap();
         let server = ThingsMcpServer::new(Arc::new(db), config, unsafe_direct_db);
         (server, temp_file)
     }

--- a/apps/things3-cli/src/mcp/mod.rs
+++ b/apps/things3-cli/src/mcp/mod.rs
@@ -7,8 +7,9 @@ use std::sync::Arc;
 #[cfg(target_os = "macos")]
 use things3_core::AppleScriptBackend;
 use things3_core::{
-    BackupManager, DataExporter, McpServerConfig, MutationBackend, PerformanceMonitor, SqlxBackend,
-    ThingsCache, ThingsConfig, ThingsDatabase, ThingsDatabaseError, ThingsError, ThingsQueryError,
+    BackupManager, DataExporter, McpServerConfig, MutationBackend, PerformanceMonitor,
+    SqliteThingsDatabase, SqlxBackend, ThingsCache, ThingsConfig, ThingsDatabaseError, ThingsError,
+    ThingsQueryError,
 };
 use thiserror::Error;
 use tokio::sync::Mutex;
@@ -551,7 +552,7 @@ pub struct GetPromptResult {
 /// MCP server for Things 3 integration
 pub struct ThingsMcpServer {
     #[allow(dead_code)]
-    pub db: Arc<ThingsDatabase>,
+    pub db: Arc<SqliteThingsDatabase>,
     /// Mutation backend used for all write operations.
     ///
     /// On macOS the default is `AppleScriptBackend` (CulturedCode-supported);
@@ -621,7 +622,7 @@ fn build_jsonrpc_error_response(
 /// # Errors
 /// Returns an error if the server fails to start
 pub async fn start_mcp_server(
-    db: Arc<ThingsDatabase>,
+    db: Arc<SqliteThingsDatabase>,
     config: ThingsConfig,
     unsafe_direct_db: bool,
 ) -> things3_core::Result<()> {
@@ -634,7 +635,7 @@ pub async fn start_mcp_server(
 /// This function is generic over the I/O layer, allowing it to work with both
 /// production stdin/stdout (via `StdIo`) and test mocks (via `MockIo`).
 pub async fn start_mcp_server_generic<I: McpIo>(
-    db: Arc<ThingsDatabase>,
+    db: Arc<SqliteThingsDatabase>,
     config: ThingsConfig,
     mut io: I,
     unsafe_direct_db: bool,
@@ -711,7 +712,7 @@ pub async fn start_mcp_server_generic<I: McpIo>(
 /// # Errors
 /// Returns an error if the server fails to start
 pub async fn start_mcp_server_with_config(
-    db: Arc<ThingsDatabase>,
+    db: Arc<SqliteThingsDatabase>,
     mcp_config: McpServerConfig,
     unsafe_direct_db: bool,
 ) -> things3_core::Result<()> {
@@ -721,7 +722,7 @@ pub async fn start_mcp_server_with_config(
 
 /// Generic MCP server with config implementation that works with any I/O implementation
 pub async fn start_mcp_server_with_config_generic<I: McpIo>(
-    db: Arc<ThingsDatabase>,
+    db: Arc<SqliteThingsDatabase>,
     mcp_config: McpServerConfig,
     mut io: I,
     unsafe_direct_db: bool,
@@ -798,7 +799,7 @@ pub async fn start_mcp_server_with_config_generic<I: McpIo>(
 /// On non-macOS the default is always `SqlxBackend` — there's no Things 3
 /// install to corrupt, and `AppleScriptBackend` is platform-gated.
 fn select_default_backend(
-    db: Arc<ThingsDatabase>,
+    db: Arc<SqliteThingsDatabase>,
     unsafe_direct_db: bool,
 ) -> Arc<dyn MutationBackend> {
     #[cfg(target_os = "macos")]
@@ -839,7 +840,11 @@ fn is_things3_running() -> bool {
 
 impl ThingsMcpServer {
     #[must_use]
-    pub fn new(db: Arc<ThingsDatabase>, config: ThingsConfig, unsafe_direct_db: bool) -> Self {
+    pub fn new(
+        db: Arc<SqliteThingsDatabase>,
+        config: ThingsConfig,
+        unsafe_direct_db: bool,
+    ) -> Self {
         let mutations = select_default_backend(Arc::clone(&db), unsafe_direct_db);
         let mut server = Self::with_mutation_backend(db, mutations, config);
         server.unsafe_direct_db = unsafe_direct_db;
@@ -855,7 +860,7 @@ impl ThingsMcpServer {
     /// `set_unsafe_direct_db` helper.
     #[must_use]
     pub fn with_mutation_backend(
-        db: Arc<ThingsDatabase>,
+        db: Arc<SqliteThingsDatabase>,
         mutations: Arc<dyn MutationBackend>,
         config: ThingsConfig,
     ) -> Self {
@@ -884,7 +889,7 @@ impl ThingsMcpServer {
     /// Create a new MCP server with custom middleware configuration
     #[must_use]
     pub fn with_middleware_config(
-        db: ThingsDatabase,
+        db: SqliteThingsDatabase,
         config: ThingsConfig,
         middleware_config: MiddlewareConfig,
         unsafe_direct_db: bool,
@@ -913,7 +918,7 @@ impl ThingsMcpServer {
     /// Create a new MCP server with comprehensive configuration
     #[must_use]
     pub fn new_with_mcp_config(
-        db: Arc<ThingsDatabase>,
+        db: Arc<SqliteThingsDatabase>,
         config: ThingsConfig,
         mcp_config: McpServerConfig,
         unsafe_direct_db: bool,
@@ -2598,7 +2603,7 @@ mod backend_selection_tests {
         let db = std::thread::spawn(move || {
             tokio::runtime::Runtime::new()
                 .unwrap()
-                .block_on(async { ThingsDatabase::new(&db_path_clone).await.unwrap() })
+                .block_on(async { SqliteThingsDatabase::new(&db_path_clone).await.unwrap() })
         })
         .join()
         .unwrap();

--- a/apps/things3-cli/src/mcp/test_harness.rs
+++ b/apps/things3-cli/src/mcp/test_harness.rs
@@ -46,7 +46,10 @@ impl McpTestHarness {
         .join()
         .unwrap();
 
-        let config = ThingsConfig::new(&db_path, false);
+        let config = ThingsConfig::builder()
+            .database_path(&db_path)
+            .build()
+            .unwrap();
         let server = ThingsMcpServer::with_middleware_config(db, config, middleware_config, true);
 
         Self { server, temp_file }

--- a/apps/things3-cli/src/mcp/test_harness.rs
+++ b/apps/things3-cli/src/mcp/test_harness.rs
@@ -7,7 +7,7 @@ use crate::mcp::{
 use serde_json::Value;
 use std::path::Path;
 use tempfile::NamedTempFile;
-use things3_core::{config::ThingsConfig, ThingsDatabase};
+use things3_core::{config::ThingsConfig, SqliteThingsDatabase};
 // use std::sync::Arc; // Not needed for test harness
 
 /// Test harness for MCP server operations
@@ -331,7 +331,7 @@ impl McpTestHarness {
 
     /// Create a comprehensive test database with mock data
     #[allow(clippy::too_many_lines)]
-    async fn create_test_database<P: AsRef<Path>>(db_path: P) -> ThingsDatabase {
+    async fn create_test_database<P: AsRef<Path>>(db_path: P) -> SqliteThingsDatabase {
         use sqlx::SqlitePool;
 
         let database_url = format!("sqlite:{}", db_path.as_ref().display());
@@ -540,7 +540,7 @@ impl McpTestHarness {
         .execute(&pool).await.unwrap();
 
         pool.close().await;
-        ThingsDatabase::new(db_path.as_ref()).await.unwrap()
+        SqliteThingsDatabase::new(db_path.as_ref()).await.unwrap()
     }
 }
 

--- a/apps/things3-cli/src/metrics.rs
+++ b/apps/things3-cli/src/metrics.rs
@@ -330,18 +330,16 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
     use tempfile::NamedTempFile;
-    use things3_core::{ObservabilityConfig, ThingsConfig};
+    use things3_core::ObservabilityConfig;
 
     #[test]
     fn test_performance_monitor_creation() {
         let temp_file = NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
 
-        let config = ThingsConfig::new(db_path, false);
         let rt = tokio::runtime::Runtime::new().unwrap();
-        let _database = Arc::new(
-            rt.block_on(async { ThingsDatabase::new(&config.database_path).await.unwrap() }),
-        );
+        let _database =
+            Arc::new(rt.block_on(async { ThingsDatabase::new(db_path).await.unwrap() }));
 
         let obs_config = ObservabilityConfig::default();
         let observability = Arc::new(ObservabilityManager::new(obs_config).unwrap());
@@ -355,11 +353,9 @@ mod tests {
         let temp_file = NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
 
-        let config = ThingsConfig::new(db_path, false);
         let rt = tokio::runtime::Runtime::new().unwrap();
-        let _database = Arc::new(
-            rt.block_on(async { ThingsDatabase::new(&config.database_path).await.unwrap() }),
-        );
+        let _database =
+            Arc::new(rt.block_on(async { ThingsDatabase::new(db_path).await.unwrap() }));
 
         let obs_config = ObservabilityConfig::default();
         let observability = Arc::new(ObservabilityManager::new(obs_config).unwrap());
@@ -373,11 +369,8 @@ mod tests {
         let temp_file = NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
 
-        let config = ThingsConfig::new(db_path, false);
         let rt = tokio::runtime::Runtime::new().unwrap();
-        let database = Arc::new(
-            rt.block_on(async { ThingsDatabase::new(&config.database_path).await.unwrap() }),
-        );
+        let database = Arc::new(rt.block_on(async { ThingsDatabase::new(db_path).await.unwrap() }));
 
         let obs_config = ObservabilityConfig::default();
         let observability = Arc::new(ObservabilityManager::new(obs_config).unwrap());
@@ -391,8 +384,7 @@ mod tests {
         let temp_file = NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
 
-        let config = ThingsConfig::new(db_path, false);
-        let _database = Arc::new(ThingsDatabase::new(&config.database_path).await.unwrap());
+        let _database = Arc::new(ThingsDatabase::new(db_path).await.unwrap());
 
         let obs_config = ObservabilityConfig::default();
         let observability = Arc::new(ObservabilityManager::new(obs_config).unwrap());
@@ -412,8 +404,7 @@ mod tests {
         let temp_file = NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
 
-        let config = ThingsConfig::new(db_path, false);
-        let _database = Arc::new(ThingsDatabase::new(&config.database_path).await.unwrap());
+        let _database = Arc::new(ThingsDatabase::new(db_path).await.unwrap());
 
         let obs_config = ObservabilityConfig::default();
         let observability = Arc::new(ObservabilityManager::new(obs_config).unwrap());
@@ -429,8 +420,7 @@ mod tests {
         let temp_file = NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
 
-        let config = ThingsConfig::new(db_path, false);
-        let _database = Arc::new(ThingsDatabase::new(&config.database_path).await.unwrap());
+        let _database = Arc::new(ThingsDatabase::new(db_path).await.unwrap());
 
         let obs_config = ObservabilityConfig::default();
         let observability = Arc::new(ObservabilityManager::new(obs_config).unwrap());
@@ -447,8 +437,7 @@ mod tests {
         let temp_file = NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
 
-        let config = ThingsConfig::new(db_path, false);
-        let _database = Arc::new(ThingsDatabase::new(&config.database_path).await.unwrap());
+        let _database = Arc::new(ThingsDatabase::new(db_path).await.unwrap());
 
         let obs_config = ObservabilityConfig::default();
         let observability = Arc::new(ObservabilityManager::new(obs_config).unwrap());
@@ -465,8 +454,7 @@ mod tests {
         let temp_file = NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
 
-        let config = ThingsConfig::new(db_path, false);
-        let _database = Arc::new(ThingsDatabase::new(&config.database_path).await.unwrap());
+        let _database = Arc::new(ThingsDatabase::new(db_path).await.unwrap());
 
         let obs_config = ObservabilityConfig::default();
         let observability = Arc::new(ObservabilityManager::new(obs_config).unwrap());
@@ -483,8 +471,7 @@ mod tests {
         let temp_file = NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
 
-        let config = ThingsConfig::new(db_path, false);
-        let database = Arc::new(ThingsDatabase::new(&config.database_path).await.unwrap());
+        let database = Arc::new(ThingsDatabase::new(db_path).await.unwrap());
 
         let obs_config = ObservabilityConfig::default();
         let observability = Arc::new(ObservabilityManager::new(obs_config).unwrap());
@@ -505,8 +492,7 @@ mod tests {
         let temp_file = NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
 
-        let config = ThingsConfig::new(db_path, false);
-        let database = Arc::new(ThingsDatabase::new(&config.database_path).await.unwrap());
+        let database = Arc::new(ThingsDatabase::new(db_path).await.unwrap());
 
         let obs_config = ObservabilityConfig::default();
         let observability = Arc::new(ObservabilityManager::new(obs_config).unwrap());
@@ -527,8 +513,7 @@ mod tests {
         let temp_file = NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
 
-        let config = ThingsConfig::new(db_path, false);
-        let database = Arc::new(ThingsDatabase::new(&config.database_path).await.unwrap());
+        let database = Arc::new(ThingsDatabase::new(db_path).await.unwrap());
 
         let obs_config = ObservabilityConfig::default();
         let observability = Arc::new(ObservabilityManager::new(obs_config).unwrap());
@@ -549,8 +534,7 @@ mod tests {
         let temp_file = NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
 
-        let config = ThingsConfig::new(db_path, false);
-        let database = Arc::new(ThingsDatabase::new(&config.database_path).await.unwrap());
+        let database = Arc::new(ThingsDatabase::new(db_path).await.unwrap());
 
         let obs_config = ObservabilityConfig::default();
         let observability = Arc::new(ObservabilityManager::new(obs_config).unwrap());
@@ -571,8 +555,7 @@ mod tests {
         let temp_file = NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
 
-        let config = ThingsConfig::new(db_path, false);
-        let database = Arc::new(ThingsDatabase::new(&config.database_path).await.unwrap());
+        let database = Arc::new(ThingsDatabase::new(db_path).await.unwrap());
 
         let obs_config = ObservabilityConfig::default();
         let observability = Arc::new(ObservabilityManager::new(obs_config).unwrap());
@@ -592,11 +575,9 @@ mod tests {
         let temp_file = NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
 
-        let config = ThingsConfig::new(db_path, false);
         let rt = tokio::runtime::Runtime::new().unwrap();
-        let _database = Arc::new(
-            rt.block_on(async { ThingsDatabase::new(&config.database_path).await.unwrap() }),
-        );
+        let _database =
+            Arc::new(rt.block_on(async { ThingsDatabase::new(db_path).await.unwrap() }));
 
         let obs_config = ObservabilityConfig {
             service_name: "test-service".to_string(),
@@ -613,11 +594,9 @@ mod tests {
         let temp_file = NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
 
-        let config = ThingsConfig::new(db_path, false);
         let rt = tokio::runtime::Runtime::new().unwrap();
-        let _database = Arc::new(
-            rt.block_on(async { ThingsDatabase::new(&config.database_path).await.unwrap() }),
-        );
+        let _database =
+            Arc::new(rt.block_on(async { ThingsDatabase::new(db_path).await.unwrap() }));
 
         let obs_config = ObservabilityConfig {
             service_name: "test-service".to_string(),
@@ -634,11 +613,8 @@ mod tests {
         let temp_file = NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
 
-        let config = ThingsConfig::new(db_path, false);
         let rt = tokio::runtime::Runtime::new().unwrap();
-        let database = Arc::new(
-            rt.block_on(async { ThingsDatabase::new(&config.database_path).await.unwrap() }),
-        );
+        let database = Arc::new(rt.block_on(async { ThingsDatabase::new(db_path).await.unwrap() }));
 
         let obs_config = ObservabilityConfig::default();
         let observability = Arc::new(ObservabilityManager::new(obs_config).unwrap());

--- a/apps/things3-cli/src/metrics.rs
+++ b/apps/things3-cli/src/metrics.rs
@@ -5,14 +5,14 @@
 
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use things3_core::{ObservabilityManager, ThingsDatabase};
+use things3_core::{ObservabilityManager, SqliteThingsDatabase};
 use tokio::time::interval;
 use tracing::{debug, error, info, instrument, warn};
 
 /// Metrics collector for continuous monitoring
 pub struct MetricsCollector {
     observability: Arc<ObservabilityManager>,
-    database: Arc<ThingsDatabase>,
+    database: Arc<SqliteThingsDatabase>,
     collection_interval: Duration,
 }
 
@@ -21,7 +21,7 @@ impl MetricsCollector {
     #[must_use]
     pub fn new(
         observability: Arc<ObservabilityManager>,
-        database: Arc<ThingsDatabase>,
+        database: Arc<SqliteThingsDatabase>,
         collection_interval: Duration,
     ) -> Self {
         Self {
@@ -316,7 +316,7 @@ impl ErrorTracker {
 /// Returns an error if metrics collection fails
 pub async fn start_metrics_collection(
     observability: Arc<ObservabilityManager>,
-    database: Arc<ThingsDatabase>,
+    database: Arc<SqliteThingsDatabase>,
     collection_interval: Duration,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let collector = MetricsCollector::new(observability, database, collection_interval);
@@ -339,7 +339,7 @@ mod tests {
 
         let rt = tokio::runtime::Runtime::new().unwrap();
         let _database =
-            Arc::new(rt.block_on(async { ThingsDatabase::new(db_path).await.unwrap() }));
+            Arc::new(rt.block_on(async { SqliteThingsDatabase::new(db_path).await.unwrap() }));
 
         let obs_config = ObservabilityConfig::default();
         let observability = Arc::new(ObservabilityManager::new(obs_config).unwrap());
@@ -355,7 +355,7 @@ mod tests {
 
         let rt = tokio::runtime::Runtime::new().unwrap();
         let _database =
-            Arc::new(rt.block_on(async { ThingsDatabase::new(db_path).await.unwrap() }));
+            Arc::new(rt.block_on(async { SqliteThingsDatabase::new(db_path).await.unwrap() }));
 
         let obs_config = ObservabilityConfig::default();
         let observability = Arc::new(ObservabilityManager::new(obs_config).unwrap());
@@ -370,7 +370,8 @@ mod tests {
         let db_path = temp_file.path();
 
         let rt = tokio::runtime::Runtime::new().unwrap();
-        let database = Arc::new(rt.block_on(async { ThingsDatabase::new(db_path).await.unwrap() }));
+        let database =
+            Arc::new(rt.block_on(async { SqliteThingsDatabase::new(db_path).await.unwrap() }));
 
         let obs_config = ObservabilityConfig::default();
         let observability = Arc::new(ObservabilityManager::new(obs_config).unwrap());
@@ -384,7 +385,7 @@ mod tests {
         let temp_file = NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
 
-        let _database = Arc::new(ThingsDatabase::new(db_path).await.unwrap());
+        let _database = Arc::new(SqliteThingsDatabase::new(db_path).await.unwrap());
 
         let obs_config = ObservabilityConfig::default();
         let observability = Arc::new(ObservabilityManager::new(obs_config).unwrap());
@@ -404,7 +405,7 @@ mod tests {
         let temp_file = NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
 
-        let _database = Arc::new(ThingsDatabase::new(db_path).await.unwrap());
+        let _database = Arc::new(SqliteThingsDatabase::new(db_path).await.unwrap());
 
         let obs_config = ObservabilityConfig::default();
         let observability = Arc::new(ObservabilityManager::new(obs_config).unwrap());
@@ -420,7 +421,7 @@ mod tests {
         let temp_file = NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
 
-        let _database = Arc::new(ThingsDatabase::new(db_path).await.unwrap());
+        let _database = Arc::new(SqliteThingsDatabase::new(db_path).await.unwrap());
 
         let obs_config = ObservabilityConfig::default();
         let observability = Arc::new(ObservabilityManager::new(obs_config).unwrap());
@@ -437,7 +438,7 @@ mod tests {
         let temp_file = NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
 
-        let _database = Arc::new(ThingsDatabase::new(db_path).await.unwrap());
+        let _database = Arc::new(SqliteThingsDatabase::new(db_path).await.unwrap());
 
         let obs_config = ObservabilityConfig::default();
         let observability = Arc::new(ObservabilityManager::new(obs_config).unwrap());
@@ -454,7 +455,7 @@ mod tests {
         let temp_file = NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
 
-        let _database = Arc::new(ThingsDatabase::new(db_path).await.unwrap());
+        let _database = Arc::new(SqliteThingsDatabase::new(db_path).await.unwrap());
 
         let obs_config = ObservabilityConfig::default();
         let observability = Arc::new(ObservabilityManager::new(obs_config).unwrap());
@@ -471,7 +472,7 @@ mod tests {
         let temp_file = NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
 
-        let database = Arc::new(ThingsDatabase::new(db_path).await.unwrap());
+        let database = Arc::new(SqliteThingsDatabase::new(db_path).await.unwrap());
 
         let obs_config = ObservabilityConfig::default();
         let observability = Arc::new(ObservabilityManager::new(obs_config).unwrap());
@@ -492,7 +493,7 @@ mod tests {
         let temp_file = NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
 
-        let database = Arc::new(ThingsDatabase::new(db_path).await.unwrap());
+        let database = Arc::new(SqliteThingsDatabase::new(db_path).await.unwrap());
 
         let obs_config = ObservabilityConfig::default();
         let observability = Arc::new(ObservabilityManager::new(obs_config).unwrap());
@@ -513,7 +514,7 @@ mod tests {
         let temp_file = NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
 
-        let database = Arc::new(ThingsDatabase::new(db_path).await.unwrap());
+        let database = Arc::new(SqliteThingsDatabase::new(db_path).await.unwrap());
 
         let obs_config = ObservabilityConfig::default();
         let observability = Arc::new(ObservabilityManager::new(obs_config).unwrap());
@@ -534,7 +535,7 @@ mod tests {
         let temp_file = NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
 
-        let database = Arc::new(ThingsDatabase::new(db_path).await.unwrap());
+        let database = Arc::new(SqliteThingsDatabase::new(db_path).await.unwrap());
 
         let obs_config = ObservabilityConfig::default();
         let observability = Arc::new(ObservabilityManager::new(obs_config).unwrap());
@@ -555,7 +556,7 @@ mod tests {
         let temp_file = NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
 
-        let database = Arc::new(ThingsDatabase::new(db_path).await.unwrap());
+        let database = Arc::new(SqliteThingsDatabase::new(db_path).await.unwrap());
 
         let obs_config = ObservabilityConfig::default();
         let observability = Arc::new(ObservabilityManager::new(obs_config).unwrap());
@@ -577,7 +578,7 @@ mod tests {
 
         let rt = tokio::runtime::Runtime::new().unwrap();
         let _database =
-            Arc::new(rt.block_on(async { ThingsDatabase::new(db_path).await.unwrap() }));
+            Arc::new(rt.block_on(async { SqliteThingsDatabase::new(db_path).await.unwrap() }));
 
         let obs_config = ObservabilityConfig {
             service_name: "test-service".to_string(),
@@ -596,7 +597,7 @@ mod tests {
 
         let rt = tokio::runtime::Runtime::new().unwrap();
         let _database =
-            Arc::new(rt.block_on(async { ThingsDatabase::new(db_path).await.unwrap() }));
+            Arc::new(rt.block_on(async { SqliteThingsDatabase::new(db_path).await.unwrap() }));
 
         let obs_config = ObservabilityConfig {
             service_name: "test-service".to_string(),
@@ -614,7 +615,8 @@ mod tests {
         let db_path = temp_file.path();
 
         let rt = tokio::runtime::Runtime::new().unwrap();
-        let database = Arc::new(rt.block_on(async { ThingsDatabase::new(db_path).await.unwrap() }));
+        let database =
+            Arc::new(rt.block_on(async { SqliteThingsDatabase::new(db_path).await.unwrap() }));
 
         let obs_config = ObservabilityConfig::default();
         let observability = Arc::new(ObservabilityManager::new(obs_config).unwrap());

--- a/apps/things3-cli/tests/error_message_format_tests.rs
+++ b/apps/things3-cli/tests/error_message_format_tests.rs
@@ -3,13 +3,13 @@
 //! Ensures all error messages follow the "Failed to {operation}: {error}" format
 
 use things3_cli::mcp::{CallToolRequest, McpError, ThingsMcpServer};
-use things3_core::{config::ThingsConfig, database::ThingsDatabase};
+use things3_core::{config::ThingsConfig, database::SqliteThingsDatabase};
 
 /// Create a test MCP server with an invalid/closed database to trigger errors
 async fn create_invalid_mcp_server() -> ThingsMcpServer {
     // Create an in-memory database but don't set up schema
     // This will cause database operations to fail
-    let db = ThingsDatabase::from_connection_string("sqlite::memory:")
+    let db = SqliteThingsDatabase::from_connection_string("sqlite::memory:")
         .await
         .unwrap();
 

--- a/apps/things3-cli/tests/integration_real_time_features.rs
+++ b/apps/things3-cli/tests/integration_real_time_features.rs
@@ -28,7 +28,9 @@ async fn test_progress_tracking_integration() {
         .await
         .unwrap();
 
-    let db = things3_core::ThingsDatabase::new(db_path).await.unwrap();
+    let db = things3_core::SqliteThingsDatabase::new(db_path)
+        .await
+        .unwrap();
 
     // Test progress tracking with bulk operations
     let manager = things3_cli::bulk_operations::BulkOperationsManager::new();

--- a/apps/things3-cli/tests/integration_tests.rs
+++ b/apps/things3-cli/tests/integration_tests.rs
@@ -1,5 +1,4 @@
 //! Integration tests for CLI functionality
-#![allow(deprecated)]
 
 use std::io::Cursor;
 use tempfile::NamedTempFile;
@@ -15,8 +14,7 @@ async fn test_print_tasks_integration() {
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
 
-    let config = ThingsConfig::new(db_path, false);
-    let db = ThingsDatabase::new(&config.database_path).await.unwrap();
+    let db = ThingsDatabase::new(db_path).await.unwrap();
 
     // Test with empty tasks
     let mut output = Cursor::new(Vec::new());
@@ -40,8 +38,7 @@ async fn test_print_projects_integration() {
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
 
-    let config = ThingsConfig::new(db_path, false);
-    let db = ThingsDatabase::new(&config.database_path).await.unwrap();
+    let db = ThingsDatabase::new(db_path).await.unwrap();
 
     // Test with empty projects
     let mut output = Cursor::new(Vec::new());
@@ -65,8 +62,7 @@ async fn test_print_areas_integration() {
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
 
-    let config = ThingsConfig::new(db_path, false);
-    let db = ThingsDatabase::new(&config.database_path).await.unwrap();
+    let db = ThingsDatabase::new(db_path).await.unwrap();
 
     // Test with empty areas
     let mut output = Cursor::new(Vec::new());
@@ -90,16 +86,14 @@ async fn test_health_check_integration() {
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
 
-    let config = ThingsConfig::new(db_path, false);
-    let db = ThingsDatabase::new(&config.database_path).await.unwrap();
+    let db = ThingsDatabase::new(db_path).await.unwrap();
 
     // Test successful health check
     let result = things3_cli::health_check(&db).await;
     assert!(result.is_ok());
 
     // Test health check with invalid database
-    let invalid_config = ThingsConfig::new("/nonexistent/path", false);
-    let invalid_db = ThingsDatabase::new(&invalid_config.database_path).await;
+    let invalid_db = ThingsDatabase::new(std::path::Path::new("/nonexistent/path")).await;
     if let Ok(db) = invalid_db {
         let result = things3_cli::health_check(&db).await;
         // This might succeed or fail depending on the database state
@@ -116,8 +110,11 @@ async fn test_mcp_server_integration() {
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
 
-    let config = ThingsConfig::new(db_path, false);
-    let db = ThingsDatabase::new(&config.database_path).await.unwrap();
+    let config = ThingsConfig::builder()
+        .database_path(db_path)
+        .build()
+        .unwrap();
+    let db = ThingsDatabase::new(config.database_path()).await.unwrap();
 
     // Test MCP server creation
     let server = things3_cli::mcp::ThingsMcpServer::new(db.into(), config, true);
@@ -164,15 +161,14 @@ fn test_cli_parsing_integration() {
 #[tokio::test]
 async fn test_cli_error_handling_integration() {
     // Test with nonexistent database
-    let config = ThingsConfig::new("/nonexistent/path", false);
-    let db_result = ThingsDatabase::new(&config.database_path).await;
+    let db_result = ThingsDatabase::new(std::path::Path::new("/nonexistent/path")).await;
 
     // This should fail
     assert!(db_result.is_err());
 
     // Test with malformed database path (invalid characters)
-    let config = ThingsConfig::new("/invalid/path/with/invalid/chars/\0", false);
-    let db_result = ThingsDatabase::new(&config.database_path).await;
+    let db_result =
+        ThingsDatabase::new(std::path::Path::new("/invalid/path/with/invalid/chars/\0")).await;
 
     // This should also fail
     assert!(db_result.is_err());

--- a/apps/things3-cli/tests/integration_tests.rs
+++ b/apps/things3-cli/tests/integration_tests.rs
@@ -3,7 +3,7 @@
 use std::io::Cursor;
 use tempfile::NamedTempFile;
 use things3_core::{
-    config::ThingsConfig, database::ThingsDatabase, test_utils::create_test_database,
+    config::ThingsConfig, database::SqliteThingsDatabase, test_utils::create_test_database,
 };
 
 /// Test the `print_tasks` function with various inputs
@@ -14,7 +14,7 @@ async fn test_print_tasks_integration() {
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
 
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     // Test with empty tasks
     let mut output = Cursor::new(Vec::new());
@@ -38,7 +38,7 @@ async fn test_print_projects_integration() {
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
 
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     // Test with empty projects
     let mut output = Cursor::new(Vec::new());
@@ -62,7 +62,7 @@ async fn test_print_areas_integration() {
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
 
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     // Test with empty areas
     let mut output = Cursor::new(Vec::new());
@@ -86,14 +86,14 @@ async fn test_health_check_integration() {
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
 
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     // Test successful health check
     let result = things3_cli::health_check(&db).await;
     assert!(result.is_ok());
 
     // Test health check with invalid database
-    let invalid_db = ThingsDatabase::new(std::path::Path::new("/nonexistent/path")).await;
+    let invalid_db = SqliteThingsDatabase::new(std::path::Path::new("/nonexistent/path")).await;
     if let Ok(db) = invalid_db {
         let result = things3_cli::health_check(&db).await;
         // This might succeed or fail depending on the database state
@@ -114,7 +114,9 @@ async fn test_mcp_server_integration() {
         .database_path(db_path)
         .build()
         .unwrap();
-    let db = ThingsDatabase::new(config.database_path()).await.unwrap();
+    let db = SqliteThingsDatabase::new(config.database_path())
+        .await
+        .unwrap();
 
     // Test MCP server creation
     let server = things3_cli::mcp::ThingsMcpServer::new(db.into(), config, true);
@@ -161,14 +163,15 @@ fn test_cli_parsing_integration() {
 #[tokio::test]
 async fn test_cli_error_handling_integration() {
     // Test with nonexistent database
-    let db_result = ThingsDatabase::new(std::path::Path::new("/nonexistent/path")).await;
+    let db_result = SqliteThingsDatabase::new(std::path::Path::new("/nonexistent/path")).await;
 
     // This should fail
     assert!(db_result.is_err());
 
     // Test with malformed database path (invalid characters)
     let db_result =
-        ThingsDatabase::new(std::path::Path::new("/invalid/path/with/invalid/chars/\0")).await;
+        SqliteThingsDatabase::new(std::path::Path::new("/invalid/path/with/invalid/chars/\0"))
+            .await;
 
     // This should also fail
     assert!(db_result.is_err());

--- a/apps/things3-cli/tests/mcp_bulk_operations_tests.rs
+++ b/apps/things3-cli/tests/mcp_bulk_operations_tests.rs
@@ -3,7 +3,7 @@
 use serde_json::json;
 use tempfile::NamedTempFile;
 use things3_cli::mcp::{CallToolRequest, ThingsMcpServer};
-use things3_core::{test_utils::create_test_database, ThingsConfig, ThingsDatabase};
+use things3_core::{test_utils::create_test_database, SqliteThingsDatabase, ThingsConfig};
 
 // Test harness for MCP server
 struct McpTestHarness {
@@ -16,7 +16,7 @@ impl McpTestHarness {
         let temp_file = NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
         create_test_database(db_path).await.unwrap();
-        let db = ThingsDatabase::new(db_path).await.unwrap();
+        let db = SqliteThingsDatabase::new(db_path).await.unwrap();
         let config = ThingsConfig::default();
         let server = ThingsMcpServer::new(std::sync::Arc::new(db), config, true);
 

--- a/apps/things3-cli/tests/mcp_io_tests.rs
+++ b/apps/things3-cli/tests/mcp_io_tests.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, OnceLock};
 use tempfile::NamedTempFile;
 use things3_cli::mcp::io_wrapper::{McpIo, MockIo};
 use things3_cli::mcp::{start_mcp_server_generic, start_mcp_server_with_config_generic};
-use things3_core::{ThingsConfig, ThingsDatabase};
+use things3_core::{SqliteThingsDatabase, ThingsConfig};
 use tokio::time::{timeout, Duration};
 
 // ============================================================================
@@ -100,7 +100,7 @@ fn validate_result(version: &str, type_name: &str, response: &serde_json::Value)
 }
 
 /// Helper to create a test database
-async fn create_test_db() -> (NamedTempFile, Arc<ThingsDatabase>) {
+async fn create_test_db() -> (NamedTempFile, Arc<SqliteThingsDatabase>) {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
 
@@ -109,7 +109,7 @@ async fn create_test_db() -> (NamedTempFile, Arc<ThingsDatabase>) {
         .await
         .unwrap();
 
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
     (temp_file, Arc::new(db))
 }
 

--- a/apps/things3-cli/tests/mcp_tests/common.rs
+++ b/apps/things3-cli/tests/mcp_tests/common.rs
@@ -4,12 +4,12 @@
 
 use sqlx::SqlitePool;
 pub(crate) use things3_cli::mcp::ThingsMcpServer;
-use things3_core::{config::ThingsConfig, database::ThingsDatabase};
+use things3_core::{config::ThingsConfig, database::SqliteThingsDatabase};
 
 /// Create a test MCP server with mock database
 pub(crate) async fn create_test_mcp_server() -> ThingsMcpServer {
     // Use in-memory database for testing
-    let db = ThingsDatabase::from_connection_string("sqlite::memory:")
+    let db = SqliteThingsDatabase::from_connection_string("sqlite::memory:")
         .await
         .unwrap();
 
@@ -21,7 +21,7 @@ pub(crate) async fn create_test_mcp_server() -> ThingsMcpServer {
 }
 
 /// Create the test database schema
-async fn create_test_schema(db: &ThingsDatabase) -> Result<(), Box<dyn std::error::Error>> {
+async fn create_test_schema(db: &SqliteThingsDatabase) -> Result<(), Box<dyn std::error::Error>> {
     let pool = db.pool();
 
     // Create the Things 3 schema

--- a/apps/things3-cli/tests/mcp_tests/tool_tests.rs
+++ b/apps/things3-cli/tests/mcp_tests/tool_tests.rs
@@ -7,7 +7,7 @@ use super::common::create_test_mcp_server;
 use serde_json::json;
 use tempfile::NamedTempFile;
 use things3_cli::mcp::{CallToolRequest, Content, McpError, ThingsMcpServer};
-use things3_core::{config::ThingsConfig, database::ThingsDatabase};
+use things3_core::{config::ThingsConfig, database::SqliteThingsDatabase};
 
 #[tokio::test]
 async fn test_mcp_server_creation() {
@@ -1063,7 +1063,7 @@ async fn test_mcp_server_with_custom_middleware() {
         .await
         .unwrap();
 
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
     let config = ThingsConfig::builder()
         .database_path(db_path)
         .build()

--- a/apps/things3-cli/tests/mcp_tests/tool_tests.rs
+++ b/apps/things3-cli/tests/mcp_tests/tool_tests.rs
@@ -1064,7 +1064,10 @@ async fn test_mcp_server_with_custom_middleware() {
         .unwrap();
 
     let db = ThingsDatabase::new(db_path).await.unwrap();
-    let config = ThingsConfig::new(db_path, false);
+    let config = ThingsConfig::builder()
+        .database_path(db_path)
+        .build()
+        .unwrap();
     let middleware_config = MiddlewareConfig::default();
 
     let server = ThingsMcpServer::with_middleware_config(db, config, middleware_config, true);

--- a/apps/things3-cli/tests/mcp_write_operations_tests.rs
+++ b/apps/things3-cli/tests/mcp_write_operations_tests.rs
@@ -1,7 +1,7 @@
 use serde_json::json;
 use tempfile::NamedTempFile;
 use things3_cli::mcp::{CallToolRequest, ThingsMcpServer};
-use things3_core::{test_utils::create_test_database, ThingsConfig, ThingsDatabase};
+use things3_core::{test_utils::create_test_database, SqliteThingsDatabase, ThingsConfig};
 use uuid::Uuid;
 
 // Test harness for MCP server
@@ -15,7 +15,7 @@ impl McpTestHarness {
         let temp_file = NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
         create_test_database(db_path).await.unwrap();
-        let db = ThingsDatabase::new(db_path).await.unwrap();
+        let db = SqliteThingsDatabase::new(db_path).await.unwrap();
         let config = ThingsConfig::default();
         let server = ThingsMcpServer::new(std::sync::Arc::new(db), config, true);
 

--- a/libs/things3-core/benches/bulk_operations_benchmarks.rs
+++ b/libs/things3-core/benches/bulk_operations_benchmarks.rs
@@ -1,21 +1,21 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use things3_core::test_utils::create_test_database;
 use things3_core::{
-    BulkCompleteRequest, BulkDeleteRequest, BulkMoveRequest, CreateTaskRequest, ThingsDatabase,
-    ThingsId,
+    BulkCompleteRequest, BulkDeleteRequest, BulkMoveRequest, CreateTaskRequest,
+    SqliteThingsDatabase, ThingsId,
 };
 use tokio::runtime::Runtime;
 
 fn create_test_db_with_tasks(
     task_count: usize,
-) -> (tempfile::NamedTempFile, ThingsDatabase, Vec<ThingsId>) {
+) -> (tempfile::NamedTempFile, SqliteThingsDatabase, Vec<ThingsId>) {
     let rt = Runtime::new().unwrap();
     let temp_file = tempfile::NamedTempFile::new().unwrap();
     let db_path = temp_file.path().to_path_buf();
 
     let (db, task_uuids) = rt.block_on(async {
         create_test_database(&db_path).await.unwrap();
-        let db = ThingsDatabase::new(&db_path).await.unwrap();
+        let db = SqliteThingsDatabase::new(&db_path).await.unwrap();
 
         let mut task_uuids = Vec::new();
         for i in 0..task_count {

--- a/libs/things3-core/benches/cache_benchmarks.rs
+++ b/libs/things3-core/benches/cache_benchmarks.rs
@@ -1,16 +1,16 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use things3_core::test_utils::create_test_database;
-use things3_core::{CreateTaskRequest, ThingsDatabase};
+use things3_core::{CreateTaskRequest, SqliteThingsDatabase};
 use tokio::runtime::Runtime;
 
-fn create_test_db_with_data(task_count: usize) -> (tempfile::NamedTempFile, ThingsDatabase) {
+fn create_test_db_with_data(task_count: usize) -> (tempfile::NamedTempFile, SqliteThingsDatabase) {
     let rt = Runtime::new().unwrap();
     let temp_file = tempfile::NamedTempFile::new().unwrap();
     let db_path = temp_file.path().to_path_buf();
 
     let db = rt.block_on(async {
         create_test_database(&db_path).await.unwrap();
-        let db = ThingsDatabase::new(&db_path).await.unwrap();
+        let db = SqliteThingsDatabase::new(&db_path).await.unwrap();
 
         // Insert test tasks
         for i in 0..task_count {

--- a/libs/things3-core/benches/database_benchmarks.rs
+++ b/libs/things3-core/benches/database_benchmarks.rs
@@ -1,16 +1,16 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use things3_core::test_utils::create_test_database;
-use things3_core::{CreateTaskRequest, ThingsDatabase};
+use things3_core::{CreateTaskRequest, SqliteThingsDatabase};
 use tokio::runtime::Runtime;
 
-fn create_test_db_with_data(task_count: usize) -> (tempfile::NamedTempFile, ThingsDatabase) {
+fn create_test_db_with_data(task_count: usize) -> (tempfile::NamedTempFile, SqliteThingsDatabase) {
     let rt = Runtime::new().unwrap();
     let temp_file = tempfile::NamedTempFile::new().unwrap();
     let db_path = temp_file.path().to_path_buf();
 
     let db = rt.block_on(async {
         create_test_database(&db_path).await.unwrap();
-        let db = ThingsDatabase::new(&db_path).await.unwrap();
+        let db = SqliteThingsDatabase::new(&db_path).await.unwrap();
 
         // Insert test tasks
         for i in 0..task_count {

--- a/libs/things3-core/examples/basic_usage.rs
+++ b/libs/things3-core/examples/basic_usage.rs
@@ -7,7 +7,7 @@
 //! - Creating and updating tasks
 
 use chrono::NaiveDate;
-use things3_core::{CreateTaskRequest, ThingsDatabase, ThingsError, UpdateTaskRequest};
+use things3_core::{CreateTaskRequest, SqliteThingsDatabase, ThingsError, UpdateTaskRequest};
 
 #[tokio::main]
 async fn main() -> Result<(), ThingsError> {
@@ -16,7 +16,7 @@ async fn main() -> Result<(), ThingsError> {
 
     // Connect to the database
     println!("Connecting to database at: {}", db_path.display());
-    let db = ThingsDatabase::new(&db_path).await?;
+    let db = SqliteThingsDatabase::new(&db_path).await?;
 
     // Get inbox tasks
     println!("\n=== Inbox Tasks ===");

--- a/libs/things3-core/examples/bulk_operations.rs
+++ b/libs/things3-core/examples/bulk_operations.rs
@@ -9,13 +9,13 @@
 use chrono::NaiveDate;
 use things3_core::{
     BulkCompleteRequest, BulkDeleteRequest, BulkMoveRequest, BulkUpdateDatesRequest,
-    ThingsDatabase, ThingsError, ThingsId,
+    SqliteThingsDatabase, ThingsError, ThingsId,
 };
 
 #[tokio::main]
 async fn main() -> Result<(), ThingsError> {
     let db_path = things3_core::get_default_database_path();
-    let db = ThingsDatabase::new(&db_path).await?;
+    let db = SqliteThingsDatabase::new(&db_path).await?;
 
     // Get some task UUIDs for demonstration
     let tasks = db.get_inbox(Some(10)).await?;

--- a/libs/things3-core/examples/search_tasks.rs
+++ b/libs/things3-core/examples/search_tasks.rs
@@ -3,7 +3,7 @@
 //! Run with: cargo run --example search_tasks -- "meeting"
 
 use std::env;
-use things3_core::{ThingsConfig, ThingsDatabase};
+use things3_core::{SqliteThingsDatabase, ThingsConfig};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -14,7 +14,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Connect to database
     let config = ThingsConfig::from_env();
-    let db = ThingsDatabase::new(&config.get_effective_database_path()?).await?;
+    let db = SqliteThingsDatabase::new(&config.get_effective_database_path()?).await?;
 
     // Search tasks
     let results = db.search_tasks(&query).await?;

--- a/libs/things3-core/src/backup.rs
+++ b/libs/things3-core/src/backup.rs
@@ -1,6 +1,6 @@
 //! Backup and restore functionality for Things 3 database
 
-use crate::{ThingsConfig, ThingsDatabase};
+use crate::{SqliteThingsDatabase, ThingsConfig};
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -218,7 +218,7 @@ impl BackupManager {
         }
 
         // Try to open the backup as a database
-        match ThingsDatabase::new(backup_path).await {
+        match SqliteThingsDatabase::new(backup_path).await {
             Ok(_) => Ok(true),
             Err(_) => Ok(false),
         }

--- a/libs/things3-core/src/batch.rs
+++ b/libs/things3-core/src/batch.rs
@@ -25,7 +25,7 @@ use std::collections::HashSet;
 use sqlx::{sqlite::SqliteRow, Row, SqlitePool};
 
 use crate::database::mappers::{map_project_row, map_task_row};
-use crate::database::SqliteSqliteThingsDatabase;
+use crate::database::SqliteThingsDatabase;
 use crate::error::{Result as ThingsResult, ThingsError};
 use crate::models::{Project, Task, ThingsId};
 
@@ -34,10 +34,10 @@ use crate::models::{Project, Task, ThingsId};
 /// long UUID lists without surfacing parameter-limit failures.
 const BATCH_CHUNK_SIZE: usize = 500;
 
-impl SqliteSqliteThingsDatabase {
+impl SqliteThingsDatabase {
     /// Fetch many tasks by UUID in a single batched query.
     ///
-    /// Mirrors [`SqliteSqliteThingsDatabase::get_task_by_uuid`]: trashed rows are omitted
+    /// Mirrors [`SqliteThingsDatabase::get_task_by_uuid`]: trashed rows are omitted
     /// and there is no task-type filter (a project or heading UUID will
     /// resolve to a [`Task`] mapped from its TMTask row, matching
     /// single-fetch loose semantics). Duplicate UUIDs are de-duplicated.

--- a/libs/things3-core/src/batch.rs
+++ b/libs/things3-core/src/batch.rs
@@ -1,14 +1,14 @@
-//! Batch fetch-by-id primitives on [`ThingsDatabase`].
+//! Batch fetch-by-id primitives on [`SqliteThingsDatabase`].
 #![allow(deprecated)]
 //!
-//! Two methods extend [`ThingsDatabase`] when the `batch-operations` feature
+//! Two methods extend [`SqliteThingsDatabase`] when the `batch-operations` feature
 //! is enabled:
-//! - [`ThingsDatabase::get_tasks_batch`] — many tasks by UUID
-//! - [`ThingsDatabase::get_projects_batch`] — many projects by UUID
+//! - [`SqliteThingsDatabase::get_tasks_batch`] — many tasks by UUID
+//! - [`SqliteThingsDatabase::get_projects_batch`] — many projects by UUID
 //!
 //! Both mirror the filtering semantics of their single-fetch siblings
-//! ([`ThingsDatabase::get_task_by_uuid`] and
-//! [`ThingsDatabase::get_project_by_uuid`]): trashed rows are omitted, no
+//! ([`SqliteThingsDatabase::get_task_by_uuid`] and
+//! [`SqliteThingsDatabase::get_project_by_uuid`]): trashed rows are omitted, no
 //! type filter is applied beyond what `get_project_by_uuid` already does
 //! (`type = 1`). Duplicate UUIDs in the input are de-duplicated; empty
 //! input returns `Ok(vec![])` without any SQL roundtrip; results are
@@ -25,7 +25,7 @@ use std::collections::HashSet;
 use sqlx::{sqlite::SqliteRow, Row, SqlitePool};
 
 use crate::database::mappers::{map_project_row, map_task_row};
-use crate::database::ThingsDatabase;
+use crate::database::SqliteSqliteThingsDatabase;
 use crate::error::{Result as ThingsResult, ThingsError};
 use crate::models::{Project, Task, ThingsId};
 
@@ -34,10 +34,10 @@ use crate::models::{Project, Task, ThingsId};
 /// long UUID lists without surfacing parameter-limit failures.
 const BATCH_CHUNK_SIZE: usize = 500;
 
-impl ThingsDatabase {
+impl SqliteSqliteThingsDatabase {
     /// Fetch many tasks by UUID in a single batched query.
     ///
-    /// Mirrors [`ThingsDatabase::get_task_by_uuid`]: trashed rows are omitted
+    /// Mirrors [`SqliteSqliteThingsDatabase::get_task_by_uuid`]: trashed rows are omitted
     /// and there is no task-type filter (a project or heading UUID will
     /// resolve to a [`Task`] mapped from its TMTask row, matching
     /// single-fetch loose semantics). Duplicate UUIDs are de-duplicated.
@@ -76,7 +76,7 @@ impl ThingsDatabase {
 
     /// Fetch many projects by UUID in a single batched query.
     ///
-    /// Mirrors [`ThingsDatabase::get_project_by_uuid`]: only `type = 1` rows
+    /// Mirrors [`SqliteThingsDatabase::get_project_by_uuid`]: only `type = 1` rows
     /// are returned, trashed rows are omitted. Duplicate UUIDs are
     /// de-duplicated. Empty input returns `Ok(vec![])` without any SQL
     /// call. Results are ordered by `(creationDate DESC, uuid DESC)`.
@@ -158,16 +158,16 @@ mod tests {
     use super::*;
     use tempfile::NamedTempFile;
 
-    async fn open_test_db() -> (ThingsDatabase, NamedTempFile) {
+    async fn open_test_db() -> (SqliteThingsDatabase, NamedTempFile) {
         let f = NamedTempFile::new().unwrap();
         crate::test_utils::create_test_database(f.path())
             .await
             .unwrap();
-        let db = ThingsDatabase::new(f.path()).await.unwrap();
+        let db = SqliteThingsDatabase::new(f.path()).await.unwrap();
         (db, f)
     }
 
-    async fn insert_task(db: &ThingsDatabase, title: &str) -> ThingsId {
+    async fn insert_task(db: &SqliteThingsDatabase, title: &str) -> ThingsId {
         let raw = uuid::Uuid::new_v4();
         sqlx::query(
             "INSERT INTO TMTask \
@@ -182,7 +182,7 @@ mod tests {
         ThingsId::from_trusted(raw.to_string())
     }
 
-    async fn insert_project(db: &ThingsDatabase, title: &str) -> ThingsId {
+    async fn insert_project(db: &SqliteThingsDatabase, title: &str) -> ThingsId {
         let raw = uuid::Uuid::new_v4();
         sqlx::query(
             "INSERT INTO TMTask \
@@ -197,7 +197,7 @@ mod tests {
         ThingsId::from_trusted(raw.to_string())
     }
 
-    async fn mark_trashed(db: &ThingsDatabase, id: &ThingsId) {
+    async fn mark_trashed(db: &SqliteThingsDatabase, id: &ThingsId) {
         sqlx::query("UPDATE TMTask SET trashed = 1 WHERE uuid = ?")
             .bind(id.as_str())
             .execute(&db.pool)

--- a/libs/things3-core/src/cache/mod.rs
+++ b/libs/things3-core/src/cache/mod.rs
@@ -754,7 +754,7 @@ mod tests {
         crate::test_utils::create_test_database(f.path())
             .await
             .unwrap();
-        let db = Arc::new(crate::ThingsDatabase::new(f.path()).await.unwrap());
+        let db = Arc::new(crate::SqliteThingsDatabase::new(f.path()).await.unwrap());
         let cache = Arc::new(ThingsCache::new_default());
         let pre = DefaultPreloader::new(&cache, db);
 
@@ -883,7 +883,7 @@ mod tests {
         crate::test_utils::create_test_database(f.path())
             .await
             .unwrap();
-        let db = Arc::new(crate::ThingsDatabase::new(f.path()).await.unwrap());
+        let db = Arc::new(crate::SqliteThingsDatabase::new(f.path()).await.unwrap());
 
         let config = CacheConfig {
             warming_interval: Duration::from_millis(20),
@@ -924,7 +924,7 @@ mod tests {
         crate::test_utils::create_test_database(f.path())
             .await
             .unwrap();
-        let db = Arc::new(crate::ThingsDatabase::new(f.path()).await.unwrap());
+        let db = Arc::new(crate::SqliteThingsDatabase::new(f.path()).await.unwrap());
 
         let cache = Arc::new(ThingsCache::new_default());
         let preloader = DefaultPreloader::new(&cache, db);

--- a/libs/things3-core/src/cache/preloader.rs
+++ b/libs/things3-core/src/cache/preloader.rs
@@ -29,7 +29,7 @@ use super::ThingsCache;
 /// enqueuing occurs until one of them expires or is invalidated.
 pub struct DefaultPreloader {
     cache: std::sync::Weak<ThingsCache>,
-    db: Arc<crate::database::ThingsDatabase>,
+    db: Arc<crate::database::SqliteThingsDatabase>,
 }
 
 impl DefaultPreloader {
@@ -37,7 +37,10 @@ impl DefaultPreloader {
     /// strong handle to `db`. Wrap in [`Arc`] before registering with
     /// [`ThingsCache::set_preloader`].
     #[must_use]
-    pub fn new(cache: &Arc<ThingsCache>, db: Arc<crate::database::ThingsDatabase>) -> Arc<Self> {
+    pub fn new(
+        cache: &Arc<ThingsCache>,
+        db: Arc<crate::database::SqliteThingsDatabase>,
+    ) -> Arc<Self> {
         Arc::new(Self {
             cache: Arc::downgrade(cache),
             db,

--- a/libs/things3-core/src/config.rs
+++ b/libs/things3-core/src/config.rs
@@ -4,49 +4,60 @@ use crate::error::{Result, ThingsError};
 use std::path::{Path, PathBuf};
 
 /// Configuration for Things 3 database access
-///
-/// **Deprecation notice**: Direct field access and the `new()` constructor are deprecated as of
-/// 2.1.0 and will be removed in 3.0. A `ThingsConfig::builder()` API is planned. Use
-/// `ThingsConfig::from_env()` or `ThingsConfig::with_default_path()` as alternatives in the
-/// meantime.
+#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct ThingsConfig {
-    /// Path to the Things 3 database
-    #[deprecated(
-        since = "2.1.0",
-        note = "Direct field access will be removed in 3.0. Use ThingsConfig::from_env() or ThingsConfig::with_default_path() for now."
-    )]
-    pub database_path: PathBuf,
-    /// Whether to use the default database path if the specified path doesn't exist
-    #[deprecated(
-        since = "2.1.0",
-        note = "Direct field access will be removed in 3.0. Use ThingsConfig::from_env() or ThingsConfig::with_default_path() for now."
-    )]
-    pub fallback_to_default: bool,
+    database_path: PathBuf,
+    fallback_to_default: bool,
+}
+
+/// Builder for [`ThingsConfig`].
+#[derive(Debug, Default)]
+pub struct ThingsConfigBuilder {
+    database_path: Option<PathBuf>,
+    fallback_to_default: bool,
+}
+
+impl ThingsConfigBuilder {
+    pub fn database_path(mut self, path: impl AsRef<Path>) -> Self {
+        self.database_path = Some(path.as_ref().to_path_buf());
+        self
+    }
+
+    pub fn fallback_to_default(mut self, fallback: bool) -> Self {
+        self.fallback_to_default = fallback;
+        self
+    }
+
+    pub fn build(self) -> Result<ThingsConfig> {
+        let database_path = self
+            .database_path
+            .unwrap_or_else(ThingsConfig::get_default_database_path);
+        Ok(ThingsConfig {
+            database_path,
+            fallback_to_default: self.fallback_to_default,
+        })
+    }
 }
 
 impl ThingsConfig {
-    /// Create a new configuration with a custom database path
-    ///
-    /// # Arguments
-    /// * `database_path` - Path to the Things 3 database
-    /// * `fallback_to_default` - Whether to fall back to the default path if the specified path doesn't exist
-    #[deprecated(
-        since = "2.1.0",
-        note = "Will be removed in 3.0. A ThingsConfig::builder() API is planned. Use ThingsConfig::from_env() or ThingsConfig::with_default_path() for now."
-    )]
-    #[must_use]
-    #[allow(deprecated)]
-    pub fn new<P: AsRef<Path>>(database_path: P, fallback_to_default: bool) -> Self {
-        Self {
-            database_path: database_path.as_ref().to_path_buf(),
-            fallback_to_default,
-        }
+    /// Returns a new builder for [`ThingsConfig`].
+    pub fn builder() -> ThingsConfigBuilder {
+        ThingsConfigBuilder::default()
+    }
+
+    /// Path to the Things 3 database.
+    pub fn database_path(&self) -> &Path {
+        &self.database_path
+    }
+
+    /// Whether to use the default database path if the specified path doesn't exist.
+    pub fn fallback_to_default(&self) -> bool {
+        self.fallback_to_default
     }
 
     /// Create a configuration with the default database path
     #[must_use]
-    #[allow(deprecated)]
     pub fn with_default_path() -> Self {
         Self {
             database_path: Self::get_default_database_path(),
@@ -57,15 +68,12 @@ impl ThingsConfig {
     /// Get the effective database path, falling back to default if needed
     ///
     /// # Errors
-    /// Returns `ThingsError::Message` if neither the specified path nor the default path exists
-    #[allow(deprecated)]
+    /// Returns an error if neither the specified path nor the default path exists
     pub fn get_effective_database_path(&self) -> Result<PathBuf> {
-        // Check if the specified path exists
         if self.database_path.exists() {
             return Ok(self.database_path.clone());
         }
 
-        // If fallback is enabled, try the default path
         if self.fallback_to_default {
             let default_path = Self::get_default_database_path();
             if default_path.exists() {
@@ -98,7 +106,6 @@ impl ThingsConfig {
     /// Reads the database path from `THINGS_DB_PATH` (preferred) or the legacy
     /// `THINGS_DATABASE_PATH`, and the fallback flag from `THINGS_FALLBACK_TO_DEFAULT`.
     #[must_use]
-    #[allow(deprecated)]
     pub fn from_env() -> Self {
         let database_path = match std::env::var("THINGS_DB_PATH") {
             Ok(v) => PathBuf::from(v),
@@ -115,27 +122,29 @@ impl ThingsConfig {
 
         let fallback_to_default = if let Ok(v) = std::env::var("THINGS_FALLBACK_TO_DEFAULT") {
             let lower = v.to_lowercase();
-            match lower.as_str() {
-                "true" | "1" | "yes" | "on" => true,
-                _ => false, // Default to false for invalid values
-            }
+            matches!(lower.as_str(), "true" | "1" | "yes" | "on")
         } else {
             true
         };
 
-        Self::new(database_path, fallback_to_default)
+        Self {
+            database_path,
+            fallback_to_default,
+        }
     }
 
     /// Create configuration for testing with a temporary database
     ///
     /// # Errors
     /// Returns `ThingsError::Io` if the temporary file cannot be created
-    #[allow(deprecated)]
     pub fn for_testing() -> Result<Self> {
         use tempfile::NamedTempFile;
         let temp_file = NamedTempFile::new()?;
         let db_path = temp_file.path().to_path_buf();
-        Ok(Self::new(db_path, false))
+        Ok(Self {
+            database_path: db_path,
+            fallback_to_default: false,
+        })
     }
 }
 
@@ -146,7 +155,6 @@ impl Default for ThingsConfig {
 }
 
 #[cfg(test)]
-#[allow(deprecated)]
 mod tests {
     use super::*;
     use crate::error::ThingsDatabaseError;
@@ -155,19 +163,23 @@ mod tests {
 
     #[test]
     fn test_config_creation() {
-        let config = ThingsConfig::new("/path/to/db.sqlite", true);
-        assert_eq!(config.database_path, PathBuf::from("/path/to/db.sqlite"));
-        assert!(config.fallback_to_default);
+        let config = ThingsConfig::builder()
+            .database_path("/path/to/db.sqlite")
+            .fallback_to_default(true)
+            .build()
+            .unwrap();
+        assert_eq!(config.database_path(), Path::new("/path/to/db.sqlite"));
+        assert!(config.fallback_to_default());
     }
 
     #[test]
     fn test_default_config() {
         let config = ThingsConfig::default();
         assert!(config
-            .database_path
+            .database_path()
             .to_string_lossy()
             .contains("Things Database.thingsdatabase"));
-        assert!(!config.fallback_to_default);
+        assert!(!config.fallback_to_default());
     }
 
     #[test]
@@ -184,8 +196,8 @@ mod tests {
         std::env::set_var("THINGS_FALLBACK_TO_DEFAULT", "true");
 
         let config = ThingsConfig::from_env();
-        let path_matches = config.database_path.as_os_str() == test_path;
-        let fallback_set = config.fallback_to_default;
+        let path_matches = config.database_path().as_os_str() == test_path;
+        let fallback_set = config.fallback_to_default();
 
         if let Some(v) = original_db_path {
             std::env::set_var("THINGS_DB_PATH", v);
@@ -217,7 +229,7 @@ mod tests {
         std::env::set_var("THINGS_DB_PATH", test_path);
 
         let config = ThingsConfig::from_env();
-        assert_eq!(config.database_path, PathBuf::from(test_path));
+        assert_eq!(config.database_path(), Path::new(test_path));
 
         if let Some(v) = original_db_path {
             std::env::set_var("THINGS_DB_PATH", v);
@@ -242,7 +254,7 @@ mod tests {
         std::env::set_var("THINGS_DATABASE_PATH", legacy_path);
 
         let config = ThingsConfig::from_env();
-        assert_eq!(config.database_path, PathBuf::from(new_path));
+        assert_eq!(config.database_path(), Path::new(new_path));
 
         if let Some(v) = original_db_path {
             std::env::set_var("THINGS_DB_PATH", v);
@@ -268,7 +280,7 @@ mod tests {
         std::env::set_var("THINGS_DATABASE_PATH", legacy_path);
 
         let config = ThingsConfig::from_env();
-        assert_eq!(config.database_path, PathBuf::from(legacy_path));
+        assert_eq!(config.database_path(), Path::new(legacy_path));
 
         if let Some(v) = original_db_path {
             std::env::set_var("THINGS_DB_PATH", v);
@@ -282,10 +294,12 @@ mod tests {
 
     #[test]
     fn test_effective_database_path() {
-        // Test with existing file
         let temp_file = NamedTempFile::new().unwrap();
         let db_path = temp_file.path();
-        let config = ThingsConfig::new(db_path, false);
+        let config = ThingsConfig::builder()
+            .database_path(db_path)
+            .build()
+            .unwrap();
 
         let effective_path = config.get_effective_database_path().unwrap();
         assert_eq!(effective_path, db_path);
@@ -293,35 +307,41 @@ mod tests {
 
     #[test]
     fn test_fallback_behavior() {
-        // Test fallback when it should succeed (default path exists)
-        let config = ThingsConfig::new("/nonexistent/path.sqlite", true);
+        let config = ThingsConfig::builder()
+            .database_path("/nonexistent/path.sqlite")
+            .fallback_to_default(true)
+            .build()
+            .unwrap();
         let result = config.get_effective_database_path();
 
-        // If the default path exists, fallback should succeed
         if ThingsConfig::get_default_database_path().exists() {
             assert!(result.is_ok());
             assert_eq!(result.unwrap(), ThingsConfig::get_default_database_path());
         } else {
-            // If default path doesn't exist, should get an error
             assert!(result.is_err());
         }
     }
 
     #[test]
     fn test_fallback_disabled() {
-        // Test when fallback is disabled - should always fail if path doesn't exist
-        let config = ThingsConfig::new("/nonexistent/path.sqlite", false);
+        let config = ThingsConfig::builder()
+            .database_path("/nonexistent/path.sqlite")
+            .build()
+            .unwrap();
         let result = config.get_effective_database_path();
 
-        // Should always fail when fallback is disabled and path doesn't exist
         assert!(result.is_err());
     }
 
     #[test]
     fn test_config_with_fallback_enabled() {
-        let config = ThingsConfig::new("/nonexistent/path", true);
-        assert_eq!(config.database_path, PathBuf::from("/nonexistent/path"));
-        assert!(config.fallback_to_default);
+        let config = ThingsConfig::builder()
+            .database_path("/nonexistent/path")
+            .fallback_to_default(true)
+            .build()
+            .unwrap();
+        assert_eq!(config.database_path(), Path::new("/nonexistent/path"));
+        assert!(config.fallback_to_default());
     }
 
     #[test]
@@ -338,8 +358,8 @@ mod tests {
         std::env::set_var("THINGS_FALLBACK_TO_DEFAULT", "false");
 
         let config = ThingsConfig::from_env();
-        let path_matches = config.database_path.as_os_str() == test_path;
-        let fallback_off = !config.fallback_to_default;
+        let path_matches = config.database_path().as_os_str() == test_path;
+        let fallback_off = !config.fallback_to_default();
 
         if let Some(v) = original_db_path {
             std::env::set_var("THINGS_DB_PATH", v);
@@ -375,8 +395,8 @@ mod tests {
 
         let config = ThingsConfig::from_env();
         let path_matches =
-            config.database_path.to_string_lossy() == PathBuf::from(&test_path).to_string_lossy();
-        let fallback_set = config.fallback_to_default;
+            config.database_path().to_string_lossy() == PathBuf::from(&test_path).to_string_lossy();
+        let fallback_set = config.fallback_to_default();
 
         if let Some(v) = original_db_path {
             std::env::set_var("THINGS_DB_PATH", v);
@@ -412,8 +432,8 @@ mod tests {
 
         let config = ThingsConfig::from_env();
         let path_matches =
-            config.database_path.to_string_lossy() == PathBuf::from(&test_path).to_string_lossy();
-        let fallback_off = !config.fallback_to_default;
+            config.database_path().to_string_lossy() == PathBuf::from(&test_path).to_string_lossy();
+        let fallback_off = !config.fallback_to_default();
 
         if let Some(v) = original_db_path {
             std::env::set_var("THINGS_DB_PATH", v);
@@ -435,7 +455,11 @@ mod tests {
 
     #[test]
     fn test_config_debug_formatting() {
-        let config = ThingsConfig::new("/test/path", true);
+        let config = ThingsConfig::builder()
+            .database_path("/test/path")
+            .fallback_to_default(true)
+            .build()
+            .unwrap();
         let debug_str = format!("{config:?}");
         assert!(debug_str.contains("/test/path"));
         assert!(debug_str.contains("true"));
@@ -443,94 +467,89 @@ mod tests {
 
     #[test]
     fn test_config_clone() {
-        let config1 = ThingsConfig::new("/test/path", true);
+        let config1 = ThingsConfig::builder()
+            .database_path("/test/path")
+            .fallback_to_default(true)
+            .build()
+            .unwrap();
         let config2 = config1.clone();
 
-        assert_eq!(config1.database_path, config2.database_path);
-        assert_eq!(config1.fallback_to_default, config2.fallback_to_default);
+        assert_eq!(config1.database_path(), config2.database_path());
+        assert_eq!(config1.fallback_to_default(), config2.fallback_to_default());
     }
 
     #[test]
     fn test_config_with_different_path_types() {
-        // Test with relative path
-        let config = ThingsConfig::new("relative/path", false);
-        assert_eq!(config.database_path, PathBuf::from("relative/path"));
+        let config = ThingsConfig::builder()
+            .database_path("relative/path")
+            .build()
+            .unwrap();
+        assert_eq!(config.database_path(), Path::new("relative/path"));
 
-        // Test with absolute path
-        let config = ThingsConfig::new("/absolute/path", false);
-        assert_eq!(config.database_path, PathBuf::from("/absolute/path"));
+        let config = ThingsConfig::builder()
+            .database_path("/absolute/path")
+            .build()
+            .unwrap();
+        assert_eq!(config.database_path(), Path::new("/absolute/path"));
 
-        // Test with current directory
-        let config = ThingsConfig::new(".", false);
-        assert_eq!(config.database_path, PathBuf::from("."));
+        let config = ThingsConfig::builder().database_path(".").build().unwrap();
+        assert_eq!(config.database_path(), Path::new("."));
     }
 
     #[test]
     fn test_config_edge_cases() {
-        // Test with empty string path
-        let config = ThingsConfig::new("", false);
-        assert_eq!(config.database_path, PathBuf::from(""));
+        let config = ThingsConfig::builder().database_path("").build().unwrap();
+        assert_eq!(config.database_path(), Path::new(""));
 
-        // Test with very long path
         let long_path = "/".repeat(1000);
-        let config = ThingsConfig::new(&long_path, false);
-        assert_eq!(config.database_path, PathBuf::from(&long_path));
+        let config = ThingsConfig::builder()
+            .database_path(&long_path)
+            .build()
+            .unwrap();
+        assert_eq!(config.database_path(), Path::new(&long_path));
     }
 
     #[test]
     fn test_get_default_database_path() {
         let default_path = ThingsConfig::get_default_database_path();
 
-        // Should be a valid path (may or may not exist)
-        assert!(!default_path.to_string_lossy().is_empty());
-
-        // Should be a reasonable path (may or may not contain "Things3" depending on system)
         assert!(!default_path.to_string_lossy().is_empty());
     }
 
     #[test]
     fn test_for_testing() {
-        // Test that for_testing creates a valid config
         let config = ThingsConfig::for_testing().unwrap();
 
-        // Should have a valid database path
-        assert!(!config.database_path.to_string_lossy().is_empty());
-
-        // Should not have fallback enabled (as specified in the method)
-        assert!(!config.fallback_to_default);
-
-        // The path should be a valid file path (even if it doesn't exist yet)
-        assert!(config.database_path.parent().is_some());
+        assert!(!config.database_path().to_string_lossy().is_empty());
+        assert!(!config.fallback_to_default());
+        assert!(config.database_path().parent().is_some());
     }
 
     #[test]
     fn test_with_default_path() {
         let config = ThingsConfig::with_default_path();
 
-        // Should use the default database path
         assert_eq!(
-            config.database_path,
+            config.database_path(),
             ThingsConfig::get_default_database_path()
         );
-
-        // Should not have fallback enabled
-        assert!(!config.fallback_to_default);
+        assert!(!config.fallback_to_default());
     }
 
     #[test]
     fn test_effective_database_path_fallback_enabled_but_default_missing() {
-        // Test the error case when fallback is enabled but default path doesn't exist
-        let config = ThingsConfig::new("/nonexistent/path.sqlite", true);
+        let config = ThingsConfig::builder()
+            .database_path("/nonexistent/path.sqlite")
+            .fallback_to_default(true)
+            .build()
+            .unwrap();
         let result = config.get_effective_database_path();
 
-        // Check if the default path exists - if it does, fallback will succeed
         let default_path = ThingsConfig::get_default_database_path();
         if default_path.exists() {
-            // If default path exists, fallback should succeed
             assert!(result.is_ok());
             assert_eq!(result.unwrap(), default_path);
         } else {
-            // If default path doesn't exist, should get an error
             assert!(result.is_err());
             let error = result.unwrap_err();
             match error {
@@ -545,11 +564,12 @@ mod tests {
 
     #[test]
     fn test_effective_database_path_fallback_disabled_error_message() {
-        // Test the error case when fallback is disabled
-        let config = ThingsConfig::new("/nonexistent/path.sqlite", false);
+        let config = ThingsConfig::builder()
+            .database_path("/nonexistent/path.sqlite")
+            .build()
+            .unwrap();
         let result = config.get_effective_database_path();
 
-        // Should get an error with specific message about fallback being disabled
         assert!(result.is_err());
         let error = result.unwrap_err();
         match error {
@@ -585,13 +605,12 @@ mod tests {
             std::env::set_var("THINGS_FALLBACK_TO_DEFAULT", v);
         }
 
-        assert_eq!(config.database_path, expected_path);
-        assert!(config.fallback_to_default);
+        assert_eq!(config.database_path(), expected_path);
+        assert!(config.fallback_to_default());
     }
 
     #[test]
     fn test_from_env_fallback_parsing() {
-        // Test various fallback value parsing without environment variable conflicts
         let test_cases = vec![
             ("true", true),
             ("TRUE", true),
@@ -611,7 +630,6 @@ mod tests {
         ];
 
         for (value, expected) in test_cases {
-            // Create a config manually to test the parsing logic
             let fallback = value.to_lowercase();
             let result =
                 fallback == "true" || fallback == "1" || fallback == "yes" || fallback == "on";
@@ -621,34 +639,40 @@ mod tests {
 
     #[test]
     fn test_default_trait_implementation() {
-        // Test that Default trait works correctly
         let config = ThingsConfig::default();
 
-        // Should be equivalent to with_default_path
         let expected = ThingsConfig::with_default_path();
-        assert_eq!(config.database_path, expected.database_path);
-        assert_eq!(config.fallback_to_default, expected.fallback_to_default);
+        assert_eq!(config.database_path(), expected.database_path());
+        assert_eq!(config.fallback_to_default(), expected.fallback_to_default());
     }
 
     #[test]
     fn test_config_with_path_reference() {
-        // Test that the config works with different path reference types
         let path_str = "/test/path/string";
         let path_buf = PathBuf::from("/test/path/buf");
 
-        let config1 = ThingsConfig::new(path_str, true);
-        let config2 = ThingsConfig::new(&path_buf, false);
+        let config1 = ThingsConfig::builder()
+            .database_path(path_str)
+            .fallback_to_default(true)
+            .build()
+            .unwrap();
+        let config2 = ThingsConfig::builder()
+            .database_path(&path_buf)
+            .build()
+            .unwrap();
 
-        assert_eq!(config1.database_path, PathBuf::from(path_str));
-        assert_eq!(config2.database_path, path_buf);
+        assert_eq!(config1.database_path(), Path::new(path_str));
+        assert_eq!(config2.database_path(), path_buf);
     }
 
     #[test]
     fn test_effective_database_path_existing_file() {
-        // Test when the specified path exists
         let temp_file = NamedTempFile::new().unwrap();
         let db_path = temp_file.path().to_path_buf();
-        let config = ThingsConfig::new(&db_path, false);
+        let config = ThingsConfig::builder()
+            .database_path(&db_path)
+            .build()
+            .unwrap();
 
         let effective_path = config.get_effective_database_path().unwrap();
         assert_eq!(effective_path, db_path);
@@ -656,12 +680,14 @@ mod tests {
 
     #[test]
     fn test_effective_database_path_fallback_success() {
-        // Test successful fallback when default path exists
         let default_path = ThingsConfig::get_default_database_path();
 
-        // Only test if default path actually exists
         if default_path.exists() {
-            let config = ThingsConfig::new("/nonexistent/path.sqlite", true);
+            let config = ThingsConfig::builder()
+                .database_path("/nonexistent/path.sqlite")
+                .fallback_to_default(true)
+                .build()
+                .unwrap();
             let effective_path = config.get_effective_database_path().unwrap();
             assert_eq!(effective_path, default_path);
         }
@@ -669,11 +695,13 @@ mod tests {
 
     #[test]
     fn test_config_debug_implementation() {
-        // Test that Debug trait is properly implemented
-        let config = ThingsConfig::new("/test/debug/path", true);
+        let config = ThingsConfig::builder()
+            .database_path("/test/debug/path")
+            .fallback_to_default(true)
+            .build()
+            .unwrap();
         let debug_str = format!("{config:?}");
 
-        // Should contain both fields
         assert!(debug_str.contains("database_path"));
         assert!(debug_str.contains("fallback_to_default"));
         assert!(debug_str.contains("/test/debug/path"));
@@ -682,25 +710,26 @@ mod tests {
 
     #[test]
     fn test_config_clone_implementation() {
-        // Test that Clone trait works correctly
-        let config1 = ThingsConfig::new("/test/clone/path", true);
+        let config1 = ThingsConfig::builder()
+            .database_path("/test/clone/path")
+            .fallback_to_default(true)
+            .build()
+            .unwrap();
         let config2 = config1.clone();
 
-        // Should be equal
-        assert_eq!(config1.database_path, config2.database_path);
-        assert_eq!(config1.fallback_to_default, config2.fallback_to_default);
+        assert_eq!(config1.database_path(), config2.database_path());
+        assert_eq!(config1.fallback_to_default(), config2.fallback_to_default());
 
-        // Should be independent (modifying one doesn't affect the other)
-        let config3 = ThingsConfig::new("/different/path", false);
-        assert_ne!(config1.database_path, config3.database_path);
-        assert_ne!(config1.fallback_to_default, config3.fallback_to_default);
+        let config3 = ThingsConfig::builder()
+            .database_path("/different/path")
+            .build()
+            .unwrap();
+        assert_ne!(config1.database_path(), config3.database_path());
+        assert_ne!(config1.fallback_to_default(), config3.fallback_to_default());
     }
 
     #[test]
     fn test_get_default_database_path_format() {
-        // Test that the default path has the expected format. The 4-char
-        // suffix on `ThingsData-XXXXX` varies per install, so we only assert
-        // structure — never the literal `ThingsData-0Z0Z2`.
         let default_path = ThingsConfig::get_default_database_path();
         let path_str = default_path.to_string_lossy();
 
@@ -714,55 +743,54 @@ mod tests {
 
     #[test]
     fn test_home_env_var_fallback() {
-        // Test that the default path handles missing HOME environment variable
-        // This is tricky to test without affecting the environment, so we'll test the logic indirectly
         let default_path = ThingsConfig::get_default_database_path();
         let path_str = default_path.to_string_lossy();
 
-        // Should start with either a valid home path or "~" fallback
         assert!(path_str.starts_with('/') || path_str.starts_with('~'));
     }
 
     #[test]
     fn test_config_effective_database_path_existing_file() {
-        // Create a temporary file for testing
         let temp_dir = std::env::temp_dir();
         let temp_file = temp_dir.join("test_db.sqlite");
         std::fs::File::create(&temp_file).unwrap();
 
-        let config = ThingsConfig::new(temp_file.clone(), false);
+        let config = ThingsConfig::builder()
+            .database_path(&temp_file)
+            .build()
+            .unwrap();
         let effective_path = config.get_effective_database_path().unwrap();
         assert_eq!(effective_path, temp_file);
 
-        // Clean up
         std::fs::remove_file(&temp_file).unwrap();
     }
 
     #[test]
     fn test_config_effective_database_path_fallback_success() {
-        // Create a temporary file to simulate an existing database
         let temp_dir = std::env::temp_dir();
         let temp_file = temp_dir.join("test_database.sqlite");
         std::fs::File::create(&temp_file).unwrap();
 
-        // Create a config with the temp file as the database path
-        let config = ThingsConfig::new(temp_file.clone(), true);
+        let config = ThingsConfig::builder()
+            .database_path(&temp_file)
+            .fallback_to_default(true)
+            .build()
+            .unwrap();
 
         let effective_path = config.get_effective_database_path().unwrap();
-
-        // Should return the existing file path
         assert_eq!(effective_path, temp_file);
 
-        // Clean up
         std::fs::remove_file(&temp_file).unwrap();
     }
 
     #[test]
     fn test_config_effective_database_path_fallback_disabled_error_message() {
         let non_existent_path = PathBuf::from("/nonexistent/path/db.sqlite");
-        let config = ThingsConfig::new(non_existent_path, false);
+        let config = ThingsConfig::builder()
+            .database_path(&non_existent_path)
+            .build()
+            .unwrap();
 
-        // This should return an error when fallback is disabled and path doesn't exist
         let result = config.get_effective_database_path();
         assert!(result.is_err());
         let error = result.unwrap_err();
@@ -775,18 +803,18 @@ mod tests {
     #[test]
     #[serial]
     fn test_config_effective_database_path_fallback_enabled_but_default_missing() {
-        // Temporarily change HOME to a non-existent directory to ensure default path doesn't exist
         let original_home = std::env::var("HOME").ok();
         std::env::set_var("HOME", "/nonexistent/home");
 
-        // Create a config with a non-existent path and fallback enabled
         let non_existent_path = PathBuf::from("/nonexistent/path/db.sqlite");
-        let config = ThingsConfig::new(non_existent_path, true);
+        let config = ThingsConfig::builder()
+            .database_path(&non_existent_path)
+            .fallback_to_default(true)
+            .build()
+            .unwrap();
 
-        // This should return an error when both the configured path and default path don't exist
         let result = config.get_effective_database_path();
 
-        // Restore original HOME
         if let Some(home) = original_home {
             std::env::set_var("HOME", home);
         } else {
@@ -803,7 +831,6 @@ mod tests {
             ThingsError::Database(ThingsDatabaseError::Configuration { .. })
         ));
 
-        // Check the error message contains the expected text
         let error_message = format!("{error}");
         assert!(error_message.contains("Database not found at /nonexistent/path/db.sqlite"));
         assert!(error_message.contains("fallback is enabled but default path also not found"));
@@ -813,20 +840,28 @@ mod tests {
     fn test_config_fallback_behavior() {
         let path = PathBuf::from("/test/path/db.sqlite");
 
-        // Test with fallback enabled
-        let config_with_fallback = ThingsConfig::new(path.clone(), true);
-        assert!(config_with_fallback.fallback_to_default);
+        let config_with_fallback = ThingsConfig::builder()
+            .database_path(&path)
+            .fallback_to_default(true)
+            .build()
+            .unwrap();
+        assert!(config_with_fallback.fallback_to_default());
 
-        // Test with fallback disabled
-        let config_without_fallback = ThingsConfig::new(path, false);
-        assert!(!config_without_fallback.fallback_to_default);
+        let config_without_fallback = ThingsConfig::builder()
+            .database_path(&path)
+            .build()
+            .unwrap();
+        assert!(!config_without_fallback.fallback_to_default());
     }
 
     #[test]
     fn test_config_fallback_disabled() {
         let path = PathBuf::from("/test/path/db.sqlite");
-        let config = ThingsConfig::new(path, false);
-        assert!(!config.fallback_to_default);
+        let config = ThingsConfig::builder()
+            .database_path(&path)
+            .build()
+            .unwrap();
+        assert!(!config.fallback_to_default());
     }
 
     #[test]
@@ -842,7 +877,7 @@ mod tests {
 
         let config = ThingsConfig::from_env();
         let contains_default = config
-            .database_path
+            .database_path()
             .to_string_lossy()
             .contains("Things Database.thingsdatabase");
 
@@ -861,9 +896,6 @@ mod tests {
 
     #[test]
     fn test_config_from_env_fallback_parsing() {
-        // Test the parsing logic directly without relying on environment variables
-        // This avoids potential race conditions or environment variable isolation issues in CI
-
         let test_cases = vec![
             ("true", true),
             ("false", false),
@@ -875,12 +907,8 @@ mod tests {
         ];
 
         for (value, expected) in test_cases {
-            // Test the parsing logic directly
             let lower = value.to_lowercase();
-            let result = match lower.as_str() {
-                "true" | "1" | "yes" | "on" => true,
-                _ => false, // Default to false for invalid values
-            };
+            let result = matches!(lower.as_str(), "true" | "1" | "yes" | "on");
 
             assert_eq!(
                 result, expected,
@@ -896,12 +924,11 @@ mod tests {
 
         let config = result.unwrap();
         assert!(
-            !config.fallback_to_default,
+            !config.fallback_to_default(),
             "Test config should have fallback disabled"
         );
 
-        // Test config should use a temporary database path
-        let path_str = config.database_path.to_string_lossy();
+        let path_str = config.database_path().to_string_lossy();
         assert!(
             path_str.contains("tmp") || !path_str.is_empty(),
             "Test config should use a temporary path"
@@ -910,9 +937,11 @@ mod tests {
 
     #[test]
     fn test_config_effective_database_path_error_cases() {
-        // Test with non-existent path and fallback disabled
         let non_existent_path = PathBuf::from("/absolutely/non/existent/path/database.db");
-        let config = ThingsConfig::new(&non_existent_path, false);
+        let config = ThingsConfig::builder()
+            .database_path(&non_existent_path)
+            .build()
+            .unwrap();
 
         let result = config.get_effective_database_path();
         assert!(
@@ -929,11 +958,13 @@ mod tests {
 
     #[test]
     fn test_config_effective_database_path_with_existing_file() {
-        // Create a temporary file to test with
         let temp_file = NamedTempFile::new().unwrap();
         let temp_path = temp_file.path().to_path_buf();
 
-        let config = ThingsConfig::new(&temp_path, false);
+        let config = ThingsConfig::builder()
+            .database_path(&temp_path)
+            .build()
+            .unwrap();
         let effective_path = config.get_effective_database_path().unwrap();
 
         assert_eq!(effective_path, temp_path);
@@ -964,22 +995,26 @@ mod tests {
 
     #[test]
     fn test_config_with_different_path_types_comprehensive() {
-        // Test with string path
         let string_path = "/test/path/db.sqlite";
-        let config1 = ThingsConfig::new(string_path, false);
-        assert_eq!(config1.database_path, PathBuf::from(string_path));
-        assert!(!config1.fallback_to_default);
+        let config1 = ThingsConfig::builder()
+            .database_path(string_path)
+            .build()
+            .unwrap();
+        assert_eq!(config1.database_path(), Path::new(string_path));
+        assert!(!config1.fallback_to_default());
 
-        // Test with PathBuf
         let pathbuf_path = PathBuf::from("/another/test/path.db");
-        let config2 = ThingsConfig::new(&pathbuf_path, true);
-        assert_eq!(config2.database_path, pathbuf_path);
-        assert!(config2.fallback_to_default);
+        let config2 = ThingsConfig::builder()
+            .database_path(&pathbuf_path)
+            .fallback_to_default(true)
+            .build()
+            .unwrap();
+        assert_eq!(config2.database_path(), pathbuf_path);
+        assert!(config2.fallback_to_default());
     }
 
     #[test]
     fn test_config_from_env_edge_cases() {
-        // Test the parsing logic for edge cases
         let test_cases = vec![
             ("true", true),
             ("TRUE", true),
@@ -1000,7 +1035,6 @@ mod tests {
         ];
 
         for (value, expected) in test_cases {
-            // Test the parsing logic directly (matches the implementation)
             let lower = value.to_lowercase();
             let result = matches!(lower.as_str(), "true" | "1" | "yes" | "on");
             assert_eq!(result, expected, "Failed for value: '{value}'");
@@ -1010,10 +1044,8 @@ mod tests {
     #[test]
     #[serial]
     fn test_config_from_env_fallback_parsing_with_env_vars() {
-        // Save original value
         let original_value = std::env::var("THINGS_FALLBACK_TO_DEFAULT").ok();
 
-        // Test different fallback values with actual environment variables
         let test_cases = vec![
             ("true", true),
             ("false", false),
@@ -1025,38 +1057,36 @@ mod tests {
         ];
 
         for (value, expected) in test_cases {
-            // Clear any existing value first
             std::env::remove_var("THINGS_FALLBACK_TO_DEFAULT");
-
-            // Set the test value
             std::env::set_var("THINGS_FALLBACK_TO_DEFAULT", value);
 
-            // Verify the environment variable is set correctly
             let env_value = std::env::var("THINGS_FALLBACK_TO_DEFAULT")
                 .unwrap_or_else(|_| "NOT_SET".to_string());
             println!("Environment variable set to: '{env_value}'");
 
-            // Double-check the environment variable is still set right before calling from_env
             let env_value_check = std::env::var("THINGS_FALLBACK_TO_DEFAULT")
                 .unwrap_or_else(|_| "NOT_SET".to_string());
             println!("Environment variable check before from_env: '{env_value_check}'");
 
             let config = ThingsConfig::from_env();
 
-            // Debug: print what we're testing
             println!(
                 "Testing value: '{}', expected: {}, got: {}",
-                value, expected, config.fallback_to_default
+                value,
+                expected,
+                config.fallback_to_default()
             );
 
             assert_eq!(
-                config.fallback_to_default, expected,
+                config.fallback_to_default(),
+                expected,
                 "Failed for value: '{}', expected: {}, got: {}",
-                value, expected, config.fallback_to_default
+                value,
+                expected,
+                config.fallback_to_default()
             );
         }
 
-        // Restore original value
         if let Some(original) = original_value {
             std::env::set_var("THINGS_FALLBACK_TO_DEFAULT", original);
         } else {
@@ -1067,8 +1097,6 @@ mod tests {
     #[test]
     #[serial]
     fn test_config_home_env_var_fallback() {
-        // Snapshot all env vars from_env() reads, so we can assert the default
-        // HOME-based path and restore cleanly even if prior serial tests leaked state.
         let original_home = std::env::var("HOME").ok();
         let original_db_path = std::env::var("THINGS_DB_PATH").ok();
         let original_legacy = std::env::var("THINGS_DATABASE_PATH").ok();
@@ -1079,7 +1107,7 @@ mod tests {
 
         let config = ThingsConfig::from_env();
         let contains_default = config
-            .database_path
+            .database_path()
             .to_string_lossy()
             .contains("Things Database.thingsdatabase");
 
@@ -1102,9 +1130,19 @@ mod tests {
     fn test_config_with_default_path() {
         let config = ThingsConfig::with_default_path();
         assert!(config
-            .database_path
+            .database_path()
             .to_string_lossy()
             .contains("Things Database.thingsdatabase"));
-        assert!(!config.fallback_to_default);
+        assert!(!config.fallback_to_default());
+    }
+
+    #[test]
+    fn test_builder_default_uses_default_database_path() {
+        let config = ThingsConfig::builder().build().unwrap();
+        assert_eq!(
+            config.database_path(),
+            ThingsConfig::get_default_database_path()
+        );
+        assert!(!config.fallback_to_default());
     }
 }

--- a/libs/things3-core/src/config.rs
+++ b/libs/things3-core/src/config.rs
@@ -12,6 +12,7 @@ pub struct ThingsConfig {
 }
 
 /// Builder for [`ThingsConfig`].
+#[non_exhaustive]
 #[derive(Debug, Default)]
 pub struct ThingsConfigBuilder {
     database_path: Option<PathBuf>,
@@ -19,11 +20,13 @@ pub struct ThingsConfigBuilder {
 }
 
 impl ThingsConfigBuilder {
+    #[must_use]
     pub fn database_path(mut self, path: impl AsRef<Path>) -> Self {
         self.database_path = Some(path.as_ref().to_path_buf());
         self
     }
 
+    #[must_use]
     pub fn fallback_to_default(mut self, fallback: bool) -> Self {
         self.fallback_to_default = fallback;
         self
@@ -42,6 +45,7 @@ impl ThingsConfigBuilder {
 
 impl ThingsConfig {
     /// Returns a new builder for [`ThingsConfig`].
+    #[must_use]
     pub fn builder() -> ThingsConfigBuilder {
         ThingsConfigBuilder::default()
     }

--- a/libs/things3-core/src/database/core.rs
+++ b/libs/things3-core/src/database/core.rs
@@ -8,26 +8,29 @@ use sqlx::{pool::PoolOptions, SqlitePool};
 use std::path::Path;
 use tracing::{info, instrument};
 
-/// SQLx-based database implementation for Things 3 data
-/// This provides async, Send + Sync compatible database access
+/// SQLite-backed implementation of [`ThingsDatabase`](crate::database::ThingsDatabase).
+///
+/// This is the production database implementation.  Use
+/// [`ThingsDatabase`](crate::database::ThingsDatabase) as the trait type when
+/// you need to accept any backend (e.g. the in-memory test fixture).
 #[derive(Debug, Clone)]
-pub struct ThingsDatabase {
+pub struct SqliteThingsDatabase {
     pub(crate) pool: SqlitePool,
     pub(crate) config: DatabasePoolConfig,
 }
 
-impl ThingsDatabase {
+impl SqliteThingsDatabase {
     /// Create a new database connection pool with default configuration
     ///
     /// # Examples
     ///
     /// ```no_run
-    /// use things3_core::{ThingsDatabase, ThingsError};
+    /// use things3_core::{SqliteThingsDatabase, ThingsError};
     /// use std::path::Path;
     ///
     /// # async fn example() -> Result<(), ThingsError> {
     /// // Connect to Things 3 database
-    /// let db = ThingsDatabase::new(Path::new("/path/to/things.db")).await?;
+    /// let db = SqliteThingsDatabase::new(Path::new("/path/to/things.db")).await?;
     ///
     /// // Get inbox tasks
     /// let tasks = db.get_inbox(None).await?;
@@ -49,7 +52,7 @@ impl ThingsDatabase {
     /// # Examples
     ///
     /// ```no_run
-    /// use things3_core::{ThingsDatabase, DatabasePoolConfig, ThingsError};
+    /// use things3_core::{SqliteThingsDatabase, DatabasePoolConfig, ThingsError};
     /// use std::path::Path;
     /// use std::time::Duration;
     ///
@@ -66,7 +69,7 @@ impl ThingsDatabase {
     /// };
     ///
     /// // Connect with custom configuration
-    /// let db = ThingsDatabase::new_with_config(
+    /// let db = SqliteThingsDatabase::new_with_config(
     ///     Path::new("/path/to/things.db"),
     ///     config,
     /// ).await?;
@@ -110,7 +113,7 @@ impl ThingsDatabase {
         Ok(Self { pool, config })
     }
 
-    /// Create a new database connection pool from a connection string with default configuration
+    /// Create a connection pool from a URL string with default configuration.
     ///
     /// # Errors
     ///
@@ -120,7 +123,7 @@ impl ThingsDatabase {
         Self::from_connection_string_with_config(database_url, DatabasePoolConfig::default()).await
     }
 
-    /// Create a new database connection pool from a connection string with custom configuration
+    /// Create a connection pool from a URL string with custom configuration.
     ///
     /// # Errors
     ///
@@ -156,7 +159,10 @@ impl ThingsDatabase {
         Ok(Self { pool, config })
     }
 
-    /// Get the underlying connection pool
+    /// Get the underlying SQLite connection pool.
+    ///
+    /// This is an inherent method specific to `SqliteThingsDatabase` and is not
+    /// part of the [`ThingsDatabase`](crate::database::ThingsDatabase) trait.
     #[must_use]
     pub fn pool(&self) -> &SqlitePool {
         &self.pool

--- a/libs/things3-core/src/database/health.rs
+++ b/libs/things3-core/src/database/health.rs
@@ -1,18 +1,19 @@
-//! Health check and metrics methods for `ThingsDatabase`.
 #![allow(deprecated)]
+//! Health check and metrics methods for `SqliteThingsDatabase`.
+
+use chrono::Utc;
+use tracing::{debug, error, instrument};
 
 use crate::{
     database::{
         pool::{ComprehensiveHealthStatus, PoolHealthStatus, PoolMetrics},
         stats::DatabaseStats,
-        ThingsDatabase,
+        SqliteThingsDatabase,
     },
     error::{Result as ThingsResult, ThingsError},
 };
-use chrono::Utc;
-use tracing::{debug, error, instrument};
 
-impl ThingsDatabase {
+impl SqliteThingsDatabase {
     /// Check if the database is connected
     #[instrument]
     pub async fn is_connected(&self) -> bool {

--- a/libs/things3-core/src/database/impl_trait.rs
+++ b/libs/things3-core/src/database/impl_trait.rs
@@ -1,0 +1,331 @@
+//! [`ThingsDatabase`] trait impl for [`SqliteThingsDatabase`].
+//!
+//! This is the single required `impl Trait for Type` block. Every method
+//! delegates to the identically-named inherent method on
+//! [`SqliteThingsDatabase`]; the inherent methods live in the per-concern
+//! submodules (`queries/`, `mutations/`, `health.rs`, etc.). Rust's method
+//! resolution prefers inherent methods over trait methods, so
+//! `self.method_name()` inside each body calls the inherent implementation,
+//! not the trait method — there is no infinite recursion.
+
+use async_trait::async_trait;
+use chrono::NaiveDate;
+
+use crate::database::{
+    pool::{ComprehensiveHealthStatus, PoolHealthStatus, PoolMetrics},
+    stats::DatabaseStats,
+    traits::ThingsDatabase,
+    SqliteThingsDatabase,
+};
+use crate::error::Result as ThingsResult;
+use crate::models::{
+    Area, BulkCompleteRequest, BulkDeleteRequest, BulkMoveRequest, BulkOperationResult,
+    BulkUpdateDatesRequest, CreateAreaRequest, CreateProjectRequest, CreateTagRequest,
+    CreateTaskRequest, DeleteChildHandling, Project, ProjectChildHandling, Tag,
+    TagAssignmentResult, TagCompletion, TagCreationResult, TagMatch, TagPair, TagStatistics, Task,
+    ThingsId, UpdateAreaRequest, UpdateProjectRequest, UpdateTagRequest, UpdateTaskRequest,
+};
+
+#[cfg(any(feature = "advanced-queries", feature = "batch-operations"))]
+use crate::models::TaskFilters;
+
+#[cfg(feature = "batch-operations")]
+use crate::models::Project as BatchProject;
+
+#[async_trait]
+impl ThingsDatabase for SqliteThingsDatabase {
+    // ── Queries: Tasks ────────────────────────────────────────────────────
+
+    async fn get_all_tasks(&self) -> ThingsResult<Vec<Task>> {
+        self.get_all_tasks().await
+    }
+
+    async fn get_tasks_by_status(
+        &self,
+        status: crate::models::TaskStatus,
+    ) -> ThingsResult<Vec<Task>> {
+        self.get_tasks_by_status(status).await
+    }
+
+    async fn search_tasks(&self, query: &str) -> ThingsResult<Vec<Task>> {
+        self.search_tasks(query).await
+    }
+
+    #[cfg(any(feature = "advanced-queries", feature = "batch-operations"))]
+    async fn query_tasks(&self, filters: &TaskFilters) -> ThingsResult<Vec<Task>> {
+        self.query_tasks(filters).await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn search_logbook(
+        &self,
+        search_text: Option<String>,
+        from_date: Option<NaiveDate>,
+        to_date: Option<NaiveDate>,
+        project_uuid: Option<ThingsId>,
+        area_uuid: Option<ThingsId>,
+        tags: Option<Vec<String>>,
+        limit: Option<u32>,
+        offset: Option<u32>,
+    ) -> ThingsResult<Vec<Task>> {
+        self.search_logbook(
+            search_text,
+            from_date,
+            to_date,
+            project_uuid,
+            area_uuid,
+            tags,
+            limit,
+            offset,
+        )
+        .await
+    }
+
+    async fn get_inbox(&self, limit: Option<usize>) -> ThingsResult<Vec<Task>> {
+        self.get_inbox(limit).await
+    }
+
+    async fn get_today(&self, limit: Option<usize>) -> ThingsResult<Vec<Task>> {
+        self.get_today(limit).await
+    }
+
+    async fn get_task_by_uuid(&self, id: &ThingsId) -> ThingsResult<Option<Task>> {
+        self.get_task_by_uuid(id).await
+    }
+
+    // ── Queries: Tags ─────────────────────────────────────────────────────
+
+    async fn find_tag_by_normalized_title(&self, normalized: &str) -> ThingsResult<Option<Tag>> {
+        self.find_tag_by_normalized_title(normalized).await
+    }
+
+    async fn find_similar_tags(
+        &self,
+        title: &str,
+        min_similarity: f32,
+    ) -> ThingsResult<Vec<TagMatch>> {
+        self.find_similar_tags(title, min_similarity).await
+    }
+
+    async fn search_tags(&self, query: &str) -> ThingsResult<Vec<Tag>> {
+        self.search_tags(query).await
+    }
+
+    async fn get_all_tags(&self) -> ThingsResult<Vec<Tag>> {
+        self.get_all_tags().await
+    }
+
+    async fn get_popular_tags(&self, limit: usize) -> ThingsResult<Vec<Tag>> {
+        self.get_popular_tags(limit).await
+    }
+
+    async fn get_recent_tags(&self, limit: usize) -> ThingsResult<Vec<Tag>> {
+        self.get_recent_tags(limit).await
+    }
+
+    async fn get_tag_completions(
+        &self,
+        partial_input: &str,
+        limit: usize,
+    ) -> ThingsResult<Vec<TagCompletion>> {
+        self.get_tag_completions(partial_input, limit).await
+    }
+
+    async fn get_tag_statistics(&self, id: &ThingsId) -> ThingsResult<TagStatistics> {
+        self.get_tag_statistics(id).await
+    }
+
+    async fn find_duplicate_tags(&self, min_similarity: f32) -> ThingsResult<Vec<TagPair>> {
+        self.find_duplicate_tags(min_similarity).await
+    }
+
+    // ── Queries: Projects ─────────────────────────────────────────────────
+
+    async fn get_all_projects(&self) -> ThingsResult<Vec<Project>> {
+        self.get_all_projects().await
+    }
+
+    async fn get_projects(&self, limit: Option<usize>) -> ThingsResult<Vec<Project>> {
+        self.get_projects(limit).await
+    }
+
+    async fn get_project_by_uuid(&self, id: &ThingsId) -> ThingsResult<Option<Project>> {
+        self.get_project_by_uuid(id).await
+    }
+
+    // ── Queries: Areas ────────────────────────────────────────────────────
+
+    async fn get_all_areas(&self) -> ThingsResult<Vec<Area>> {
+        self.get_all_areas().await
+    }
+
+    async fn get_areas(&self) -> ThingsResult<Vec<Area>> {
+        self.get_areas().await
+    }
+
+    // ── Mutations: Tasks ──────────────────────────────────────────────────
+
+    async fn create_task(&self, request: CreateTaskRequest) -> ThingsResult<ThingsId> {
+        self.create_task(request).await
+    }
+
+    async fn update_task(&self, request: UpdateTaskRequest) -> ThingsResult<()> {
+        self.update_task(request).await
+    }
+
+    async fn complete_task(&self, id: &ThingsId) -> ThingsResult<()> {
+        self.complete_task(id).await
+    }
+
+    async fn uncomplete_task(&self, id: &ThingsId) -> ThingsResult<()> {
+        self.uncomplete_task(id).await
+    }
+
+    async fn delete_task(
+        &self,
+        id: &ThingsId,
+        child_handling: DeleteChildHandling,
+    ) -> ThingsResult<()> {
+        self.delete_task(id, child_handling).await
+    }
+
+    // ── Mutations: Tags ───────────────────────────────────────────────────
+
+    async fn create_tag_smart(&self, request: CreateTagRequest) -> ThingsResult<TagCreationResult> {
+        self.create_tag_smart(request).await
+    }
+
+    async fn create_tag_force(&self, request: CreateTagRequest) -> ThingsResult<ThingsId> {
+        self.create_tag_force(request).await
+    }
+
+    async fn update_tag(&self, request: UpdateTagRequest) -> ThingsResult<()> {
+        self.update_tag(request).await
+    }
+
+    async fn delete_tag(&self, id: &ThingsId, remove_from_tasks: bool) -> ThingsResult<()> {
+        self.delete_tag(id, remove_from_tasks).await
+    }
+
+    async fn merge_tags(&self, source_id: &ThingsId, target_id: &ThingsId) -> ThingsResult<()> {
+        self.merge_tags(source_id, target_id).await
+    }
+
+    async fn add_tag_to_task(
+        &self,
+        task_id: &ThingsId,
+        tag_title: &str,
+    ) -> ThingsResult<TagAssignmentResult> {
+        self.add_tag_to_task(task_id, tag_title).await
+    }
+
+    async fn remove_tag_from_task(&self, task_id: &ThingsId, tag_title: &str) -> ThingsResult<()> {
+        self.remove_tag_from_task(task_id, tag_title).await
+    }
+
+    async fn set_task_tags(
+        &self,
+        task_id: &ThingsId,
+        tag_titles: Vec<String>,
+    ) -> ThingsResult<Vec<TagMatch>> {
+        self.set_task_tags(task_id, tag_titles).await
+    }
+
+    // ── Mutations: Projects ───────────────────────────────────────────────
+
+    async fn create_project(&self, request: CreateProjectRequest) -> ThingsResult<ThingsId> {
+        self.create_project(request).await
+    }
+
+    async fn update_project(&self, request: UpdateProjectRequest) -> ThingsResult<()> {
+        self.update_project(request).await
+    }
+
+    async fn complete_project(
+        &self,
+        id: &ThingsId,
+        child_handling: ProjectChildHandling,
+    ) -> ThingsResult<()> {
+        self.complete_project(id, child_handling).await
+    }
+
+    async fn delete_project(
+        &self,
+        id: &ThingsId,
+        child_handling: ProjectChildHandling,
+    ) -> ThingsResult<()> {
+        self.delete_project(id, child_handling).await
+    }
+
+    // ── Mutations: Areas ──────────────────────────────────────────────────
+
+    async fn create_area(&self, request: CreateAreaRequest) -> ThingsResult<ThingsId> {
+        self.create_area(request).await
+    }
+
+    async fn update_area(&self, request: UpdateAreaRequest) -> ThingsResult<()> {
+        self.update_area(request).await
+    }
+
+    async fn delete_area(&self, id: &ThingsId) -> ThingsResult<()> {
+        self.delete_area(id).await
+    }
+
+    // ── Mutations: Bulk ───────────────────────────────────────────────────
+
+    async fn bulk_move(&self, request: BulkMoveRequest) -> ThingsResult<BulkOperationResult> {
+        self.bulk_move(request).await
+    }
+
+    async fn bulk_update_dates(
+        &self,
+        request: BulkUpdateDatesRequest,
+    ) -> ThingsResult<BulkOperationResult> {
+        self.bulk_update_dates(request).await
+    }
+
+    async fn bulk_complete(
+        &self,
+        request: BulkCompleteRequest,
+    ) -> ThingsResult<BulkOperationResult> {
+        self.bulk_complete(request).await
+    }
+
+    async fn bulk_delete(&self, request: BulkDeleteRequest) -> ThingsResult<BulkOperationResult> {
+        self.bulk_delete(request).await
+    }
+
+    // ── Health & Diagnostics ──────────────────────────────────────────────
+
+    async fn is_connected(&self) -> bool {
+        self.is_connected().await
+    }
+
+    async fn get_pool_health(&self) -> ThingsResult<PoolHealthStatus> {
+        self.get_pool_health().await
+    }
+
+    async fn get_pool_metrics(&self) -> ThingsResult<PoolMetrics> {
+        self.get_pool_metrics().await
+    }
+
+    async fn comprehensive_health_check(&self) -> ThingsResult<ComprehensiveHealthStatus> {
+        self.comprehensive_health_check().await
+    }
+
+    async fn get_stats(&self) -> ThingsResult<DatabaseStats> {
+        self.get_stats().await
+    }
+
+    // ── Batch operations (feature-gated) ──────────────────────────────────
+
+    #[cfg(feature = "batch-operations")]
+    async fn get_tasks_batch(&self, uuids: &[ThingsId]) -> ThingsResult<Vec<Task>> {
+        self.get_tasks_batch(uuids).await
+    }
+
+    #[cfg(feature = "batch-operations")]
+    async fn get_projects_batch(&self, uuids: &[ThingsId]) -> ThingsResult<Vec<BatchProject>> {
+        self.get_projects_batch(uuids).await
+    }
+}

--- a/libs/things3-core/src/database/mod.rs
+++ b/libs/things3-core/src/database/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod conversions;
 mod core;
 pub mod date_utils;
 mod health;
+mod impl_trait;
 pub mod mappers;
 mod mutations;
 pub(crate) mod path_discovery;
@@ -14,10 +15,14 @@ pub(crate) mod stats;
 pub mod tag_utils;
 #[cfg(test)]
 mod tests;
+pub mod traits;
 pub mod validators;
 
-// Re-export everything from core for backward compatibility
-pub use core::*;
+// Re-export the concrete SQLite implementation
+pub use core::SqliteThingsDatabase;
+
+// Re-export the database trait
+pub use traits::ThingsDatabase;
 
 // Re-export conversions
 pub use conversions::{

--- a/libs/things3-core/src/database/mutations/areas.rs
+++ b/libs/things3-core/src/database/mutations/areas.rs
@@ -1,14 +1,13 @@
 #![allow(deprecated)]
-
 use crate::{
-    database::{validators, ThingsDatabase},
+    database::{validators, SqliteThingsDatabase},
     error::{Result as ThingsResult, ThingsError},
     models::ThingsId,
 };
 use chrono::Utc;
 use tracing::{info, instrument};
 
-impl ThingsDatabase {
+impl SqliteThingsDatabase {
     /// Create a new area
     ///
     /// # Errors

--- a/libs/things3-core/src/database/mutations/bulk.rs
+++ b/libs/things3-core/src/database/mutations/bulk.rs
@@ -1,14 +1,13 @@
 #![allow(deprecated)]
-
 use crate::{
-    database::{conversions::naive_date_to_things_timestamp, validators, ThingsDatabase},
+    database::{conversions::naive_date_to_things_timestamp, validators, SqliteThingsDatabase},
     error::{Result as ThingsResult, ThingsDatabaseError, ThingsError},
 };
 use chrono::Utc;
 use sqlx::Row;
 use tracing::{info, instrument};
 
-impl ThingsDatabase {
+impl SqliteThingsDatabase {
     /// Maximum number of tasks that can be processed in a single bulk operation
     /// This prevents abuse and ensures reasonable transaction sizes
     const MAX_BULK_BATCH_SIZE: usize = 1000;

--- a/libs/things3-core/src/database/mutations/projects.rs
+++ b/libs/things3-core/src/database/mutations/projects.rs
@@ -1,9 +1,8 @@
 #![allow(deprecated)]
-
 use crate::{
     database::{
         conversions::naive_date_to_things_timestamp, query_builders::TaskUpdateBuilder, validators,
-        ThingsDatabase,
+        SqliteThingsDatabase,
     },
     error::{Result as ThingsResult, ThingsError},
     models::ThingsId,
@@ -11,7 +10,7 @@ use crate::{
 use chrono::Utc;
 use tracing::{info, instrument};
 
-impl ThingsDatabase {
+impl SqliteThingsDatabase {
     /// Create a new project
     ///
     /// Projects are tasks with type = 1 in the TMTask table

--- a/libs/things3-core/src/database/mutations/tags.rs
+++ b/libs/things3-core/src/database/mutations/tags.rs
@@ -1,14 +1,13 @@
 #![allow(deprecated)]
-
 use crate::{
-    database::{validators, ThingsDatabase},
+    database::{validators, SqliteThingsDatabase},
     error::{Result as ThingsResult, ThingsError},
     models::ThingsId,
 };
 use chrono::Utc;
 use tracing::{info, instrument};
 
-impl ThingsDatabase {
+impl SqliteThingsDatabase {
     /// Create a tag with smart duplicate detection
     ///
     /// Returns:

--- a/libs/things3-core/src/database/mutations/tasks.rs
+++ b/libs/things3-core/src/database/mutations/tasks.rs
@@ -1,9 +1,8 @@
 #![allow(deprecated)]
-
 use crate::{
     database::{
         conversions::naive_date_to_things_timestamp, query_builders::TaskUpdateBuilder, validators,
-        ThingsDatabase,
+        SqliteThingsDatabase,
     },
     error::{Result as ThingsResult, ThingsError},
     models::{
@@ -14,7 +13,7 @@ use chrono::Utc;
 use sqlx::Row;
 use tracing::{info, instrument};
 
-impl ThingsDatabase {
+impl SqliteThingsDatabase {
     /// Create a new task in the database
     ///
     /// Validates:
@@ -28,12 +27,12 @@ impl ThingsDatabase {
     /// # Examples
     ///
     /// ```no_run
-    /// use things3_core::{ThingsDatabase, CreateTaskRequest, ThingsError};
+    /// use things3_core::{SqliteThingsDatabase, CreateTaskRequest, ThingsError};
     /// use std::path::Path;
     /// use chrono::NaiveDate;
     ///
     /// # async fn example() -> Result<(), ThingsError> {
-    /// let db = ThingsDatabase::new(Path::new("/path/to/things.db")).await?;
+    /// let db = SqliteThingsDatabase::new(Path::new("/path/to/things.db")).await?;
     ///
     /// // Create a simple task
     /// let request = CreateTaskRequest {

--- a/libs/things3-core/src/database/queries/areas.rs
+++ b/libs/things3-core/src/database/queries/areas.rs
@@ -1,7 +1,6 @@
 #![allow(deprecated)]
-
 use crate::{
-    database::ThingsDatabase,
+    database::SqliteThingsDatabase,
     error::{Result as ThingsResult, ThingsError},
     models::{Area, ThingsId},
 };
@@ -9,7 +8,7 @@ use chrono::Utc;
 use sqlx::Row;
 use tracing::{debug, instrument};
 
-impl ThingsDatabase {
+impl SqliteThingsDatabase {
     /// Get all areas
     ///
     /// # Errors

--- a/libs/things3-core/src/database/queries/projects.rs
+++ b/libs/things3-core/src/database/queries/projects.rs
@@ -1,7 +1,8 @@
 #![allow(deprecated)]
-
 use crate::{
-    database::{conversions::safe_timestamp_convert, mappers::map_project_row, ThingsDatabase},
+    database::{
+        conversions::safe_timestamp_convert, mappers::map_project_row, SqliteThingsDatabase,
+    },
     error::{Result as ThingsResult, ThingsError},
     models::{Project, TaskStatus, ThingsId},
 };
@@ -9,7 +10,7 @@ use chrono::{DateTime, Utc};
 use sqlx::Row;
 use tracing::{debug, instrument};
 
-impl ThingsDatabase {
+impl SqliteThingsDatabase {
     /// Get all projects (from `TMTask` table where type = 1)
     ///
     /// # Errors

--- a/libs/things3-core/src/database/queries/tags.rs
+++ b/libs/things3-core/src/database/queries/tags.rs
@@ -1,7 +1,6 @@
 #![allow(deprecated)]
-
 use crate::{
-    database::{conversions::safe_timestamp_convert, ThingsDatabase},
+    database::{conversions::safe_timestamp_convert, SqliteThingsDatabase},
     error::{Result as ThingsResult, ThingsError},
     models::ThingsId,
 };
@@ -9,7 +8,7 @@ use chrono::DateTime;
 use sqlx::Row;
 use tracing::instrument;
 
-impl ThingsDatabase {
+impl SqliteThingsDatabase {
     /// Find a tag by normalized title (exact match, case-insensitive)
     ///
     /// # Errors

--- a/libs/things3-core/src/database/queries/tasks.rs
+++ b/libs/things3-core/src/database/queries/tasks.rs
@@ -1,11 +1,10 @@
 #![allow(deprecated)]
-
 #[cfg(feature = "advanced-queries")]
 use crate::database::conversions::naive_date_to_things_timestamp;
 #[cfg(feature = "advanced-queries")]
 use crate::models::TaskFilters;
 use crate::{
-    database::{mappers::map_task_row, ThingsDatabase},
+    database::{mappers::map_task_row, SqliteThingsDatabase},
     error::{Result as ThingsResult, ThingsError},
     models::{Task, TaskStatus, TaskType, ThingsId},
 };
@@ -15,17 +14,17 @@ use tracing::{debug, instrument};
 #[cfg(any(feature = "advanced-queries", feature = "batch-operations"))]
 use uuid::Uuid;
 
-impl ThingsDatabase {
+impl SqliteThingsDatabase {
     /// Get all tasks from the database
     ///
     /// # Examples
     ///
     /// ```no_run
-    /// use things3_core::{ThingsDatabase, ThingsError};
+    /// use things3_core::{SqliteThingsDatabase, ThingsError};
     /// use std::path::Path;
     ///
     /// # async fn example() -> Result<(), ThingsError> {
-    /// let db = ThingsDatabase::new(Path::new("/path/to/things.db")).await?;
+    /// let db = SqliteThingsDatabase::new(Path::new("/path/to/things.db")).await?;
     ///
     /// // Get all tasks
     /// let tasks = db.get_all_tasks().await?;

--- a/libs/things3-core/src/database/tests.rs
+++ b/libs/things3-core/src/database/tests.rs
@@ -12,13 +12,13 @@ async fn test_database_connection() {
 
     // This will fail because the database doesn't exist yet
     // In a real implementation, we'd need to create the schema first
-    let result = super::ThingsDatabase::new(&db_path).await;
+    let result = super::SqliteThingsDatabase::new(&db_path).await;
     assert!(result.is_err());
 }
 
 #[tokio::test]
 async fn test_connection_string() {
-    let result = super::ThingsDatabase::from_connection_string("sqlite::memory:").await;
+    let result = super::SqliteThingsDatabase::from_connection_string("sqlite::memory:").await;
     assert!(result.is_ok());
 }
 
@@ -41,7 +41,7 @@ async fn test_database_new_with_config() {
         sqlite_optimizations: SqliteOptimizations::default(),
     };
 
-    let database = ThingsDatabase::new_with_config(db_path, config)
+    let database = SqliteThingsDatabase::new_with_config(db_path, config)
         .await
         .unwrap();
     let pool = database.pool();
@@ -51,7 +51,7 @@ async fn test_database_new_with_config() {
 #[tokio::test]
 async fn test_database_error_handling_invalid_path() {
     // Test with non-existent database path
-    let result = ThingsDatabase::new(Path::new("/non/existent/path.db")).await;
+    let result = SqliteThingsDatabase::new(Path::new("/non/existent/path.db")).await;
     assert!(result.is_err(), "Should fail with non-existent path");
 }
 
@@ -63,7 +63,7 @@ async fn test_database_get_stats() {
     crate::test_utils::create_test_database(db_path)
         .await
         .unwrap();
-    let database = ThingsDatabase::new(db_path).await.unwrap();
+    let database = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     let stats = database.get_stats().await.unwrap();
     assert!(stats.task_count > 0, "Should have test tasks");
@@ -79,7 +79,7 @@ async fn test_database_comprehensive_health_check() {
     crate::test_utils::create_test_database(db_path)
         .await
         .unwrap();
-    let database = ThingsDatabase::new(db_path).await.unwrap();
+    let database = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     let health = database.comprehensive_health_check().await.unwrap();
     assert!(health.overall_healthy, "Database should be healthy");
@@ -97,12 +97,12 @@ mod query_tasks_tests {
     use crate::query::TaskQueryBuilder;
     use tempfile::NamedTempFile;
 
-    async fn open_test_db() -> (ThingsDatabase, NamedTempFile) {
+    async fn open_test_db() -> (SqliteThingsDatabase, NamedTempFile) {
         let f = NamedTempFile::new().unwrap();
         crate::test_utils::create_test_database(f.path())
             .await
             .unwrap();
-        let db = ThingsDatabase::new(f.path()).await.unwrap();
+        let db = SqliteThingsDatabase::new(f.path()).await.unwrap();
         (db, f)
     }
 
@@ -185,7 +185,7 @@ mod query_tasks_tests {
         .unwrap();
         pool.close().await;
 
-        let db = ThingsDatabase::new(f.path()).await.unwrap();
+        let db = SqliteThingsDatabase::new(f.path()).await.unwrap();
 
         // Default query must not surface the trashed row
         let active = db.query_tasks(&TaskFilters::default()).await.unwrap();
@@ -263,7 +263,7 @@ mod query_tasks_tests {
     /// Insert a TMTask row with optional notes and tags.
     /// Used to seed tests; bypasses create_test_database which inserts only untagged rows.
     async fn insert_task(
-        db: &ThingsDatabase,
+        db: &SqliteThingsDatabase,
         title: &str,
         notes: Option<&str>,
         tags: &[&str],
@@ -320,12 +320,21 @@ mod query_tasks_tests {
         task_id
     }
 
-    async fn insert_task_with_tags(db: &ThingsDatabase, title: &str, tags: &[&str]) -> ThingsId {
+    async fn insert_task_with_tags(
+        db: &SqliteThingsDatabase,
+        title: &str,
+        tags: &[&str],
+    ) -> ThingsId {
         insert_task(db, title, None, tags).await
     }
 
-    async fn open_db_with_tagged_rows(
-    ) -> (ThingsDatabase, NamedTempFile, ThingsId, ThingsId, ThingsId) {
+    async fn open_db_with_tagged_rows() -> (
+        SqliteThingsDatabase,
+        NamedTempFile,
+        ThingsId,
+        ThingsId,
+        ThingsId,
+    ) {
         let (db, f) = open_test_db().await;
         let a = insert_task_with_tags(&db, "task-a", &["a"]).await;
         let b = insert_task_with_tags(&db, "task-b", &["b"]).await;
@@ -548,7 +557,7 @@ mod query_tasks_tests {
     }
 
     async fn insert_task_with_status(
-        db: &ThingsDatabase,
+        db: &SqliteThingsDatabase,
         title: &str,
         status: TaskStatus,
     ) -> ThingsId {
@@ -574,7 +583,7 @@ mod query_tasks_tests {
     }
 
     async fn insert_task_with_type(
-        db: &ThingsDatabase,
+        db: &SqliteThingsDatabase,
         title: &str,
         task_type: crate::models::TaskType,
     ) -> ThingsId {

--- a/libs/things3-core/src/database/traits.rs
+++ b/libs/things3-core/src/database/traits.rs
@@ -1,0 +1,215 @@
+//! [`ThingsDatabase`] async trait — the contract for all Things 3 database
+//! operations.  [`crate::database::SqliteThingsDatabase`] is the production
+//! implementation; alternative backends (in-memory test fixture, PostgreSQL,
+//! …) implement this trait to satisfy the same interface.
+
+use async_trait::async_trait;
+use chrono::NaiveDate;
+
+use crate::database::{
+    pool::{ComprehensiveHealthStatus, PoolHealthStatus, PoolMetrics},
+    stats::DatabaseStats,
+};
+use crate::error::Result as ThingsResult;
+use crate::models::{
+    Area, BulkCompleteRequest, BulkDeleteRequest, BulkMoveRequest, BulkOperationResult,
+    BulkUpdateDatesRequest, CreateAreaRequest, CreateProjectRequest, CreateTagRequest,
+    CreateTaskRequest, DeleteChildHandling, Project, ProjectChildHandling, Tag,
+    TagAssignmentResult, TagCompletion, TagCreationResult, TagMatch, TagPair, TagStatistics, Task,
+    ThingsId, UpdateAreaRequest, UpdateProjectRequest, UpdateTagRequest, UpdateTaskRequest,
+};
+
+#[cfg(any(feature = "advanced-queries", feature = "batch-operations"))]
+use crate::models::TaskFilters;
+
+/// Async trait covering all Things 3 database operations.
+///
+/// Implementations must be `Send + Sync` so they can be shared across async
+/// tasks via `Arc<dyn ThingsDatabase>`.
+///
+/// The production implementation is
+/// [`SqliteThingsDatabase`](crate::database::SqliteThingsDatabase).
+/// Constructor methods (`new`, `new_with_config`, `from_connection_string`,
+/// `from_connection_string_with_config`) are inherent methods on concrete
+/// types and are not part of this trait.
+#[async_trait]
+pub trait ThingsDatabase: Send + Sync {
+    // ── Queries: Tasks ────────────────────────────────────────────────────
+
+    async fn get_all_tasks(&self) -> ThingsResult<Vec<Task>>;
+
+    async fn get_tasks_by_status(
+        &self,
+        status: crate::models::TaskStatus,
+    ) -> ThingsResult<Vec<Task>>;
+
+    async fn search_tasks(&self, query: &str) -> ThingsResult<Vec<Task>>;
+
+    #[cfg(any(feature = "advanced-queries", feature = "batch-operations"))]
+    async fn query_tasks(&self, filters: &TaskFilters) -> ThingsResult<Vec<Task>>;
+
+    #[allow(clippy::too_many_arguments)]
+    async fn search_logbook(
+        &self,
+        search_text: Option<String>,
+        from_date: Option<NaiveDate>,
+        to_date: Option<NaiveDate>,
+        project_uuid: Option<ThingsId>,
+        area_uuid: Option<ThingsId>,
+        tags: Option<Vec<String>>,
+        limit: Option<u32>,
+        offset: Option<u32>,
+    ) -> ThingsResult<Vec<Task>>;
+
+    async fn get_inbox(&self, limit: Option<usize>) -> ThingsResult<Vec<Task>>;
+
+    async fn get_today(&self, limit: Option<usize>) -> ThingsResult<Vec<Task>>;
+
+    async fn get_task_by_uuid(&self, id: &ThingsId) -> ThingsResult<Option<Task>>;
+
+    // ── Queries: Tags ─────────────────────────────────────────────────────
+
+    async fn find_tag_by_normalized_title(&self, normalized: &str) -> ThingsResult<Option<Tag>>;
+
+    async fn find_similar_tags(
+        &self,
+        title: &str,
+        min_similarity: f32,
+    ) -> ThingsResult<Vec<TagMatch>>;
+
+    async fn search_tags(&self, query: &str) -> ThingsResult<Vec<Tag>>;
+
+    async fn get_all_tags(&self) -> ThingsResult<Vec<Tag>>;
+
+    async fn get_popular_tags(&self, limit: usize) -> ThingsResult<Vec<Tag>>;
+
+    async fn get_recent_tags(&self, limit: usize) -> ThingsResult<Vec<Tag>>;
+
+    async fn get_tag_completions(
+        &self,
+        partial_input: &str,
+        limit: usize,
+    ) -> ThingsResult<Vec<TagCompletion>>;
+
+    async fn get_tag_statistics(&self, id: &ThingsId) -> ThingsResult<TagStatistics>;
+
+    async fn find_duplicate_tags(&self, min_similarity: f32) -> ThingsResult<Vec<TagPair>>;
+
+    // ── Queries: Projects ─────────────────────────────────────────────────
+
+    async fn get_all_projects(&self) -> ThingsResult<Vec<Project>>;
+
+    async fn get_projects(&self, limit: Option<usize>) -> ThingsResult<Vec<Project>>;
+
+    async fn get_project_by_uuid(&self, id: &ThingsId) -> ThingsResult<Option<Project>>;
+
+    // ── Queries: Areas ────────────────────────────────────────────────────
+
+    async fn get_all_areas(&self) -> ThingsResult<Vec<Area>>;
+
+    async fn get_areas(&self) -> ThingsResult<Vec<Area>>;
+
+    // ── Mutations: Tasks ──────────────────────────────────────────────────
+
+    async fn create_task(&self, request: CreateTaskRequest) -> ThingsResult<ThingsId>;
+
+    async fn update_task(&self, request: UpdateTaskRequest) -> ThingsResult<()>;
+
+    async fn complete_task(&self, id: &ThingsId) -> ThingsResult<()>;
+
+    async fn uncomplete_task(&self, id: &ThingsId) -> ThingsResult<()>;
+
+    async fn delete_task(
+        &self,
+        id: &ThingsId,
+        child_handling: DeleteChildHandling,
+    ) -> ThingsResult<()>;
+
+    // ── Mutations: Tags ───────────────────────────────────────────────────
+
+    async fn create_tag_smart(&self, request: CreateTagRequest) -> ThingsResult<TagCreationResult>;
+
+    async fn create_tag_force(&self, request: CreateTagRequest) -> ThingsResult<ThingsId>;
+
+    async fn update_tag(&self, request: UpdateTagRequest) -> ThingsResult<()>;
+
+    async fn delete_tag(&self, id: &ThingsId, remove_from_tasks: bool) -> ThingsResult<()>;
+
+    async fn merge_tags(&self, source_id: &ThingsId, target_id: &ThingsId) -> ThingsResult<()>;
+
+    async fn add_tag_to_task(
+        &self,
+        task_id: &ThingsId,
+        tag_title: &str,
+    ) -> ThingsResult<TagAssignmentResult>;
+
+    async fn remove_tag_from_task(&self, task_id: &ThingsId, tag_title: &str) -> ThingsResult<()>;
+
+    async fn set_task_tags(
+        &self,
+        task_id: &ThingsId,
+        tag_titles: Vec<String>,
+    ) -> ThingsResult<Vec<TagMatch>>;
+
+    // ── Mutations: Projects ───────────────────────────────────────────────
+
+    async fn create_project(&self, request: CreateProjectRequest) -> ThingsResult<ThingsId>;
+
+    async fn update_project(&self, request: UpdateProjectRequest) -> ThingsResult<()>;
+
+    async fn complete_project(
+        &self,
+        id: &ThingsId,
+        child_handling: ProjectChildHandling,
+    ) -> ThingsResult<()>;
+
+    async fn delete_project(
+        &self,
+        id: &ThingsId,
+        child_handling: ProjectChildHandling,
+    ) -> ThingsResult<()>;
+
+    // ── Mutations: Areas ──────────────────────────────────────────────────
+
+    async fn create_area(&self, request: CreateAreaRequest) -> ThingsResult<ThingsId>;
+
+    async fn update_area(&self, request: UpdateAreaRequest) -> ThingsResult<()>;
+
+    async fn delete_area(&self, id: &ThingsId) -> ThingsResult<()>;
+
+    // ── Mutations: Bulk ───────────────────────────────────────────────────
+
+    async fn bulk_move(&self, request: BulkMoveRequest) -> ThingsResult<BulkOperationResult>;
+
+    async fn bulk_update_dates(
+        &self,
+        request: BulkUpdateDatesRequest,
+    ) -> ThingsResult<BulkOperationResult>;
+
+    async fn bulk_complete(
+        &self,
+        request: BulkCompleteRequest,
+    ) -> ThingsResult<BulkOperationResult>;
+
+    async fn bulk_delete(&self, request: BulkDeleteRequest) -> ThingsResult<BulkOperationResult>;
+
+    // ── Health & Diagnostics ──────────────────────────────────────────────
+
+    async fn is_connected(&self) -> bool;
+
+    async fn get_pool_health(&self) -> ThingsResult<PoolHealthStatus>;
+
+    async fn get_pool_metrics(&self) -> ThingsResult<PoolMetrics>;
+
+    async fn comprehensive_health_check(&self) -> ThingsResult<ComprehensiveHealthStatus>;
+
+    async fn get_stats(&self) -> ThingsResult<DatabaseStats>;
+
+    // ── Batch operations (feature-gated) ──────────────────────────────────
+
+    #[cfg(feature = "batch-operations")]
+    async fn get_tasks_batch(&self, uuids: &[ThingsId]) -> ThingsResult<Vec<Task>>;
+
+    #[cfg(feature = "batch-operations")]
+    async fn get_projects_batch(&self, uuids: &[ThingsId]) -> ThingsResult<Vec<Project>>;
+}

--- a/libs/things3-core/src/lib.rs
+++ b/libs/things3-core/src/lib.rs
@@ -103,7 +103,7 @@ pub use cache_invalidation_middleware::{
     InvalidationEventType, InvalidationRule, InvalidationStats, InvalidationStrategy,
     ThingsCacheInvalidationHandler,
 };
-pub use config::ThingsConfig;
+pub use config::{ThingsConfig, ThingsConfigBuilder};
 pub use config_hot_reload::{
     ConfigChangeHandler, ConfigHotReloader, ConfigHotReloaderWithHandler,
     DefaultConfigChangeHandler,

--- a/libs/things3-core/src/lib.rs
+++ b/libs/things3-core/src/lib.rs
@@ -16,12 +16,12 @@
 //! # Quick Start
 //!
 //! ```no_run
-//! use things3_core::{ThingsDatabase, ThingsError};
+//! use things3_core::{SqliteThingsDatabase, ThingsError};
 //! use std::path::Path;
 //!
 //! # async fn example() -> Result<(), ThingsError> {
 //! // Connect to Things 3 database
-//! let db = ThingsDatabase::new(Path::new("/path/to/things.db")).await?;
+//! let db = SqliteThingsDatabase::new(Path::new("/path/to/things.db")).await?;
 //!
 //! // Get inbox tasks
 //! let tasks = db.get_inbox(None).await?;
@@ -111,7 +111,7 @@ pub use config_hot_reload::{
 pub use config_loader::{load_config, load_config_from_env, load_config_with_paths, ConfigLoader};
 pub use database::{
     get_default_database_path, ComprehensiveHealthStatus, DatabasePoolConfig, DatabaseStats,
-    PoolHealthStatus, PoolMetrics, SqliteOptimizations, ThingsDatabase,
+    PoolHealthStatus, PoolMetrics, SqliteOptimizations, SqliteThingsDatabase, ThingsDatabase,
 };
 pub use disk_cache::{DiskCache, DiskCacheConfig, DiskCacheStats};
 pub use error::{Result, ThingsDatabaseError, ThingsError, ThingsExportError, ThingsQueryError};

--- a/libs/things3-core/src/mutations/applescript/mod.rs
+++ b/libs/things3-core/src/mutations/applescript/mod.rs
@@ -35,7 +35,7 @@ use async_trait::async_trait;
 use sqlx::Row;
 
 use super::MutationBackend;
-use crate::database::ThingsDatabase;
+use crate::database::SqliteThingsDatabase;
 use crate::error::{Result as ThingsResult, ThingsError};
 use crate::models::{
     BulkCompleteRequest, BulkCreateTasksRequest, BulkDeleteRequest, BulkMoveRequest,
@@ -47,17 +47,17 @@ use crate::models::{
 
 /// AppleScript-driven mutation backend.
 ///
-/// Holds an [`Arc<ThingsDatabase>`] for read-only side-channel queries — used
+/// Holds an [`Arc<SqliteThingsDatabase>`] for read-only side-channel queries — used
 /// today only by [`AppleScriptBackend::delete_task`] when it needs to discover
 /// a task's subtasks before deciding how to handle them. Reads are safe per
 /// CulturedCode; only writes risk corruption.
 pub struct AppleScriptBackend {
-    db: Arc<ThingsDatabase>,
+    db: Arc<SqliteThingsDatabase>,
 }
 
 impl AppleScriptBackend {
     #[must_use]
-    pub fn new(db: Arc<ThingsDatabase>) -> Self {
+    pub fn new(db: Arc<SqliteThingsDatabase>) -> Self {
         Self { db }
     }
 
@@ -743,7 +743,7 @@ impl MutationBackend for AppleScriptBackend {
                     });
                 }
                 // No existing match and no similar tags — auto-create. Mirrors
-                // `ThingsDatabase::add_tag_to_task` (`database/core.rs:2792-2802`).
+                // `SqliteThingsDatabase::add_tag_to_task` (`database/core.rs:2792-2802`).
                 let create_req = CreateTagRequest {
                     title: tag_title.to_string(),
                     shortcut: None,
@@ -799,7 +799,7 @@ impl MutationBackend for AppleScriptBackend {
 
         // Intentionally asymmetric with add_tag_to_task: similar-tag suggestions
         // accumulate for the caller but never block the write — every title is
-        // auto-created if absent, matching ThingsDatabase::set_task_tags semantics.
+        // auto-created if absent, matching SqliteThingsDatabase::set_task_tags semantics.
         let mut suggestions: Vec<TagMatch> = Vec::new();
         let mut resolved: Vec<String> = Vec::with_capacity(tag_titles.len());
 
@@ -813,7 +813,7 @@ impl MutationBackend for AppleScriptBackend {
             if !similar.is_empty() {
                 suggestions.extend(similar);
             }
-            // Auto-create on miss — mirrors `ThingsDatabase::set_task_tags`
+            // Auto-create on miss — mirrors `SqliteThingsDatabase::set_task_tags`
             // (`database/core.rs:2966-2981`). Suggestions are accumulated
             // for the caller's review but do not block creation.
             let create_req = CreateTagRequest {
@@ -840,7 +840,7 @@ mod tests {
     #[tokio::test]
     async fn new_does_not_spawn_osascript() {
         let db = Arc::new(
-            ThingsDatabase::from_connection_string("sqlite::memory:")
+            SqliteThingsDatabase::from_connection_string("sqlite::memory:")
                 .await
                 .expect("in-memory db"),
         );
@@ -1081,7 +1081,7 @@ mod tests {
     #[tokio::test]
     async fn merge_tags_rejects_identical_source_and_target() {
         let db = Arc::new(
-            ThingsDatabase::from_connection_string("sqlite::memory:")
+            SqliteThingsDatabase::from_connection_string("sqlite::memory:")
                 .await
                 .expect("in-memory db"),
         );
@@ -1098,7 +1098,7 @@ mod tests {
     #[tokio::test]
     async fn bulk_validation_rejects_empty_and_oversize() {
         let db = Arc::new(
-            ThingsDatabase::from_connection_string("sqlite::memory:")
+            SqliteThingsDatabase::from_connection_string("sqlite::memory:")
                 .await
                 .expect("in-memory db"),
         );
@@ -1144,7 +1144,7 @@ mod tests {
 
     async fn guard_test_backend() -> AppleScriptBackend {
         let db = Arc::new(
-            ThingsDatabase::from_connection_string("sqlite::memory:")
+            SqliteThingsDatabase::from_connection_string("sqlite::memory:")
                 .await
                 .expect("in-memory db"),
         );

--- a/libs/things3-core/src/mutations/sqlx.rs
+++ b/libs/things3-core/src/mutations/sqlx.rs
@@ -1,6 +1,6 @@
 //! `SqlxBackend` — direct-SQLite implementation of [`MutationBackend`].
 //!
-//! Forwards every call to the corresponding method on [`ThingsDatabase`]. Behavior
+//! Forwards every call to the corresponding method on [`SqliteThingsDatabase`]. Behavior
 //! is byte-for-byte identical to calling the database directly. Kept around after
 //! AppleScript becomes the default (#125) for offline tests, CI, and the
 //! `--unsafe-direct-db` opt-in.
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 
 use super::MutationBackend;
-use crate::database::ThingsDatabase;
+use crate::database::SqliteThingsDatabase;
 use crate::error::Result as ThingsResult;
 use crate::models::{
     BulkCompleteRequest, BulkCreateTasksRequest, BulkDeleteRequest, BulkMoveRequest,
@@ -21,12 +21,12 @@ use crate::models::{
 };
 
 pub struct SqlxBackend {
-    db: Arc<ThingsDatabase>,
+    db: Arc<SqliteThingsDatabase>,
 }
 
 impl SqlxBackend {
     #[must_use]
-    pub fn new(db: Arc<ThingsDatabase>) -> Self {
+    pub fn new(db: Arc<SqliteThingsDatabase>) -> Self {
         Self { db }
     }
 }

--- a/libs/things3-core/src/query.rs
+++ b/libs/things3-core/src/query.rs
@@ -310,7 +310,7 @@ impl TaskQueryBuilder {
     #[cfg(feature = "advanced-queries")]
     pub async fn execute(
         &self,
-        db: &crate::database::ThingsDatabase,
+        db: &crate::database::SqliteThingsDatabase,
     ) -> crate::error::Result<Vec<crate::models::Task>> {
         if self.fuzzy_query.is_some() {
             return self
@@ -397,11 +397,11 @@ impl TaskQueryBuilder {
     /// - [`crate::error::ThingsQueryError::InvalidCursor`] if `.offset(...)` and
     ///   `.after(...)` are both set, or if `.fuzzy_search(...)` and
     ///   `.after(...)` are both set, or if the cursor itself is malformed.
-    /// - Any error returned by [`crate::database::ThingsDatabase::query_tasks`].
+    /// - Any error returned by [`crate::database::SqliteThingsDatabase::query_tasks`].
     #[cfg(all(feature = "advanced-queries", feature = "batch-operations"))]
     pub async fn execute_paged(
         &self,
-        db: &crate::database::ThingsDatabase,
+        db: &crate::database::SqliteThingsDatabase,
     ) -> crate::error::Result<crate::cursor::Page<crate::models::Task>> {
         if self.fuzzy_query.is_some() {
             return Err(crate::error::ThingsError::Query(crate::error::ThingsQueryError::InvalidCursor(
@@ -522,7 +522,7 @@ impl TaskQueryBuilder {
     #[cfg(all(feature = "advanced-queries", feature = "batch-operations"))]
     pub fn execute_stream<'a>(
         mut self,
-        db: &'a crate::database::ThingsDatabase,
+        db: &'a crate::database::SqliteThingsDatabase,
     ) -> std::pin::Pin<
         Box<dyn futures_core::Stream<Item = crate::error::Result<crate::models::Task>> + Send + 'a>,
     >
@@ -559,7 +559,7 @@ impl TaskQueryBuilder {
     #[cfg(feature = "advanced-queries")]
     pub async fn execute_ranked(
         &self,
-        db: &crate::database::ThingsDatabase,
+        db: &crate::database::SqliteThingsDatabase,
     ) -> crate::error::Result<Vec<crate::models::RankedTask>> {
         let query = self.fuzzy_query.as_deref().ok_or_else(|| {
             crate::error::ThingsError::validation(
@@ -873,7 +873,7 @@ mod tests {
             crate::test_utils::create_test_database(f.path())
                 .await
                 .unwrap();
-            let db = crate::database::ThingsDatabase::new(f.path())
+            let db = crate::database::SqliteThingsDatabase::new(f.path())
                 .await
                 .unwrap();
 
@@ -900,7 +900,7 @@ mod tests {
             crate::test_utils::create_test_database(f.path())
                 .await
                 .unwrap();
-            let db = crate::database::ThingsDatabase::new(f.path())
+            let db = crate::database::SqliteThingsDatabase::new(f.path())
                 .await
                 .unwrap();
 
@@ -1190,7 +1190,7 @@ mod tests {
             crate::test_utils::create_test_database(f.path())
                 .await
                 .unwrap();
-            let db = crate::database::ThingsDatabase::new(f.path())
+            let db = crate::database::SqliteThingsDatabase::new(f.path())
                 .await
                 .unwrap();
             let result = TaskQueryBuilder::new().execute(&db).await;
@@ -1203,7 +1203,7 @@ mod tests {
             crate::test_utils::create_test_database(f.path())
                 .await
                 .unwrap();
-            let db = crate::database::ThingsDatabase::new(f.path())
+            let db = crate::database::SqliteThingsDatabase::new(f.path())
                 .await
                 .unwrap();
             let result = TaskQueryBuilder::new()

--- a/libs/things3-core/src/test_utils.rs
+++ b/libs/things3-core/src/test_utils.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     models::{Area, CreateTaskRequest, Project, Task, TaskStatus, TaskType, ThingsId},
-    ThingsDatabase,
+    SqliteThingsDatabase,
 };
 use chrono::{NaiveDate, Utc};
 use std::path::Path;
@@ -815,18 +815,18 @@ mod tests {
 ///
 /// # Returns
 ///
-/// A tuple of (`ThingsDatabase`, `NamedTempFile`) where the file must be kept
+/// A tuple of (`SqliteThingsDatabase`, `NamedTempFile`) where the file must be kept
 /// alive to prevent premature deletion.
 ///
 /// # Errors
 ///
 /// Returns an error if database creation or connection fails
 pub async fn create_test_database_and_connect(
-) -> Result<(ThingsDatabase, NamedTempFile), crate::ThingsError> {
+) -> Result<(SqliteThingsDatabase, NamedTempFile), crate::ThingsError> {
     let temp_file = NamedTempFile::new()?;
     let db_path = temp_file.path();
     create_test_database(db_path).await?;
-    let db = ThingsDatabase::new(db_path).await?;
+    let db = SqliteThingsDatabase::new(db_path).await?;
     Ok((db, temp_file))
 }
 

--- a/libs/things3-core/tests/applescript_live.rs
+++ b/libs/things3-core/tests/applescript_live.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 use things3_core::{
     mutations::{AppleScriptBackend, MutationBackend},
     CreateAreaRequest, CreateProjectRequest, CreateTagRequest, CreateTaskRequest,
-    DeleteChildHandling, ProjectChildHandling, ThingsDatabase, ThingsId, UpdateAreaRequest,
+    DeleteChildHandling, ProjectChildHandling, SqliteThingsDatabase, ThingsId, UpdateAreaRequest,
     UpdateProjectRequest, UpdateTagRequest, UpdateTaskRequest,
 };
 
@@ -51,7 +51,7 @@ async fn live_backend() -> Arc<AppleScriptBackend> {
         .map(std::path::PathBuf::from)
         .unwrap_or_else(|_| things3_core::get_default_database_path());
     let db = Arc::new(
-        ThingsDatabase::new(&db_path)
+        SqliteThingsDatabase::new(&db_path)
             .await
             .expect("failed to open Things 3 database"),
     );

--- a/libs/things3-core/tests/benchmark_tests.rs
+++ b/libs/things3-core/tests/benchmark_tests.rs
@@ -5,7 +5,7 @@
 
 use std::time::Instant;
 use tempfile::NamedTempFile;
-use things3_core::{CacheConfig, ThingsCache, ThingsDatabase};
+use things3_core::{CacheConfig, SqliteThingsDatabase, ThingsCache};
 
 #[cfg(feature = "test-utils")]
 use things3_core::test_utils::create_test_database;
@@ -20,7 +20,7 @@ async fn benchmark_database_connection() {
     create_test_database(db_path).await.unwrap();
 
     let start = Instant::now();
-    let _db = ThingsDatabase::new(db_path).await.unwrap();
+    let _db = SqliteThingsDatabase::new(db_path).await.unwrap();
     let duration = start.elapsed();
 
     println!("Database connection time: {:?}", duration);
@@ -39,7 +39,7 @@ async fn benchmark_get_inbox() {
     let db_path = temp_file.path();
 
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     let start = Instant::now();
     let _tasks = db.get_inbox(Some(100)).await.unwrap();
@@ -61,7 +61,7 @@ async fn benchmark_get_today() {
     let db_path = temp_file.path();
 
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     let start = Instant::now();
     let _tasks = db.get_today(Some(100)).await.unwrap();
@@ -83,7 +83,7 @@ async fn benchmark_get_projects() {
     let db_path = temp_file.path();
 
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     let start = Instant::now();
     let _projects = db.get_projects(Some(100)).await.unwrap();
@@ -105,7 +105,7 @@ async fn benchmark_search_tasks() {
     let db_path = temp_file.path();
 
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     let start = Instant::now();
     let _results = db.search_tasks("test").await.unwrap();
@@ -144,7 +144,7 @@ async fn benchmark_sequential_queries() {
     let db_path = temp_file.path();
 
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     let start = Instant::now();
     for _ in 0..10 {
@@ -169,7 +169,7 @@ async fn benchmark_health_check() {
     let db_path = temp_file.path();
 
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     let start = Instant::now();
     let _is_connected = db.is_connected().await;
@@ -191,7 +191,7 @@ async fn benchmark_mixed_queries() {
     let db_path = temp_file.path();
 
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     let start = Instant::now();
     let _ = db.get_inbox(Some(10)).await.unwrap();

--- a/libs/things3-core/tests/ci_tests.rs
+++ b/libs/things3-core/tests/ci_tests.rs
@@ -1,7 +1,7 @@
 //! CI-friendly tests that use mock data when Things 3 is not available
 
 use tempfile::NamedTempFile;
-use things3_core::ThingsDatabase;
+use things3_core::SqliteThingsDatabase;
 
 #[cfg(feature = "test-utils")]
 use things3_core::test_utils;
@@ -18,7 +18,7 @@ async fn test_ci_mock_database() {
     test_utils::create_test_database(db_path).await.unwrap();
 
     // Test that we can connect to the mock database
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     // Test all major functionality with mock data
     test_database_operations(&db);
@@ -27,7 +27,7 @@ async fn test_ci_mock_database() {
 }
 
 /// Test database operations with mock data
-fn test_database_operations(_db: &ThingsDatabase) {
+fn test_database_operations(_db: &SqliteThingsDatabase) {
     // Test basic database connection
     println!("✅ Database connection successful");
 
@@ -43,7 +43,7 @@ async fn test_fallback_to_mock_data() {
     // Use a test database path instead of trying to access the real Things 3 database
     let real_db_path = std::path::Path::new("test_things.db");
 
-    if let Ok(db) = ThingsDatabase::new(real_db_path).await {
+    if let Ok(db) = SqliteThingsDatabase::new(real_db_path).await {
         // Real database available, test with it
         println!("Using real Things 3 database for testing");
         test_database_operations(&db);
@@ -61,7 +61,7 @@ async fn test_fallback_to_mock_data() {
             println!("Testing fallback to mock data (test-utils enabled)");
 
             test_utils::create_test_database(temp_path).await.unwrap();
-            let db = ThingsDatabase::new(temp_path).await.unwrap();
+            let db = SqliteThingsDatabase::new(temp_path).await.unwrap();
             test_database_operations(&db);
 
             println!("✅ Fallback to mock data successful");
@@ -72,9 +72,9 @@ async fn test_fallback_to_mock_data() {
             // Without test-utils: verify we can handle databases gracefully
             println!("Testing database handling without test-utils");
 
-            // ThingsDatabase::new() may succeed (SQLite can open empty files)
+            // SqliteThingsDatabase::new() may succeed (SQLite can open empty files)
             // but queries should fail gracefully on an invalid database
-            let result = ThingsDatabase::new(temp_path).await;
+            let result = SqliteThingsDatabase::new(temp_path).await;
 
             match result {
                 Ok(db) => {

--- a/libs/things3-core/tests/concurrent_operations_tests.rs
+++ b/libs/things3-core/tests/concurrent_operations_tests.rs
@@ -5,7 +5,7 @@
 
 use std::sync::Arc;
 use tempfile::NamedTempFile;
-use things3_core::{CacheConfig, ThingsCache, ThingsDatabase};
+use things3_core::{CacheConfig, SqliteThingsDatabase, ThingsCache};
 use tokio::task::JoinSet;
 
 #[cfg(feature = "test-utils")]
@@ -19,7 +19,7 @@ async fn concurrent_test_database_reads() {
     let db_path = temp_file.path();
 
     create_test_database(db_path).await.unwrap();
-    let db = Arc::new(ThingsDatabase::new(db_path).await.unwrap());
+    let db = Arc::new(SqliteThingsDatabase::new(db_path).await.unwrap());
 
     let mut tasks = JoinSet::new();
     let num_tasks = 20;
@@ -61,7 +61,7 @@ async fn concurrent_test_searches() {
     let db_path = temp_file.path();
 
     create_test_database(db_path).await.unwrap();
-    let db = Arc::new(ThingsDatabase::new(db_path).await.unwrap());
+    let db = Arc::new(SqliteThingsDatabase::new(db_path).await.unwrap());
 
     let queries = vec!["test", "project", "task", "important"];
     let mut tasks = JoinSet::new();
@@ -96,7 +96,7 @@ async fn concurrent_test_health_checks() {
     let db_path = temp_file.path();
 
     create_test_database(db_path).await.unwrap();
-    let db = Arc::new(ThingsDatabase::new(db_path).await.unwrap());
+    let db = Arc::new(SqliteThingsDatabase::new(db_path).await.unwrap());
 
     let mut tasks = JoinSet::new();
     let num_checks = 30;
@@ -156,7 +156,7 @@ async fn concurrent_test_mixed_operations() {
     let db_path = temp_file.path();
 
     create_test_database(db_path).await.unwrap();
-    let db = Arc::new(ThingsDatabase::new(db_path).await.unwrap());
+    let db = Arc::new(SqliteThingsDatabase::new(db_path).await.unwrap());
 
     let mut tasks = JoinSet::new();
 
@@ -205,7 +205,7 @@ async fn concurrent_test_pool_stress() {
     let db_path = temp_file.path();
 
     create_test_database(db_path).await.unwrap();
-    let db = Arc::new(ThingsDatabase::new(db_path).await.unwrap());
+    let db = Arc::new(SqliteThingsDatabase::new(db_path).await.unwrap());
 
     let mut tasks = JoinSet::new();
     let num_concurrent = 15;
@@ -274,7 +274,7 @@ async fn concurrent_test_database_cloning() {
     let db_path = temp_file.path();
 
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     let mut tasks = JoinSet::new();
 
@@ -304,7 +304,7 @@ async fn concurrent_test_varying_query_sizes() {
     let db_path = temp_file.path();
 
     create_test_database(db_path).await.unwrap();
-    let db = Arc::new(ThingsDatabase::new(db_path).await.unwrap());
+    let db = Arc::new(SqliteThingsDatabase::new(db_path).await.unwrap());
 
     let mut tasks = JoinSet::new();
     let sizes = vec![1, 5, 10, 50, 100];
@@ -361,7 +361,7 @@ async fn concurrent_test_areas_queries() {
     let db_path = temp_file.path();
 
     create_test_database(db_path).await.unwrap();
-    let db = Arc::new(ThingsDatabase::new(db_path).await.unwrap());
+    let db = Arc::new(SqliteThingsDatabase::new(db_path).await.unwrap());
 
     let mut tasks = JoinSet::new();
 

--- a/libs/things3-core/tests/database_error_tests.rs
+++ b/libs/things3-core/tests/database_error_tests.rs
@@ -5,14 +5,14 @@
 
 use std::path::PathBuf;
 use tempfile::{NamedTempFile, TempDir};
-use things3_core::ThingsDatabase;
+use things3_core::SqliteThingsDatabase;
 
 /// Test that connecting to a non-existent database fails gracefully
 #[tokio::test]
 async fn test_database_not_found() {
     let nonexistent_path = PathBuf::from("/nonexistent/path/to/database.db");
 
-    let result = ThingsDatabase::new(&nonexistent_path).await;
+    let result = SqliteThingsDatabase::new(&nonexistent_path).await;
 
     assert!(result.is_err(), "Should fail when database doesn't exist");
 
@@ -32,7 +32,7 @@ async fn test_database_path_is_directory() {
     let temp_dir = TempDir::new().unwrap();
     let dir_path = temp_dir.path();
 
-    let result = ThingsDatabase::new(dir_path).await;
+    let result = SqliteThingsDatabase::new(dir_path).await;
 
     assert!(result.is_err(), "Should fail when path is a directory");
 }
@@ -44,7 +44,7 @@ async fn test_database_empty_file() {
     let db_path = temp_file.path();
 
     // Empty file exists but is not a valid SQLite database
-    let result = ThingsDatabase::new(db_path).await;
+    let result = SqliteThingsDatabase::new(db_path).await;
 
     // Connection might succeed (SQLite can initialize), but queries should fail
     match result {
@@ -71,7 +71,7 @@ async fn test_database_corrupted_file() {
     // Write garbage data to simulate corruption
     std::fs::write(db_path, b"This is not a valid SQLite database file!").unwrap();
 
-    let result = ThingsDatabase::new(db_path).await;
+    let result = SqliteThingsDatabase::new(db_path).await;
 
     // Should fail to connect or queries should fail
     match result {
@@ -94,7 +94,7 @@ async fn test_database_invalid_path_characters() {
     // Test with null bytes (invalid in paths)
     let invalid_path = PathBuf::from("invalid\0path.db");
 
-    let result = ThingsDatabase::new(&invalid_path).await;
+    let result = SqliteThingsDatabase::new(&invalid_path).await;
 
     assert!(result.is_err(), "Should fail with invalid path characters");
 }
@@ -118,8 +118,8 @@ async fn test_database_wrong_schema() {
 
     pool.close().await;
 
-    // Now try to use it with ThingsDatabase
-    let result = ThingsDatabase::new(db_path).await;
+    // Now try to use it with SqliteThingsDatabase
+    let result = SqliteThingsDatabase::new(db_path).await;
 
     match result {
         Ok(db) => {
@@ -153,7 +153,7 @@ async fn test_database_wrong_schema() {
 async fn test_database_invalid_connection_string() {
     let invalid_conn_str = "invalid://connection/string";
 
-    let result = ThingsDatabase::from_connection_string(invalid_conn_str).await;
+    let result = SqliteThingsDatabase::from_connection_string(invalid_conn_str).await;
 
     assert!(
         result.is_err(),
@@ -183,7 +183,7 @@ async fn test_database_file_removed_during_operation() {
     }
 
     // Connect to database
-    let db = ThingsDatabase::new(&db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(&db_path).await.unwrap();
 
     // Remove the file while connection is open
     std::fs::remove_file(&db_path).unwrap();
@@ -205,7 +205,7 @@ async fn test_database_health_check_on_invalid_db() {
         .unwrap();
     pool.close().await;
 
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     // Health check should work even on minimal database
     let is_connected = db.is_connected().await;
@@ -222,7 +222,7 @@ async fn test_database_extremely_long_path() {
     let long_component = "a".repeat(300);
     let long_path = PathBuf::from(format!("/tmp/{}/{}", long_component, long_component));
 
-    let result = ThingsDatabase::new(&long_path).await;
+    let result = SqliteThingsDatabase::new(&long_path).await;
 
     assert!(result.is_err(), "Should fail with extremely long path");
 }

--- a/libs/things3-core/tests/database_tests.rs
+++ b/libs/things3-core/tests/database_tests.rs
@@ -3,13 +3,13 @@ use std::path::Path;
 use tempfile::{tempdir, NamedTempFile};
 use things3_core::{
     models::{TaskStatus, TaskType},
-    ThingsDatabase,
+    SqliteThingsDatabase,
 };
 use uuid::Uuid;
 
 // Helper function to create test schema and data
 #[allow(clippy::too_many_lines)]
-async fn create_test_schema(db: &ThingsDatabase) -> Result<(), Box<dyn std::error::Error>> {
+async fn create_test_schema(db: &SqliteThingsDatabase) -> Result<(), Box<dyn std::error::Error>> {
     let pool = db.pool();
 
     // Create the Things 3 schema - matches real database structure
@@ -181,7 +181,7 @@ async fn create_test_schema(db: &ThingsDatabase) -> Result<(), Box<dyn std::erro
 
 #[tokio::test]
 async fn test_database_new() {
-    let db = ThingsDatabase::from_connection_string("sqlite::memory:")
+    let db = SqliteThingsDatabase::from_connection_string("sqlite::memory:")
         .await
         .unwrap();
     // Test that we can create a database connection
@@ -194,7 +194,7 @@ async fn test_database_new() {
 
 #[tokio::test]
 async fn test_database_default_path() {
-    let db = ThingsDatabase::from_connection_string("sqlite::memory:")
+    let db = SqliteThingsDatabase::from_connection_string("sqlite::memory:")
         .await
         .unwrap();
     // Test that we can create a database connection with in-memory database
@@ -203,7 +203,7 @@ async fn test_database_default_path() {
 
 #[tokio::test]
 async fn test_get_inbox() {
-    let db = ThingsDatabase::from_connection_string("sqlite::memory:")
+    let db = SqliteThingsDatabase::from_connection_string("sqlite::memory:")
         .await
         .unwrap();
 
@@ -224,7 +224,7 @@ async fn test_get_inbox() {
 
 #[tokio::test]
 async fn test_get_today() {
-    let db = ThingsDatabase::from_connection_string("sqlite::memory:")
+    let db = SqliteThingsDatabase::from_connection_string("sqlite::memory:")
         .await
         .unwrap();
 
@@ -239,7 +239,7 @@ async fn test_get_today() {
 
 #[tokio::test]
 async fn test_get_projects() {
-    let db = ThingsDatabase::from_connection_string("sqlite::memory:")
+    let db = SqliteThingsDatabase::from_connection_string("sqlite::memory:")
         .await
         .unwrap();
 
@@ -259,7 +259,7 @@ async fn test_get_projects() {
 
 #[tokio::test]
 async fn test_get_areas() {
-    let db = ThingsDatabase::from_connection_string("sqlite::memory:")
+    let db = SqliteThingsDatabase::from_connection_string("sqlite::memory:")
         .await
         .unwrap();
 
@@ -278,7 +278,7 @@ async fn test_get_areas() {
 
 #[tokio::test]
 async fn test_search_tasks() {
-    let db = ThingsDatabase::from_connection_string("sqlite::memory:")
+    let db = SqliteThingsDatabase::from_connection_string("sqlite::memory:")
         .await
         .unwrap();
 
@@ -297,7 +297,7 @@ async fn test_search_tasks() {
 
 #[tokio::test]
 async fn test_search_tasks_empty_query() {
-    let db = ThingsDatabase::from_connection_string("sqlite::memory:")
+    let db = SqliteThingsDatabase::from_connection_string("sqlite::memory:")
         .await
         .unwrap();
 
@@ -311,7 +311,7 @@ async fn test_search_tasks_empty_query() {
 
 #[tokio::test]
 async fn test_search_tasks_no_results() {
-    let db = ThingsDatabase::from_connection_string("sqlite::memory:")
+    let db = SqliteThingsDatabase::from_connection_string("sqlite::memory:")
         .await
         .unwrap();
 
@@ -327,13 +327,13 @@ async fn test_search_tasks_no_results() {
 async fn test_database_error_handling() {
     // Test with invalid path
     let invalid_path = Path::new("/invalid/path/that/does/not/exist/database.sqlite");
-    let result = ThingsDatabase::new(Path::new(invalid_path));
+    let result = SqliteThingsDatabase::new(Path::new(invalid_path));
     assert!(result.await.is_err());
 }
 
 #[tokio::test]
 async fn test_database_connection_persistence() {
-    let db = ThingsDatabase::from_connection_string("sqlite::memory:")
+    let db = SqliteThingsDatabase::from_connection_string("sqlite::memory:")
         .await
         .unwrap();
 
@@ -341,7 +341,7 @@ async fn test_database_connection_persistence() {
     create_test_schema(&db).await.unwrap();
 
     // Test that we can create multiple connections to the same in-memory database
-    let db2 = ThingsDatabase::from_connection_string("sqlite::memory:")
+    let db2 = SqliteThingsDatabase::from_connection_string("sqlite::memory:")
         .await
         .unwrap();
 
@@ -358,7 +358,7 @@ async fn test_database_connection_persistence() {
 
 #[tokio::test]
 async fn test_database_with_mock_data_consistency() {
-    let db = ThingsDatabase::from_connection_string("sqlite::memory:")
+    let db = SqliteThingsDatabase::from_connection_string("sqlite::memory:")
         .await
         .unwrap();
 
@@ -406,7 +406,7 @@ async fn test_database_with_mock_data_consistency() {
 
 #[tokio::test]
 async fn test_database_query_consistency() {
-    let db = ThingsDatabase::from_connection_string("sqlite::memory:")
+    let db = SqliteThingsDatabase::from_connection_string("sqlite::memory:")
         .await
         .unwrap();
 
@@ -433,7 +433,7 @@ async fn test_database_query_consistency() {
 
 #[tokio::test]
 async fn test_database_date_filtering() {
-    let db = ThingsDatabase::from_connection_string("sqlite::memory:")
+    let db = SqliteThingsDatabase::from_connection_string("sqlite::memory:")
         .await
         .unwrap();
 
@@ -457,7 +457,7 @@ async fn test_database_error_recovery() {
     let _db_path = temp_dir.path().join("test.db");
 
     // Create a valid database first
-    let db = ThingsDatabase::from_connection_string("sqlite::memory:")
+    let db = SqliteThingsDatabase::from_connection_string("sqlite::memory:")
         .await
         .unwrap();
 
@@ -479,10 +479,10 @@ async fn test_database_concurrent_access() {
     let _db_path = temp_dir.path().join("test.db");
 
     // Create multiple database connections
-    let db1 = ThingsDatabase::from_connection_string("sqlite::memory:")
+    let db1 = SqliteThingsDatabase::from_connection_string("sqlite::memory:")
         .await
         .unwrap();
-    let db2 = ThingsDatabase::from_connection_string("sqlite::memory:")
+    let db2 = SqliteThingsDatabase::from_connection_string("sqlite::memory:")
         .await
         .unwrap();
 
@@ -505,7 +505,7 @@ async fn test_database_concurrent_access() {
 
 #[tokio::test]
 async fn test_database_helper_functions_indirectly() {
-    let db = ThingsDatabase::from_connection_string("sqlite::memory:")
+    let db = SqliteThingsDatabase::from_connection_string("sqlite::memory:")
         .await
         .unwrap();
 
@@ -568,7 +568,7 @@ async fn test_database_helper_functions_indirectly() {
 async fn test_database_error_handling_comprehensive() {
     // Test with invalid database path
     let invalid_path = "/invalid/path/that/does/not/exist/database.sqlite";
-    let result = ThingsDatabase::new(Path::new(invalid_path));
+    let result = SqliteThingsDatabase::new(Path::new(invalid_path));
     assert!(result.await.is_err());
 
     // Test with valid path but invalid database file
@@ -578,7 +578,7 @@ async fn test_database_error_handling_comprehensive() {
     // Create an empty file (not a valid SQLite database)
     std::fs::write(db_path, "not a database").unwrap();
 
-    let result = ThingsDatabase::new(db_path).await;
+    let result = SqliteThingsDatabase::new(db_path).await;
     // The database might still open successfully even with invalid content
     // or it might fail - both are valid test cases
     let _ = result;
@@ -586,7 +586,7 @@ async fn test_database_error_handling_comprehensive() {
 
 #[tokio::test]
 async fn test_database_edge_cases() {
-    let db = ThingsDatabase::from_connection_string("sqlite::memory:")
+    let db = SqliteThingsDatabase::from_connection_string("sqlite::memory:")
         .await
         .unwrap();
 
@@ -619,7 +619,7 @@ async fn test_database_edge_cases() {
 
 #[tokio::test]
 async fn test_database_performance_with_large_limits() {
-    let db = ThingsDatabase::from_connection_string("sqlite::memory:")
+    let db = SqliteThingsDatabase::from_connection_string("sqlite::memory:")
         .await
         .unwrap();
 
@@ -702,7 +702,7 @@ async fn create_minimal_task_schema(pool: &sqlx::SqlitePool) {
 
 #[tokio::test]
 async fn test_get_today_with_null_today_index() {
-    let db = ThingsDatabase::from_connection_string("sqlite::memory:")
+    let db = SqliteThingsDatabase::from_connection_string("sqlite::memory:")
         .await
         .unwrap();
     let pool = db.pool();
@@ -739,7 +739,7 @@ async fn test_get_today_with_null_today_index() {
 
 #[tokio::test]
 async fn test_get_today_with_zero_today_index() {
-    let db = ThingsDatabase::from_connection_string("sqlite::memory:")
+    let db = SqliteThingsDatabase::from_connection_string("sqlite::memory:")
         .await
         .unwrap();
     let pool = db.pool();
@@ -776,7 +776,7 @@ async fn test_get_today_with_zero_today_index() {
 
 #[tokio::test]
 async fn test_get_today_with_positive_today_index() {
-    let db = ThingsDatabase::from_connection_string("sqlite::memory:")
+    let db = SqliteThingsDatabase::from_connection_string("sqlite::memory:")
         .await
         .unwrap();
     let pool = db.pool();
@@ -814,7 +814,7 @@ async fn test_get_today_with_positive_today_index() {
 
 #[tokio::test]
 async fn test_get_today_excludes_trashed() {
-    let db = ThingsDatabase::from_connection_string("sqlite::memory:")
+    let db = SqliteThingsDatabase::from_connection_string("sqlite::memory:")
         .await
         .unwrap();
     let pool = db.pool();
@@ -851,7 +851,7 @@ async fn test_get_today_excludes_trashed() {
 
 #[tokio::test]
 async fn test_get_today_with_limit() {
-    let db = ThingsDatabase::from_connection_string("sqlite::memory:")
+    let db = SqliteThingsDatabase::from_connection_string("sqlite::memory:")
         .await
         .unwrap();
     let pool = db.pool();
@@ -891,7 +891,7 @@ async fn test_get_today_with_limit() {
 
 #[tokio::test]
 async fn test_get_inbox_empty_database() {
-    let db = ThingsDatabase::from_connection_string("sqlite::memory:")
+    let db = SqliteThingsDatabase::from_connection_string("sqlite::memory:")
         .await
         .unwrap();
     let pool = db.pool();
@@ -905,7 +905,7 @@ async fn test_get_inbox_empty_database() {
 
 #[tokio::test]
 async fn test_get_inbox_excludes_tasks_with_project() {
-    let db = ThingsDatabase::from_connection_string("sqlite::memory:")
+    let db = SqliteThingsDatabase::from_connection_string("sqlite::memory:")
         .await
         .unwrap();
     let pool = db.pool();
@@ -960,7 +960,7 @@ async fn test_get_inbox_excludes_tasks_with_project() {
 
 #[tokio::test]
 async fn test_get_inbox_with_limit_zero() {
-    let db = ThingsDatabase::from_connection_string("sqlite::memory:")
+    let db = SqliteThingsDatabase::from_connection_string("sqlite::memory:")
         .await
         .unwrap();
     let pool = db.pool();
@@ -993,7 +993,7 @@ async fn test_get_inbox_with_limit_zero() {
 
 #[tokio::test]
 async fn test_get_inbox_large_result_set() {
-    let db = ThingsDatabase::from_connection_string("sqlite::memory:")
+    let db = SqliteThingsDatabase::from_connection_string("sqlite::memory:")
         .await
         .unwrap();
     let pool = db.pool();
@@ -1035,7 +1035,7 @@ async fn test_get_inbox_large_result_set() {
 
 #[tokio::test]
 async fn test_search_tasks_includes_headings() {
-    let db = ThingsDatabase::from_connection_string("sqlite::memory:")
+    let db = SqliteThingsDatabase::from_connection_string("sqlite::memory:")
         .await
         .unwrap();
 
@@ -1056,7 +1056,7 @@ async fn test_search_tasks_includes_headings() {
 
 #[tokio::test]
 async fn test_get_inbox_includes_headings_without_project() {
-    let db = ThingsDatabase::from_connection_string("sqlite::memory:")
+    let db = SqliteThingsDatabase::from_connection_string("sqlite::memory:")
         .await
         .unwrap();
     let pool = db.pool();

--- a/libs/things3-core/tests/integration_tests.rs
+++ b/libs/things3-core/tests/integration_tests.rs
@@ -1,7 +1,7 @@
 //! Integration tests for things-core
 
 use tempfile::NamedTempFile;
-use things3_core::{Result, ThingsDatabase};
+use things3_core::{Result, SqliteThingsDatabase};
 
 #[cfg(feature = "test-utils")]
 use things3_core::test_utils;
@@ -14,7 +14,7 @@ async fn test_database_connection() -> Result<()> {
     println!("Testing database connection to: {db_path:?}");
 
     // Try to connect (this might fail in CI, which is expected)
-    match ThingsDatabase::new(db_path).await {
+    match SqliteThingsDatabase::new(db_path).await {
         Ok(_db) => {
             println!("✅ Database connection successful");
         }
@@ -43,7 +43,7 @@ async fn test_mock_database() {
     test_utils::create_test_database(db_path).await.unwrap();
 
     // Test that we can connect to the mock database
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     // Test basic queries
     let inbox_tasks = db.get_inbox(Some(10)).await.unwrap();

--- a/libs/things3-core/tests/logbook_search_tests.rs
+++ b/libs/things3-core/tests/logbook_search_tests.rs
@@ -2,21 +2,24 @@
 
 use chrono::Utc;
 use things3_core::{
-    database::ThingsDatabase,
+    database::SqliteThingsDatabase,
     models::CreateTaskRequest,
     test_utils::{create_test_database_and_connect, TaskRequestBuilder},
     ThingsId,
 };
 
 /// Helper to complete a task
-async fn complete_task(db: &ThingsDatabase, uuid: ThingsId) {
+async fn complete_task(db: &SqliteThingsDatabase, uuid: ThingsId) {
     db.complete_task(&uuid)
         .await
         .expect("Failed to complete task");
 }
 
 /// Helper to create and complete a task
-async fn create_and_complete_task(db: &ThingsDatabase, request: CreateTaskRequest) -> ThingsId {
+async fn create_and_complete_task(
+    db: &SqliteThingsDatabase,
+    request: CreateTaskRequest,
+) -> ThingsId {
     let uuid = db
         .create_task(request)
         .await

--- a/libs/things3-core/tests/memory_profiling_tests.rs
+++ b/libs/things3-core/tests/memory_profiling_tests.rs
@@ -5,7 +5,7 @@
 
 use std::sync::Arc;
 use tempfile::NamedTempFile;
-use things3_core::{CacheConfig, ThingsCache, ThingsDatabase};
+use things3_core::{CacheConfig, SqliteThingsDatabase, ThingsCache};
 
 #[cfg(any(feature = "export-csv", feature = "export-opml"))]
 use things3_core::{DataExporter, ExportData, ExportFormat};
@@ -24,7 +24,7 @@ async fn memory_test_database_connection() {
 
     // Create and drop database connections
     for _ in 0..10 {
-        let _db = ThingsDatabase::new(db_path).await.unwrap();
+        let _db = SqliteThingsDatabase::new(db_path).await.unwrap();
         // Database should be properly cleaned up on drop
     }
 
@@ -40,7 +40,7 @@ async fn memory_test_large_query_results() {
     let db_path = temp_file.path();
 
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     // Query large result sets
     let _inbox = db.get_inbox(Some(1000)).await.unwrap();
@@ -91,7 +91,7 @@ async fn memory_test_repeated_operations() {
     let db_path = temp_file.path();
 
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     // Perform same operation many times
     for _ in 0..100 {
@@ -135,7 +135,7 @@ async fn memory_test_arc_wrapped_database() {
     let db_path = temp_file.path();
 
     create_test_database(db_path).await.unwrap();
-    let db = Arc::new(ThingsDatabase::new(db_path).await.unwrap());
+    let db = Arc::new(SqliteThingsDatabase::new(db_path).await.unwrap());
 
     // Clone Arc multiple times
     let mut handles = Vec::new();
@@ -161,7 +161,7 @@ async fn memory_test_health_checks() {
     let db_path = temp_file.path();
 
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     // Perform many health checks
     for _ in 0..100 {
@@ -192,7 +192,7 @@ async fn memory_test_search_operations() {
     let db_path = temp_file.path();
 
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     // Perform various searches
     let queries = vec!["test", "project", "task", "important"];
@@ -212,7 +212,7 @@ async fn memory_test_error_cleanup() {
 
     // Attempt connections that will fail
     for _ in 0..10 {
-        let _result = ThingsDatabase::new(&nonexistent_path).await;
+        let _result = SqliteThingsDatabase::new(&nonexistent_path).await;
         // Error paths should clean up properly
     }
 
@@ -227,7 +227,7 @@ async fn memory_test_database_pool() {
     let db_path = temp_file.path();
 
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     // Perform concurrent operations (uses connection pool)
     let mut tasks = Vec::new();

--- a/libs/things3-core/tests/project_area_operations_tests.rs
+++ b/libs/things3-core/tests/project_area_operations_tests.rs
@@ -5,7 +5,7 @@ use things3_core::{
         CreateAreaRequest, CreateProjectRequest, ProjectChildHandling, UpdateAreaRequest,
         UpdateProjectRequest,
     },
-    ThingsDatabase,
+    SqliteThingsDatabase,
 };
 
 #[cfg(feature = "test-utils")]
@@ -20,7 +20,7 @@ async fn test_create_project_success() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     let request = CreateProjectRequest {
         title: "Test Project".to_string(),
@@ -48,7 +48,7 @@ async fn test_create_project_with_area() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     // Create an area first
     let area_request = CreateAreaRequest {
@@ -77,7 +77,7 @@ async fn test_update_project_success() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     // Create a project
     let create_request = CreateProjectRequest {
@@ -114,7 +114,7 @@ async fn test_complete_project_success() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     // Create a project
     let request = CreateProjectRequest {
@@ -144,7 +144,7 @@ async fn test_complete_project_with_children_cascade() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     // Create a project
     let project_request = CreateProjectRequest {
@@ -183,7 +183,7 @@ async fn test_delete_project_with_children_error() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     // Create a project with a child task
     let project_request = CreateProjectRequest {
@@ -215,7 +215,7 @@ async fn test_delete_project_with_children_orphan() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     // Create a project with a child task
     let project_request = CreateProjectRequest {
@@ -254,7 +254,7 @@ async fn test_create_area_success() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     let request = CreateAreaRequest {
         title: "Personal".to_string(),
@@ -276,7 +276,7 @@ async fn test_update_area_success() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     // Create an area
     let create_request = CreateAreaRequest {
@@ -303,7 +303,7 @@ async fn test_delete_area_with_projects() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     // Create an area
     let area_request = CreateAreaRequest {
@@ -340,7 +340,7 @@ async fn test_delete_area_empty() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     // Create an area with no projects
     let request = CreateAreaRequest {

--- a/libs/things3-core/tests/reliability_tests.rs
+++ b/libs/things3-core/tests/reliability_tests.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 use things3_core::test_utils::create_test_database;
-use things3_core::{CreateTaskRequest, ThingsDatabase};
+use things3_core::{CreateTaskRequest, SqliteThingsDatabase};
 use tokio::task::JoinSet;
 
 /// Test concurrent read operations
@@ -12,7 +12,7 @@ async fn test_concurrent_reads() {
     let db_path = temp_file.path().to_path_buf();
 
     create_test_database(&db_path).await.unwrap();
-    let db = Arc::new(ThingsDatabase::new(&db_path).await.unwrap());
+    let db = Arc::new(SqliteThingsDatabase::new(&db_path).await.unwrap());
 
     // Create test data
     for i in 0..100 {
@@ -61,7 +61,7 @@ async fn test_concurrent_writes() {
     let db_path = temp_file.path().to_path_buf();
 
     create_test_database(&db_path).await.unwrap();
-    let db = Arc::new(ThingsDatabase::new(&db_path).await.unwrap());
+    let db = Arc::new(SqliteThingsDatabase::new(&db_path).await.unwrap());
 
     // Spawn 10 concurrent write operations
     let mut join_set = JoinSet::new();
@@ -108,7 +108,7 @@ async fn test_concurrent_mixed_operations() {
     let db_path = temp_file.path().to_path_buf();
 
     create_test_database(&db_path).await.unwrap();
-    let db = Arc::new(ThingsDatabase::new(&db_path).await.unwrap());
+    let db = Arc::new(SqliteThingsDatabase::new(&db_path).await.unwrap());
 
     // Create initial data
     for i in 0..50 {
@@ -185,7 +185,7 @@ async fn test_empty_database() {
     let db_path = temp_file.path().to_path_buf();
 
     create_test_database(&db_path).await.unwrap();
-    let db = ThingsDatabase::new(&db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(&db_path).await.unwrap();
 
     // All queries should succeed (may have test data from schema)
     let _inbox = db.get_inbox(None).await.unwrap();
@@ -217,7 +217,7 @@ async fn test_large_dataset() {
     let db_path = temp_file.path().to_path_buf();
 
     create_test_database(&db_path).await.unwrap();
-    let db = ThingsDatabase::new(&db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(&db_path).await.unwrap();
 
     // Create 1000 tasks
     for i in 0..1000 {
@@ -261,13 +261,13 @@ async fn test_resource_cleanup() {
 
     // Create and drop multiple database instances
     for _ in 0..10 {
-        let db = ThingsDatabase::new(&db_path).await.unwrap();
+        let db = SqliteThingsDatabase::new(&db_path).await.unwrap();
         let _ = db.get_inbox(None).await.unwrap();
         // db is dropped here, connections should be released
     }
 
     // Final connection should still work
-    let db = ThingsDatabase::new(&db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(&db_path).await.unwrap();
     let _inbox = db.get_inbox(None).await.unwrap();
     // Just verify it doesn't error (may have test data)
 }
@@ -281,9 +281,9 @@ async fn test_multiple_database_instances() {
     create_test_database(&db_path).await.unwrap();
 
     // Create multiple instances pointing to same database
-    let db1 = Arc::new(ThingsDatabase::new(&db_path).await.unwrap());
-    let db2 = Arc::new(ThingsDatabase::new(&db_path).await.unwrap());
-    let db3 = Arc::new(ThingsDatabase::new(&db_path).await.unwrap());
+    let db1 = Arc::new(SqliteThingsDatabase::new(&db_path).await.unwrap());
+    let db2 = Arc::new(SqliteThingsDatabase::new(&db_path).await.unwrap());
+    let db3 = Arc::new(SqliteThingsDatabase::new(&db_path).await.unwrap());
 
     // Write from db1
     let request = CreateTaskRequest {
@@ -323,7 +323,7 @@ async fn test_error_recovery() {
     let db_path = temp_file.path().to_path_buf();
 
     create_test_database(&db_path).await.unwrap();
-    let db = ThingsDatabase::new(&db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(&db_path).await.unwrap();
 
     // Try to complete a non-existent task
     let fake_uuid = things3_core::ThingsId::new_v4();

--- a/libs/things3-core/tests/schema_inspection.rs
+++ b/libs/things3-core/tests/schema_inspection.rs
@@ -1,7 +1,7 @@
 //! Schema inspection test to understand the real Things 3 database structure
 
 use std::path::Path;
-use things3_core::{Result, ThingsDatabase};
+use things3_core::{Result, SqliteThingsDatabase};
 
 #[tokio::test]
 async fn test_inspect_things_schema() -> Result<()> {
@@ -9,7 +9,7 @@ async fn test_inspect_things_schema() -> Result<()> {
     let db_path = Path::new("test_things.db");
     println!("Testing database connection at: {db_path:?}");
 
-    match ThingsDatabase::new(db_path).await {
+    match SqliteThingsDatabase::new(db_path).await {
         Ok(_db) => {
             println!("✅ Successfully connected to test database");
             println!("📋 Database connection test passed");

--- a/libs/things3-core/tests/write_operations_tests.rs
+++ b/libs/things3-core/tests/write_operations_tests.rs
@@ -1,6 +1,6 @@
 use chrono::NaiveDate;
 use things3_core::{
-    CreateTaskRequest, TaskStatus, TaskType, ThingsDatabase, ThingsId, UpdateTaskRequest,
+    CreateTaskRequest, SqliteThingsDatabase, TaskStatus, TaskType, ThingsId, UpdateTaskRequest,
 };
 
 #[cfg(feature = "test-utils")]
@@ -19,7 +19,7 @@ async fn test_create_task_minimal_fields() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     let request = CreateTaskRequest {
         title: "Test Task".to_string(),
@@ -47,7 +47,7 @@ async fn test_create_task_all_fields() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     // First create a project to reference
     let project_request = CreateTaskRequest {
@@ -91,7 +91,7 @@ async fn test_create_task_returns_valid_uuid() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     let request = CreateTaskRequest {
         title: "UUID Test Task".to_string(),
@@ -125,7 +125,7 @@ async fn test_create_task_appears_in_database() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     let request = CreateTaskRequest {
         title: "Verifiable Task".to_string(),
@@ -155,7 +155,7 @@ async fn test_create_task_timestamps_set() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     let request = CreateTaskRequest {
         title: "Timestamp Test".to_string(),
@@ -186,7 +186,7 @@ async fn test_create_task_with_invalid_project_uuid() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     let invalid_uuid = ThingsId::new_v4();
     let request = CreateTaskRequest {
@@ -212,7 +212,7 @@ async fn test_create_task_with_invalid_area_uuid() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     let invalid_uuid = ThingsId::new_v4();
     let request = CreateTaskRequest {
@@ -238,7 +238,7 @@ async fn test_create_task_with_invalid_parent_uuid() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     let invalid_uuid = ThingsId::new_v4();
     let request = CreateTaskRequest {
@@ -264,7 +264,7 @@ async fn test_create_task_with_valid_project() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     // Create a project first
     let project_request = CreateTaskRequest {
@@ -305,7 +305,7 @@ async fn test_create_task_with_valid_dates() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     let request = CreateTaskRequest {
         title: "Task with Dates".to_string(),
@@ -330,7 +330,7 @@ async fn test_create_task_type_todo() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     let request = CreateTaskRequest {
         title: "Todo Task".to_string(),
@@ -355,7 +355,7 @@ async fn test_create_task_type_project() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     let request = CreateTaskRequest {
         title: "Project Task".to_string(),
@@ -380,7 +380,7 @@ async fn test_create_task_type_heading() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     let request = CreateTaskRequest {
         title: "Heading Task".to_string(),
@@ -405,7 +405,7 @@ async fn test_create_task_all_statuses() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     let statuses = vec![
         TaskStatus::Incomplete,
@@ -442,7 +442,7 @@ async fn test_create_task_with_empty_title_succeeds() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     // Empty title is technically allowed by the database
     let request = CreateTaskRequest {
@@ -472,7 +472,7 @@ async fn test_update_task_title() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     // Create task
     let create_request = CreateTaskRequest {
@@ -512,7 +512,7 @@ async fn test_update_task_notes() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     // Create task
     let create_request = CreateTaskRequest {
@@ -552,7 +552,7 @@ async fn test_update_task_dates() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     // Create task
     let create_request = CreateTaskRequest {
@@ -592,7 +592,7 @@ async fn test_update_task_project_assignment() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     // Create project
     let project_request = CreateTaskRequest {
@@ -647,7 +647,7 @@ async fn test_update_task_status() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     // Create task
     let create_request = CreateTaskRequest {
@@ -687,7 +687,7 @@ async fn test_update_task_tags() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     // Create task
     let create_request = CreateTaskRequest {
@@ -727,7 +727,7 @@ async fn test_update_task_partial() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     // Create task with multiple fields
     let create_request = CreateTaskRequest {
@@ -767,7 +767,7 @@ async fn test_update_nonexistent_task() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     let nonexistent_uuid = ThingsId::new_v4();
     let update_request = UpdateTaskRequest {
@@ -795,7 +795,7 @@ async fn test_update_task_with_no_fields() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     // Create a task first
     let create_request = CreateTaskRequest {
@@ -835,7 +835,7 @@ async fn test_update_task_with_invalid_project_uuid() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     // Create a task first
     let create_request = CreateTaskRequest {
@@ -879,7 +879,7 @@ async fn test_update_task_with_invalid_area_uuid() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     // Create a task first
     let create_request = CreateTaskRequest {
@@ -927,7 +927,7 @@ async fn test_create_task_very_long_title() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     let long_title = "A".repeat(1000);
     let request = CreateTaskRequest {
@@ -953,7 +953,7 @@ async fn test_create_task_special_characters() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     let special_title = "Task with émojis 🎉 and symbols @#$%";
     let request = CreateTaskRequest {
@@ -979,7 +979,7 @@ async fn test_create_task_empty_vs_null_notes() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     // Task with null notes
     let request1 = CreateTaskRequest {
@@ -1020,7 +1020,7 @@ async fn test_create_subtask() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     // Create parent task
     let parent_request = CreateTaskRequest {
@@ -1061,7 +1061,7 @@ async fn test_create_task_multiple_tags() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     let request = CreateTaskRequest {
         title: "Task with Multiple Tags".to_string(),
@@ -1091,7 +1091,7 @@ async fn test_concurrent_create_operations() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = std::sync::Arc::new(ThingsDatabase::new(db_path).await.unwrap());
+    let db = std::sync::Arc::new(SqliteThingsDatabase::new(db_path).await.unwrap());
 
     let mut handles = vec![];
 
@@ -1127,7 +1127,7 @@ async fn test_update_task_remove_optional_fields() {
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path();
     create_test_database(db_path).await.unwrap();
-    let db = ThingsDatabase::new(db_path).await.unwrap();
+    let db = SqliteThingsDatabase::new(db_path).await.unwrap();
 
     // Create task with notes
     let create_request = CreateTaskRequest {


### PR DESCRIPTION
## Summary

- Extracts `ThingsDatabase` as an `#[async_trait]` async trait (~50 methods covering all queries, mutations, bulk ops, and health checks)
- Renames the concrete SQLite-backed struct from `ThingsDatabase` → `SqliteThingsDatabase`
- Adds `database/traits.rs` (trait definition) and `database/impl_trait.rs` (single delegation `impl ThingsDatabase for SqliteThingsDatabase`)
- All existing inherent impl files (`queries/`, `mutations/`, `health.rs`, etc.) updated to `impl SqliteThingsDatabase` — method bodies unchanged
- All call sites (CLI, tests, examples, cache, backup, mutations layer) updated to use `SqliteThingsDatabase` as the concrete type
- Both `ThingsDatabase` (trait) and `SqliteThingsDatabase` (struct) are now publicly exported from `lib.rs`

## Why this approach

Rust requires a single `impl Trait for Type` block. Rather than moving all ~3,700 lines of method bodies into one file, the impl in `impl_trait.rs` delegates each method to the identically-named inherent method on `SqliteThingsDatabase`. Rust's method resolution prefers inherent methods over trait methods, so `self.method_name()` inside the trait impl body calls the inherent implementation — no infinite recursion, no duplicated logic.

## Test plan

- [x] `cargo build --all` — clean
- [x] `cargo test --all` — all passing
- [x] `cargo test -p things3-core --features advanced-queries --lib` — passing
- [x] `cargo clippy --all -- -D warnings` — clean
- [x] Pre-push hook: full test suite + `cargo audit`

Closes #202. Unblocks #204 (in-memory backend) and #206 (GraphQL API layer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)